### PR TITLE
Minor palette improvements

### DIFF
--- a/src/main/java/dan200/computercraft/core/apis/TermAPI.java
+++ b/src/main/java/dan200/computercraft/core/apis/TermAPI.java
@@ -11,6 +11,7 @@ import dan200.computercraft.api.lua.ILuaContext;
 import dan200.computercraft.api.lua.LuaException;
 import dan200.computercraft.core.computer.IComputerEnvironment;
 import dan200.computercraft.core.terminal.Terminal;
+import dan200.computercraft.shared.util.Colour;
 import dan200.computercraft.shared.util.Palette;
 import org.apache.commons.lang3.ArrayUtils;
 
@@ -65,6 +66,8 @@ public class TermAPI implements ILuaAPI
             "setPaletteColor",
             "getPaletteColour",
             "getPaletteColor",
+            "nativePaletteColour",
+            "nativePaletteColor",
             "getCursorBlink",
         };
     }
@@ -289,6 +292,19 @@ public class TermAPI implements ILuaAPI
                 return null;
             }
             case 23:
+            case 24:
+            {
+                // nativePaletteColour/nativePaletteColor
+                int colour = 15 - parseColour( args );
+                Colour c = Colour.fromInt( colour );
+
+                float[] rgb = c.getRGB();
+
+                Object[] rgbObj = new Object[rgb.length];
+                for( int i = 0; i < rgbObj.length; ++i ) rgbObj[i] = rgb[i];
+                return rgbObj;
+            }
+            case 25:
                 // getCursorBlink
                 return new Object[] { m_terminal.getCursorBlink() };
             default:

--- a/src/main/resources/assets/computercraft/lua/rom/apis/colors.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/apis/colors.lua
@@ -48,22 +48,36 @@ function test( colors, color )
     if type( color ) ~= "number" then
         error( "bad argument #2 (expected number, got " .. type( color ) .. ")", 2 )
     end
-    return ((bit32.band(colors, color)) == color)
+    return bit32.band(colors, color) == color
+end
+
+function packRGB( r, g, b )
+    if type( r ) ~= "number" then
+        error( "bad argument #1 (expected number, got " .. type( r ) .. ")", 2 )
+    end
+    if type( g ) ~= "number" then
+        error( "bad argument #2 (expected number, got " .. type( g ) .. ")", 2 )
+    end
+    if type( b ) ~= "number" then
+        error( "bad argument #3 (expected number, got " .. type( b ) .. ")", 2 )
+    end
+    return
+        bit32.band( r, 0xFF ) * 2^16 +
+        bit32.band( g, 0xFF ) * 2^8 +
+        bit32.band( b, 0xFF )
+end
+
+function unpackRGB( rgb )
+    if type( rgb ) ~= "number" then
+        error( "bad argument #1 (expected number, got " .. type( rgb ) .. ")", 2 )
+    end
+    return bit32.band( bit32.rshift( rgb, 16 ), 0xFF ), bit32.band( bit32.rshift( rgb, 8 ), 0xFF ), bit32.band( rgb, 0xFF )
 end
 
 function rgb8( r, g, b )
-    if type( r ) ~= "number" then
-        error( "bad argument #1 (expected number, got " .. type( r ) .. ")", 2 )
-    elseif type(r) == "number" and g == nil and b == nil then
-        return bit32.band( bit32.rshift( r, 16 ), 0xFF ) / 255, bit32.band( bit32.rshift( r, 8 ), 0xFF ) / 255, bit32.band( r, 0xFF ) / 255
-    elseif type(r) == "number" and type(g) == "number" and type(b) == "number" then
-        return
-            bit32.lshift( bit32.band(r * 255, 0xFF), 16 ) +
-            bit32.lshift( bit32.band(g * 255, 0xFF), 8 ) +
-            bit32.band(b * 255, 0xFF)
-    elseif type( g ) ~= "number" then
-        error( "bad argument #2 (expected number, got " .. type( g ) .. ")", 2 )
-    elseif type( b ) ~= "number" then
-        error( "bad argument #3 (expected number, got " .. type( b ) .. ")", 2 )
+    if g == nil and b == nil then
+        return unpackRGB( r )
+    else
+        return packRGB( r, g, b )
     end
 end

--- a/src/main/resources/assets/computercraft/lua/rom/apis/term.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/apis/term.lua
@@ -42,11 +42,16 @@ term.native = function()
     return native
 end
 
+-- Some methods shouldn't go through redirects, so we move them to the main
+-- term API.
+for _, method in ipairs { "nativePaletteColor", "nativePaletteColour"} do
+    term[method] = native[method]
+    native[method] = nil
+end
+
 for k,v in pairs( native ) do
-    if type( k ) == "string" and type( v ) == "function" then
-        if term[k] == nil then
-            term[k] = wrap( k )
-        end
+    if type( k ) == "string" and type( v ) == "function" and term[k] == nil then
+        term[k] = wrap( k )
     end
 end
 

--- a/src/main/resources/assets/computercraft/lua/rom/apis/window.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/apis/window.lua
@@ -298,7 +298,7 @@ function create( parent, nX, nY, nWidth, nHeight, bStartVisible )
 
         local tCol
         if type(r) == "number" and g == nil and b == nil then
-            tCol = { colours.rgb8( r ) }
+            tCol = { colours.unpackRGB( r ) }
             tPalette[ colour ] = tCol
         else
             if type( r ) ~= "number" then error( "bad argument #2 (expected number, got " .. type( r ) .. ")", 2 ) end


### PR DESCRIPTION
This cherry picks the backwards compatible parts of dan200/ComputerCraft#433, namely:

 - `term.nativePaletteColo(u+ε)r`. Note, this has been changed slightly: the methods are defined on the main `term` API, rather than the redirect object.
 - Split `colours.rgb8` into `colours.packRGB` and `colours.unpackRGB`. We still keep the original method for the sake of backwards compatibility.

To discuss:
 - Is it sane to put `nativePaletteColour` on the root term object? I can't see a situation where a redirect would have different colours, so this seems sensible to me.
 - `packRGB` or `packRgb`? We use all capitals for initialisms already (`os.loadAPI`), so it's consistent, but IMO looks a little ugly.