### PR TITLE
Preempting computer execution

### DIFF
--- a/src/main/java/dan200/computercraft/core/computer/ComputerThread.java
+++ b/src/main/java/dan200/computercraft/core/computer/ComputerThread.java
@@ -127,6 +127,16 @@ public class ComputerThread
     }
 
     /**
+     * Determine if the thread has computers queued up
+     *
+     * @return If we have work queued up.
+     */
+    static boolean hasPendingWork()
+    {
+        return computersActive.size() > 0;
+    }
+
+    /**
      * Observes all currently active {@link TaskRunner}s and terminates their tasks once they have exceeded the hard
      * abort limit.
      *
@@ -158,7 +168,7 @@ public class ComputerThread
 
                             // If we're still within normal execution times (TIMEOUT) or soft abort (ABORT_TIMEOUT),
                             // then we can let the Lua machine do its work.
-                            long afterStart = executor.timeout.nanoSinceStart();
+                            long afterStart = executor.timeout.nanoCumulative();
                             long afterHardAbort = afterStart - TIMEOUT - ABORT_TIMEOUT;
                             if( afterHardAbort < 0 ) continue;
 

--- a/src/main/java/dan200/computercraft/core/lua/MachineResult.java
+++ b/src/main/java/dan200/computercraft/core/lua/MachineResult.java
@@ -23,42 +23,54 @@ import java.io.InputStream;
 public final class MachineResult
 {
     /**
-     * Represents a successful execution
+     * A successful complete execution.
      */
-    public static final MachineResult OK = new MachineResult( false, null );
+    public static final MachineResult OK = new MachineResult( false, false, null );
+
+    /**
+     * A successful paused execution.
+     */
+    public static final MachineResult PAUSE = new MachineResult( false, true, null );
 
     /**
      * An execution which timed out.
      */
-    public static final MachineResult TIMEOUT = new MachineResult( true, TimeoutState.ABORT_MESSAGE );
+    public static final MachineResult TIMEOUT = new MachineResult( true, false, TimeoutState.ABORT_MESSAGE );
 
     /**
      * An error with no user-friendly error message
      */
-    public static final MachineResult GENERIC_ERROR = new MachineResult( true, null );
+    public static final MachineResult GENERIC_ERROR = new MachineResult( true, false, null );
 
     private final boolean error;
+    private final boolean pause;
     private final String message;
 
-    private MachineResult( boolean error, String message )
+    private MachineResult( boolean error, boolean pause, String message )
     {
+        this.pause = pause;
         this.message = message;
         this.error = error;
     }
 
     public static MachineResult error( @Nonnull String error )
     {
-        return new MachineResult( true, error );
+        return new MachineResult( true, false, error );
     }
 
     public static MachineResult error( @Nonnull Exception error )
     {
-        return new MachineResult( true, error.getMessage() );
+        return new MachineResult( true, false, error.getMessage() );
     }
 
     public boolean isError()
     {
         return error;
+    }
+
+    public boolean isPause()
+    {
+        return pause;
     }
 
     @Nullable

--- a/src/main/java/dan200/computercraft/shared/Config.java
+++ b/src/main/java/dan200/computercraft/shared/Config.java
@@ -106,7 +106,7 @@ public class Config
             computerThreads = config.get( CATEGORY_GENERAL, "computer_threads", ComputerCraft.computer_threads );
             computerThreads
                 .setMinValue( 1 )
-                .setRequiresWorldRestart( true )
+                .setRequiresMcRestart( true )
                 .setComment( "Set the number of threads computers can run on. A higher number means more computers can run at once, but may induce lag.\n" +
                     "Please note that some mods may not work with a thread count higher than 1. Use with caution." );
 

--- a/src/test/java/dan200/computercraft/core/computer/ComputerBootstrap.java
+++ b/src/test/java/dan200/computercraft/core/computer/ComputerBootstrap.java
@@ -84,10 +84,10 @@ public class ComputerBootstrap
 
             if( computer.isOn() || !api.didAssert )
             {
-                StringBuilder builder = new StringBuilder().append( "Did not correctly" );
+                StringBuilder builder = new StringBuilder().append( "Did not correctly [" );
                 if( !api.didAssert ) builder.append( " assert" );
                 if( computer.isOn() ) builder.append( " shutdown" );
-                builder.append( "\n" );
+                builder.append( " ]\n" );
 
                 for( int line = 0; line < 19; line++ )
                 {


### PR DESCRIPTION
This implements computer-thread preemption or pausing, as discussed in #114.

## Summary of changes
 - `CobaltLuaMachine`/`ComputerExecutor` can now be paused - this suspends the machine via a debug hook. When doing work again, we resume the machine, rather than starting a new task.

 - `ComputerThread` now has an implementation of CFS:

   We aim to execute one task from every compute within a 50ms window (`ComputerThread.DEFAULT_LATENCY`). Thus, each computer is run with a timeout of (`latency / (tasks + 1)`). Once that timeout is reached (or the task is finished), we pause the machine, and add it to the queue.

   In order to ensure fair sharing of resources, the queue is sorted by the "virtual runtime", which is effectively computed by how much time it has received, weighted by how many other computers also want to do work. The more tasks to be queued, the less weight the current time is worth (as it is given a smaller share of the "ideal" processor).

## To improve before merging
 - [x] Find good defaults for the above parameters.
 - [x] Rework the documentation of `ComputerThread` and `TimeoutState`, as we've tweaked these a little.