### PR TITLE
Amend typo in keys.lua

### DIFF
--- a/src/main/resources/assets/computercraft/lua/rom/apis/keys.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/apis/keys.lua
@@ -16,7 +16,7 @@ local tKeys = {
 	"comma",	"period",	"slash",	"rightShift","multiply",	-- 51
 	"leftAlt",	"space",	"capsLock",	"f1",		"f2",			-- 56
 	"f3",		"f4",		"f5",		"f6",		"f7",			-- 61
-	"f8",		"f9",		"f10",		"numLock",	"scollLock",	-- 66	
+	"f8",		"f9",		"f10",		"numLock",	"scrollLock",	-- 66	
 	"numPad7",	"numPad8",	"numPad9",	"numPadSubtract","numPad4",	-- 71
 	"numPad5",	"numPad6",	"numPadAdd","numPad1",	"numPad2",		-- 76
 	"numPad3",	"numPad0",	"numPadDecimal",nil,	nil,			-- 81


### PR DESCRIPTION
Skimming through the CC API for an emulator project and found this bug. I decided to take this game-breaking issue into my own hands and repair it. You're welcome CC.

In other words this is the worst reason to receive a contributor tag, so if you ( @SquidDev ) want to close this and fix it yourself and not actually give me a pity tag, feel free. XP