### PR TITLE
Implemented energy peripheral

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,8 @@ deploy
 luaj-2.0.3/lib
 luaj-2.0.3/*.jar
 *.DS_Store
+/bin/
+.classpath
+.project
+*.launch
+.settings

--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,10 @@ repositories {
         name = "squiddev"
         url = "https://dl.bintray.com/squiddev/maven"
     }
+    maven {
+        name = "CoFH Maven"
+        url = "http://maven.covers1624.net"
+    }
 }
 
 configurations {
@@ -57,6 +61,7 @@ configurations {
 
 dependencies {
     deobfProvided "mezz.jei:jei_1.12:4.7.5.86:api"
+    compile "cofh:RedstoneFlux:1.12-2.0.0.1:deobf"
     runtime "mezz.jei:jei_1.12:4.7.5.86"
     shade 'org.squiddev:Cobalt:0.3.1'
 }

--- a/src/main/java/dan200/computercraft/ComputerCraft.java
+++ b/src/main/java/dan200/computercraft/ComputerCraft.java
@@ -72,6 +72,7 @@ import net.minecraftforge.common.config.ConfigCategory;
 import net.minecraftforge.common.config.Configuration;
 import net.minecraftforge.common.config.Property;
 import net.minecraftforge.fml.common.FMLCommonHandler;
+import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.SidedProxy;
 import net.minecraftforge.fml.common.event.*;
@@ -103,6 +104,9 @@ public class ComputerCraft
 {
     public static final String MOD_ID = "computercraft";
     public static final String LOWER_ID = "computercraft";
+
+    // Integration
+    public static boolean redstonefluxLoaded = false;
 
     // GUI IDs
     public static final int diskDriveGUIID = 100;
@@ -420,6 +424,7 @@ public class ComputerCraft
     @Mod.EventHandler
     public void init( FMLInitializationEvent event )
     {
+    	redstonefluxLoaded = Loader.isModLoaded("redstoneflux");
         proxy.init();
         turtleProxy.init();
     }

--- a/src/main/java/dan200/computercraft/shared/integration/RedstoneFluxCC.java
+++ b/src/main/java/dan200/computercraft/shared/integration/RedstoneFluxCC.java
@@ -1,0 +1,66 @@
+package dan200.computercraft.shared.integration;
+
+import cofh.redstoneflux.api.IEnergyHandler;
+import cofh.redstoneflux.api.IEnergyProvider;
+import cofh.redstoneflux.api.IEnergyReceiver;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
+
+public class RedstoneFluxCC {
+
+	public static boolean isEnergyHandler( final TileEntity tile )
+	{
+		return tile instanceof IEnergyHandler;
+	}
+	
+	public static boolean isEnergyProvider( final TileEntity tile )
+	{
+		return tile instanceof IEnergyProvider;
+	}
+	
+	public static boolean isEnergyReceiver( final TileEntity tile )
+	{
+		return tile instanceof IEnergyReceiver;
+	}
+	
+	public static int getEnergyStored( final TileEntity tile, final EnumFacing side )
+	{
+		if ( isEnergyHandler(tile) )
+		{
+			return ((IEnergyHandler)tile).getEnergyStored(side);
+		}
+		
+		return 0;
+	}
+	
+	public static int getMaxEnergyStored( final TileEntity tile, final EnumFacing side )
+	{
+		if ( isEnergyHandler(tile) )
+		{
+			return ((IEnergyHandler)tile).getMaxEnergyStored(side);
+		}
+		
+		return 0;
+	}
+	
+	public static int getMaxEnergyExtract( final TileEntity tile, final EnumFacing side )
+	{
+		if ( isEnergyProvider(tile) )
+		{
+			return ((IEnergyProvider)tile).extractEnergy(side, Integer.MAX_VALUE, true);
+		}
+		
+		return 0;
+	}
+	
+	public static int getMaxEnergyReceive( final TileEntity tile, final EnumFacing side )
+	{
+		if ( isEnergyReceiver(tile) )
+		{
+			return ((IEnergyReceiver)tile).receiveEnergy(side, Integer.MAX_VALUE, true);
+		}
+		
+		return 0;
+	}
+
+}

--- a/src/main/java/dan200/computercraft/shared/peripheral/common/EnergyPeripheral.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/common/EnergyPeripheral.java
@@ -1,0 +1,89 @@
+package dan200.computercraft.shared.peripheral.common;
+
+import dan200.computercraft.api.lua.ILuaContext;
+import dan200.computercraft.api.lua.LuaException;
+import dan200.computercraft.api.peripheral.IComputerAccess;
+import dan200.computercraft.api.peripheral.IPeripheral;
+import dan200.computercraft.shared.util.EnergyUtils;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
+
+public class EnergyPeripheral implements IPeripheral
+{
+	
+	private final TileEntity tile;
+	private final EnumFacing side;
+	
+	private String[] methods;
+	
+	public EnergyPeripheral(TileEntity tile, EnumFacing side)
+	{
+		this.tile = tile;
+		this.side = side;
+	}
+
+	@Override
+	public String getType()
+	{
+		String name = "energy";
+		final String blockName = tile.getBlockType().getUnlocalizedName();
+		
+		if (blockName.contains("."))
+		{
+			final String[] splitName = blockName.split("\\.");
+			name += "_" + splitName[splitName.length - 1];
+		}
+		return name;
+	}
+
+	@Override
+	public String[] getMethodNames()
+	{
+		this.methods = EnergyUtils.getPossibleMethods(tile, side.getOpposite());
+		
+		return this.methods;
+	}
+
+	@Override
+	public Object[] callMethod(IComputerAccess computer, ILuaContext context, int method, Object[] arguments) throws LuaException, InterruptedException
+	{
+		switch( this.methods[method] )
+        {
+            case "getEnergyStored":
+            {
+            	synchronized( this )
+                {
+            		return new Object[] {EnergyUtils.getEnergyStored(tile, side.getOpposite())};
+                }
+            }
+            case "getMaxEnergyStored":
+            {
+            	synchronized( this )
+                {
+            		return new Object[] {EnergyUtils.getMaxEnergyStored(tile, side.getOpposite())};
+                }
+            }
+            case "getMaxEnergyExtract":
+            {
+            	synchronized( this )
+                {
+            		return new Object[] {EnergyUtils.getMaxEnergyExtract(tile, side.getOpposite())};
+                }
+            }
+            case "getMaxEnergyReceive":
+            {
+            	synchronized( this )
+                {
+            		return new Object[] {EnergyUtils.getMaxEnergyReceive(tile, side.getOpposite())};
+                }
+            }
+        }
+		
+		return null;
+	}
+
+	@Override
+	public boolean equals(IPeripheral other) {
+		return false;
+	}
+}

--- a/src/main/java/dan200/computercraft/shared/util/EnergyUtils.java
+++ b/src/main/java/dan200/computercraft/shared/util/EnergyUtils.java
@@ -1,0 +1,133 @@
+package dan200.computercraft.shared.util;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import dan200.computercraft.ComputerCraft;
+import dan200.computercraft.shared.integration.RedstoneFluxCC;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraftforge.energy.CapabilityEnergy;
+
+public class EnergyUtils {
+	
+	public static boolean blockHasEnergyHandler( final World world, final BlockPos pos, final EnumFacing side )
+	{
+		final TileEntity tile = world.getTileEntity(pos);
+		
+		if ( ComputerCraft.redstonefluxLoaded && RedstoneFluxCC.isEnergyHandler(tile) )
+		{
+			return true;
+		}
+		
+		if ( tile != null && tile.hasCapability(CapabilityEnergy.ENERGY, side) )
+		{
+			return true;
+		}
+    	
+		return false;
+	}
+	
+	public static String[] getPossibleMethods( final TileEntity tile, final EnumFacing side )
+	{
+		List<String> methods = new ArrayList<String>();
+		
+		if ( ComputerCraft.redstonefluxLoaded )
+		{
+			if ( RedstoneFluxCC.isEnergyHandler(tile) )
+			{
+				methods.add("getEnergyStored");
+				methods.add("getMaxEnergyStored");
+			}
+			
+			if ( RedstoneFluxCC.isEnergyProvider(tile) )
+			{
+				methods.add("getMaxEnergyExtract");
+			}
+			
+			if ( RedstoneFluxCC.isEnergyReceiver(tile) )
+			{
+				methods.add("getMaxEnergyReceive");
+			}
+		}
+		
+		if ( tile != null && tile.hasCapability(CapabilityEnergy.ENERGY, side) )
+		{
+			if ( !methods.contains("getEnergyStored") ) 
+				methods.add("getEnergyStored");
+			
+			if ( !methods.contains("getMaxEnergyStored") ) 
+				methods.add("getMaxEnergyStored");
+			
+			if ( !methods.contains("getMaxEnergyExtract") ) 
+				methods.add("getMaxEnergyExtract");
+			
+			if ( !methods.contains("getMaxEnergyReceive") ) 
+				methods.add("getMaxEnergyReceive");
+		}
+		
+		return methods.toArray(new String[0]);
+	}
+	
+	public static int getEnergyStored( final TileEntity tile, final EnumFacing side )
+	{
+		if ( ComputerCraft.redstonefluxLoaded )
+		{
+			return RedstoneFluxCC.getEnergyStored(tile, side);
+		}
+		
+		if ( tile != null && tile.hasCapability(CapabilityEnergy.ENERGY, side) )
+		{
+			return tile.getCapability(CapabilityEnergy.ENERGY, side).getEnergyStored();
+		}
+		
+		return 0;
+	}
+	
+	public static int getMaxEnergyStored( final TileEntity tile, final EnumFacing side )
+	{
+		if ( ComputerCraft.redstonefluxLoaded )
+		{
+			return RedstoneFluxCC.getMaxEnergyStored(tile, side);
+		}
+		
+		if ( tile != null && tile.hasCapability(CapabilityEnergy.ENERGY, side) )
+		{
+			return tile.getCapability(CapabilityEnergy.ENERGY, side).getMaxEnergyStored();
+		}
+		
+		return 0;
+	}
+	
+	public static int getMaxEnergyExtract( final TileEntity tile, final EnumFacing side )
+	{
+		if ( ComputerCraft.redstonefluxLoaded )
+		{
+			return RedstoneFluxCC.getMaxEnergyExtract(tile, side);
+		}
+		
+		if ( tile != null && tile.hasCapability(CapabilityEnergy.ENERGY, side) )
+		{
+			return tile.getCapability(CapabilityEnergy.ENERGY, side).extractEnergy(Integer.MAX_VALUE, true);
+		}
+		
+		return 0;
+	}
+	
+	public static int getMaxEnergyReceive( final TileEntity tile, final EnumFacing side )
+	{
+		if ( ComputerCraft.redstonefluxLoaded )
+		{
+			return RedstoneFluxCC.getMaxEnergyReceive(tile, side);
+		}
+		
+		if ( tile != null && tile.hasCapability(CapabilityEnergy.ENERGY, side) )
+		{
+			return tile.getCapability(CapabilityEnergy.ENERGY, side).receiveEnergy(Integer.MAX_VALUE, true);
+		}
+		
+		return 0;
+	}
+}

--- a/src/main/java/dan200/computercraft/shared/util/PeripheralUtil.java
+++ b/src/main/java/dan200/computercraft/shared/util/PeripheralUtil.java
@@ -2,6 +2,7 @@ package dan200.computercraft.shared.util;
 
 import dan200.computercraft.ComputerCraft;
 import dan200.computercraft.api.peripheral.IPeripheral;
+import dan200.computercraft.shared.peripheral.common.EnergyPeripheral;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.world.World;
@@ -13,7 +14,13 @@ public class PeripheralUtil
         int y = pos.getY();
         if( y >= 0 && y < world.getHeight() && !world.isRemote )
         {
-            return ComputerCraft.getPeripheralAt( world, pos, side );
+        	IPeripheral peripheral = ComputerCraft.getPeripheralAt( world, pos, side );
+        	
+        	if (peripheral == null && EnergyUtils.blockHasEnergyHandler(world, pos, side)) {
+        		peripheral = new EnergyPeripheral(world.getTileEntity(pos),  side.getOpposite());
+        	}
+        	
+            return peripheral;
         }
         return null;
     }


### PR DESCRIPTION
Allow computers and modems to get energy information from adjecent / connected blocks. Ignore if block already contains peripheral.

Supported energy types:
- Forge Energy
- Redstone Flux