### PR TITLE
Handle Pastebin spam protection and add a cache buster

### DIFF
--- a/src/main/resources/assets/computercraft/lua/rom/programs/http/pastebin.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/programs/http/pastebin.lua
@@ -78,8 +78,6 @@ if sCommand == "put" then
     if response then
         print( "Success." )
 
-        print(response.getResponseHeaders())
-
         local sResponse = response.readAll()
         response.close()
 

--- a/src/main/resources/assets/computercraft/lua/rom/programs/http/pastebin.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/programs/http/pastebin.lua
@@ -20,11 +20,20 @@ end
 
 local function get(paste)
     write( "Connecting to pastebin.com... " )
+    -- Add a cache buster so that spam protection is re-checked
+    local cacheBuster = tostring(math.random())
     local response = http.get(
-        "https://pastebin.com/raw/"..textutils.urlEncode( paste )
+        "https://pastebin.com/raw/"..textutils.urlEncode( paste ).."?cb="..cacheBuster
     )
 
     if response then
+        -- If spam protection is activated, we get redirected to /paste with Content-Type: text/html
+        local headers = response.getResponseHeaders()
+        if not headers["Content-Type"] or not headers["Content-Type"]:find( "^text/plain" ) then
+            printError( "\nFailed to get paste. Please complete the captcha in a web browser: https://pastebin.com/"..textutils.urlEncode( paste ) )
+            return
+        end
+
         print( "Success." )
 
         local sResponse = response.readAll()

--- a/src/main/resources/assets/computercraft/lua/rom/programs/http/pastebin.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/programs/http/pastebin.lua
@@ -21,8 +21,8 @@ end
 local function get(paste)
     write( "Connecting to pastebin.com... " )
     -- Add a cache buster so that spam protection is re-checked
-    local cacheBuster = tostring(math.random())
-    local response = http.get(
+    local cacheBuster = ("%x"):format(math.random(0, 2^30))
+    local response, err = http.get(
         "https://pastebin.com/raw/"..textutils.urlEncode( paste ).."?cb="..cacheBuster
     )
 
@@ -30,7 +30,8 @@ local function get(paste)
         -- If spam protection is activated, we get redirected to /paste with Content-Type: text/html
         local headers = response.getResponseHeaders()
         if not headers["Content-Type"] or not headers["Content-Type"]:find( "^text/plain" ) then
-            printError( "\nFailed to get paste. Please complete the captcha in a web browser: https://pastebin.com/"..textutils.urlEncode( paste ) )
+            io.stderr:write( "Failed.\n" )
+            print( "Pastebin blocked the download due to spam protection. Please complete the captcha in a web browser: https://pastebin.com/"..textutils.urlEncode( paste ) )
             return
         end
 
@@ -40,7 +41,8 @@ local function get(paste)
         response.close()
         return sResponse
     else
-        print( "Failed." )
+        io.stderr:write( "Failed.\n" )
+        print(err)
     end
 end
 
@@ -75,6 +77,8 @@ if sCommand == "put" then
 
     if response then
         print( "Success." )
+
+        print(response.getResponseHeaders())
 
         local sResponse = response.readAll()
         response.close()


### PR DESCRIPTION
If you `pastebin put <filename>` when the file contains a URL, you will trigger Pastebin's spam protection:

![](https://shitty.download/UfHu6.png)

The user will have to manually navigate to the paste in their browser and complete the captcha before the paste can then be retrieved with `pastebin get`. This PR adds an additional check to `get()` that ensures the content is plaintext, otherwise it will inform the user that they need to complete the captcha in a web browser. It does assume that the reason for failure was a captcha, but it does provide the URL for them to check themselves if it was anything else.

As well as this, it adds a cache buster onto the end of the URL when getting. This is because ComputerCraft caches the redirect to the HTML page (`/raw/paste` → `/paste`) if they tried to retrieve it during spam protection. The cache buster fixes this issue.

![](https://shitty.download/4auFo.png)