### PR TITLE
Rework computer execution and ComputerThread

### DIFF
--- a/src/main/java/dan200/computercraft/core/computer/ApiWrapper.java
+++ b/src/main/java/dan200/computercraft/core/computer/ApiWrapper.java
@@ -16,7 +16,7 @@ import javax.annotation.Nullable;
 /**
  * A wrapper for {@link ILuaAPI}s which cleans up after a {@link ComputerSystem} when the computer is shutdown.
  */
-public class ApiWrapper implements ILuaAPI
+final class ApiWrapper implements ILuaAPI
 {
     private final ILuaAPI delegate;
     private final ComputerSystem system;

--- a/src/main/java/dan200/computercraft/core/computer/Computer.java
+++ b/src/main/java/dan200/computercraft/core/computer/Computer.java
@@ -20,10 +20,12 @@ import dan200.computercraft.core.lua.CobaltLuaMachine;
 import dan200.computercraft.core.lua.ILuaMachine;
 import dan200.computercraft.core.terminal.Terminal;
 
+import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class Computer
 {
@@ -48,13 +50,14 @@ public class Computer
 
     private ILuaMachine m_machine = null;
     private final List<ILuaAPI> m_apis = new ArrayList<>();
+    final TimeoutFlags timeout = new TimeoutFlags();
     private final Environment m_internalEnvironment = new Environment( this );
 
     private final Terminal m_terminal;
     private FileSystem m_fileSystem = null;
     private IWritableMount m_rootMount = null;
 
-    private boolean m_externalOutputChanged;
+    private final AtomicBoolean externalOutputChanged = new AtomicBoolean();
 
     public Computer( IComputerEnvironment environment, Terminal terminal, int id )
     {
@@ -130,24 +133,6 @@ public class Computer
         }
     }
 
-    public void abort( boolean hard )
-    {
-        synchronized( this )
-        {
-            if( m_state != State.Off && m_machine != null )
-            {
-                if( hard )
-                {
-                    m_machine.hardAbort( "Too long without yielding" );
-                }
-                else
-                {
-                    m_machine.softAbort( "Too long without yielding" );
-                }
-            }
-        }
-    }
-
     public void unload()
     {
         stopComputer( false );
@@ -182,11 +167,11 @@ public class Computer
         if( !Objects.equal( label, m_label ) )
         {
             m_label = label;
-            m_externalOutputChanged = true;
+            externalOutputChanged.set( true );
         }
     }
 
-    public void advance()
+    public void tick()
     {
         synchronized( this )
         {
@@ -212,7 +197,7 @@ public class Computer
         }
 
         // Prepare to propagate the environment's output to the world.
-        if( m_internalEnvironment.updateOutput() ) m_externalOutputChanged = true;
+        if( m_internalEnvironment.updateOutput() ) externalOutputChanged.set( true );
 
         // Set output changed if the terminal has changed from blinking to not
         boolean blinking =
@@ -223,18 +208,13 @@ public class Computer
         if( blinking != m_blinking )
         {
             m_blinking = blinking;
-            m_externalOutputChanged = true;
+            externalOutputChanged.set( true );
         }
     }
 
     public boolean pollAndResetChanged()
     {
-        synchronized( this )
-        {
-            boolean changed = m_externalOutputChanged;
-            m_externalOutputChanged = false;
-            return changed;
-        }
+        return externalOutputChanged.getAndSet( false );
     }
 
     public boolean isBlinking()
@@ -287,7 +267,7 @@ public class Computer
     private void initLua()
     {
         // Create the lua machine
-        ILuaMachine machine = new CobaltLuaMachine( this );
+        ILuaMachine machine = new CobaltLuaMachine( this, timeout );
 
         // Add the APIs
         for( ILuaAPI api : m_apis )
@@ -327,7 +307,7 @@ public class Computer
                 m_terminal.setCursorPos( 0, 1 );
                 m_terminal.write( "ComputerCraft may be installed incorrectly" );
 
-                machine.unload();
+                machine.close();
                 m_machine = null;
             }
             else
@@ -342,7 +322,7 @@ public class Computer
             m_terminal.setCursorPos( 0, 1 );
             m_terminal.write( "ComputerCraft may be installed incorrectly" );
 
-            machine.unload();
+            machine.close();
             m_machine = null;
         }
     }
@@ -356,18 +336,18 @@ public class Computer
                 return;
             }
             m_state = State.Starting;
-            m_externalOutputChanged = true;
+            externalOutputChanged.set( true );
             m_ticksSinceStart = 0;
         }
 
         // Turn the computercraft on
-        final Computer computer = this;
         ComputerThread.queueTask( new ITask()
         {
+            @Nonnull
             @Override
             public Computer getOwner()
             {
-                return computer;
+                return Computer.this;
             }
 
             @Override
@@ -414,14 +394,14 @@ public class Computer
 
                     // Start a new state
                     m_state = State.Running;
-                    m_externalOutputChanged = true;
+                    externalOutputChanged.set( true );
                     synchronized( m_machine )
                     {
                         m_machine.handleEvent( null, null );
                     }
                 }
             }
-        }, computer );
+        }, this );
     }
 
     private void stopComputer( final boolean reboot )
@@ -433,17 +413,17 @@ public class Computer
                 return;
             }
             m_state = State.Stopping;
-            m_externalOutputChanged = true;
+            externalOutputChanged.set( true );
         }
 
         // Turn the computercraft off
-        final Computer computer = this;
         ComputerThread.queueTask( new ITask()
         {
+            @Nonnull
             @Override
             public Computer getOwner()
             {
-                return computer;
+                return Computer.this;
             }
 
             @Override
@@ -478,7 +458,7 @@ public class Computer
 
                         synchronized( m_machine )
                         {
-                            m_machine.unload();
+                            m_machine.close();
                             m_machine = null;
                         }
                     }
@@ -487,14 +467,14 @@ public class Computer
                     m_internalEnvironment.resetOutput();
 
                     m_state = State.Off;
-                    m_externalOutputChanged = true;
+                    externalOutputChanged.set( true );
                     if( reboot )
                     {
                         m_startRequested = true;
                     }
                 }
             }
-        }, computer );
+        }, this );
     }
 
     public void queueEvent( final String event, final Object[] arguments )
@@ -507,13 +487,13 @@ public class Computer
             }
         }
 
-        final Computer computer = this;
-        ITask task = new ITask()
+        ComputerThread.queueTask( new ITask()
         {
+            @Nonnull
             @Override
             public Computer getOwner()
             {
-                return computer;
+                return Computer.this;
             }
 
             @Override
@@ -541,9 +521,7 @@ public class Computer
                     }
                 }
             }
-        };
-
-        ComputerThread.queueTask( task, computer );
+        }, this );
     }
 
     @Deprecated
@@ -568,7 +546,7 @@ public class Computer
     @SuppressWarnings( "unused" )
     public void advance( double dt )
     {
-        advance();
+        tick();
     }
 
     public static final String[] s_sideNames = IAPIEnvironment.SIDE_NAMES;

--- a/src/main/java/dan200/computercraft/core/computer/Computer.java
+++ b/src/main/java/dan200/computercraft/core/computer/Computer.java
@@ -7,57 +7,46 @@
 package dan200.computercraft.core.computer;
 
 import com.google.common.base.Objects;
-import dan200.computercraft.ComputerCraft;
-import dan200.computercraft.api.filesystem.IMount;
-import dan200.computercraft.api.filesystem.IWritableMount;
 import dan200.computercraft.api.lua.ILuaAPI;
-import dan200.computercraft.api.lua.ILuaAPIFactory;
 import dan200.computercraft.api.peripheral.IPeripheral;
-import dan200.computercraft.core.apis.*;
+import dan200.computercraft.core.apis.IAPIEnvironment;
 import dan200.computercraft.core.filesystem.FileSystem;
-import dan200.computercraft.core.filesystem.FileSystemException;
-import dan200.computercraft.core.lua.CobaltLuaMachine;
-import dan200.computercraft.core.lua.ILuaMachine;
 import dan200.computercraft.core.terminal.Terminal;
 
-import javax.annotation.Nonnull;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+/**
+ * Represents a computer which may exist in-world or elsewhere.
+ *
+ * Note, this class has several (read: far, far too many) responsibilities, so can get a little unwieldy at times.
+ *
+ * <ul>
+ * <li>Updates the {@link Environment}.</li>
+ * <li>Keeps track of whether the computer is on and blinking.</li>
+ * <li>Monitors whether the computer's visible state (redstone, on/off/blinking) has changed.</li>
+ * <li>Passes commands and events to the {@link ComputerExecutor}.</li>
+ * </ul>
+ */
 public class Computer
 {
-    private enum State
-    {
-        Off,
-        Starting,
-        Running,
-        Stopping,
-    }
+    private static final int START_DELAY = 50;
 
-    private static IMount s_romMount = null;
-
+    // Various properties of the computer
     private int m_id;
     private String m_label = null;
+
+    // Read-only fields about the computer
     private final IComputerEnvironment m_environment;
-
-    private int m_ticksSinceStart = -1;
-    private boolean m_startRequested = false;
-    private State m_state = State.Off;
-    private boolean m_blinking = false;
-
-    private ILuaMachine m_machine = null;
-    private final List<ILuaAPI> m_apis = new ArrayList<>();
-    final TimeoutFlags timeout = new TimeoutFlags();
-    private final Environment m_internalEnvironment = new Environment( this );
-
     private final Terminal m_terminal;
-    private FileSystem m_fileSystem = null;
-    private IWritableMount m_rootMount = null;
+    private final ComputerExecutor executor;
 
-    private final AtomicBoolean externalOutputChanged = new AtomicBoolean();
+    // Additional state about the computer and its environment.
+    private boolean m_blinking = false;
+    private final Environment internalEnvironment = new Environment( this );
+    private AtomicBoolean externalOutputChanged = new AtomicBoolean();
+
+    private boolean startRequested;
+    private int m_ticksSinceStart = -1;
 
     public Computer( IComputerEnvironment environment, Terminal terminal, int id )
     {
@@ -65,24 +54,7 @@ public class Computer
         m_environment = environment;
         m_terminal = terminal;
 
-        // Ensure the computer thread is running as required.
-        ComputerThread.start();
-
-        // Add all default APIs to the loaded list.
-        m_apis.add( new TermAPI( m_internalEnvironment ) );
-        m_apis.add( new RedstoneAPI( m_internalEnvironment ) );
-        m_apis.add( new FSAPI( m_internalEnvironment ) );
-        m_apis.add( new PeripheralAPI( m_internalEnvironment ) );
-        m_apis.add( new OSAPI( m_internalEnvironment ) );
-        if( ComputerCraft.http_enable ) m_apis.add( new HTTPAPI( m_internalEnvironment ) );
-
-        // Load in the API registered APIs.
-        for( ILuaAPIFactory factory : ApiFactories.getAll() )
-        {
-            ComputerSystem system = new ComputerSystem( m_internalEnvironment );
-            ILuaAPI api = factory.create( system );
-            if( api != null ) m_apis.add( new ApiWrapper( api, system ) );
-        }
+        executor = new ComputerExecutor( this );
     }
 
     IComputerEnvironment getComputerEnvironment()
@@ -92,7 +64,7 @@ public class Computer
 
     FileSystem getFileSystem()
     {
-        return m_fileSystem;
+        return executor.getFileSystem();
     }
 
     Terminal getTerminal()
@@ -102,40 +74,42 @@ public class Computer
 
     public Environment getEnvironment()
     {
-        return m_internalEnvironment;
+        return internalEnvironment;
     }
 
     public IAPIEnvironment getAPIEnvironment()
     {
-        return m_internalEnvironment;
-    }
-
-    public void turnOn()
-    {
-        if( m_state == State.Off ) m_startRequested = true;
-    }
-
-    public void shutdown()
-    {
-        stopComputer( false );
-    }
-
-    public void reboot()
-    {
-        stopComputer( true );
+        return internalEnvironment;
     }
 
     public boolean isOn()
     {
-        synchronized( this )
-        {
-            return m_state == State.Running;
-        }
+        return executor.isOn();
+    }
+
+    public void turnOn()
+    {
+        startRequested = true;
+    }
+
+    public void shutdown()
+    {
+        executor.queueStop( false, false );
+    }
+
+    public void reboot()
+    {
+        executor.queueStop( true, false );
     }
 
     public void unload()
     {
-        stopComputer( false );
+        executor.queueStop( false, true );
+    }
+
+    public void queueEvent( String event, Object[] args )
+    {
+        executor.queueEvent( event, args );
     }
 
     public int getID()
@@ -173,43 +147,38 @@ public class Computer
 
     public void tick()
     {
-        synchronized( this )
+        // We keep track of the number of ticks since the last start, only
+        if( m_ticksSinceStart >= 0 && m_ticksSinceStart <= START_DELAY ) m_ticksSinceStart++;
+
+        if( startRequested && !executor.isOn() && (m_ticksSinceStart < 0 || m_ticksSinceStart > START_DELAY) )
         {
-            // Start after a number of ticks
-            if( m_ticksSinceStart >= 0 )
-            {
-                m_ticksSinceStart++;
-            }
-            if( m_startRequested && (m_ticksSinceStart < 0 || m_ticksSinceStart > 50) )
-            {
-                startComputer();
-                m_startRequested = false;
-            }
-
-            if( m_state == State.Running )
-            {
-                // Update the environment's internal state.
-                m_internalEnvironment.update();
-
-                // Advance our APIs
-                for( ILuaAPI api : m_apis ) api.update();
-            }
+            m_ticksSinceStart = 0;
+            startRequested = false;
+            executor.queueStart();
         }
 
-        // Prepare to propagate the environment's output to the world.
-        if( m_internalEnvironment.updateOutput() ) externalOutputChanged.set( true );
+        executor.tick();
+
+        // Update the environment's internal state.
+        internalEnvironment.update();
+
+        // Propagate the environment's output to the world.
+        if( internalEnvironment.updateOutput() ) externalOutputChanged.set( true );
 
         // Set output changed if the terminal has changed from blinking to not
-        boolean blinking =
-            m_terminal.getCursorBlink() &&
-                m_terminal.getCursorX() >= 0 && m_terminal.getCursorX() < m_terminal.getWidth() &&
-                m_terminal.getCursorY() >= 0 && m_terminal.getCursorY() < m_terminal.getHeight();
-
+        boolean blinking = m_terminal.getCursorBlink() &&
+            m_terminal.getCursorX() >= 0 && m_terminal.getCursorX() < m_terminal.getWidth() &&
+            m_terminal.getCursorY() >= 0 && m_terminal.getCursorY() < m_terminal.getHeight();
         if( blinking != m_blinking )
         {
             m_blinking = blinking;
             externalOutputChanged.set( true );
         }
+    }
+
+    void markChanged()
+    {
+        externalOutputChanged.set( true );
     }
 
     public boolean pollAndResetChanged()
@@ -222,324 +191,27 @@ public class Computer
         return isOn() && m_blinking;
     }
 
-    public IWritableMount getRootMount()
+    public void addApi( ILuaAPI api )
     {
-        if( m_rootMount == null )
-        {
-            m_rootMount = m_environment.createSaveDirMount( "computer/" + assignID(), m_environment.getComputerSpaceLimit() );
-        }
-        return m_rootMount;
-    }
-
-    // FileSystem
-
-    private boolean initFileSystem()
-    {
-        // Create the file system
-        assignID();
-        try
-        {
-            m_fileSystem = new FileSystem( "hdd", getRootMount() );
-            if( s_romMount == null ) s_romMount = m_environment.createResourceMount( "computercraft", "lua/rom" );
-            if( s_romMount != null )
-            {
-                m_fileSystem.mount( "rom", "rom", s_romMount );
-                return true;
-            }
-            return false;
-        }
-        catch( FileSystemException e )
-        {
-            ComputerCraft.log.error( "Cannot mount rom", e );
-            return false;
-        }
-    }
-
-    // Peripherals
-
-    public void addAPI( ILuaAPI api )
-    {
-        m_apis.add( api );
-    }
-
-    // Lua
-
-    private void initLua()
-    {
-        // Create the lua machine
-        ILuaMachine machine = new CobaltLuaMachine( this, timeout );
-
-        // Add the APIs
-        for( ILuaAPI api : m_apis )
-        {
-            machine.addAPI( api );
-            api.startup();
-        }
-
-        // Load the bios resource
-        InputStream biosStream;
-        try
-        {
-            biosStream = m_environment.createResourceFile( "computercraft", "lua/bios.lua" );
-        }
-        catch( Exception e )
-        {
-            biosStream = null;
-        }
-
-        // Start the machine running the bios resource
-        if( biosStream != null )
-        {
-            machine.loadBios( biosStream );
-            try
-            {
-                biosStream.close();
-            }
-            catch( IOException e )
-            {
-                // meh
-            }
-
-            if( machine.isFinished() )
-            {
-                m_terminal.reset();
-                m_terminal.write( "Error starting bios.lua" );
-                m_terminal.setCursorPos( 0, 1 );
-                m_terminal.write( "ComputerCraft may be installed incorrectly" );
-
-                machine.close();
-                m_machine = null;
-            }
-            else
-            {
-                m_machine = machine;
-            }
-        }
-        else
-        {
-            m_terminal.reset();
-            m_terminal.write( "Error loading bios.lua" );
-            m_terminal.setCursorPos( 0, 1 );
-            m_terminal.write( "ComputerCraft may be installed incorrectly" );
-
-            machine.close();
-            m_machine = null;
-        }
-    }
-
-    private void startComputer()
-    {
-        synchronized( this )
-        {
-            if( m_state != State.Off )
-            {
-                return;
-            }
-            m_state = State.Starting;
-            externalOutputChanged.set( true );
-            m_ticksSinceStart = 0;
-        }
-
-        // Turn the computercraft on
-        ComputerThread.queueTask( new ITask()
-        {
-            @Nonnull
-            @Override
-            public Computer getOwner()
-            {
-                return Computer.this;
-            }
-
-            @Override
-            public void execute()
-            {
-                synchronized( this )
-                {
-                    if( m_state != State.Starting )
-                    {
-                        return;
-                    }
-
-                    // Init terminal
-                    m_terminal.reset();
-
-                    // Init filesystem
-                    if( !initFileSystem() )
-                    {
-                        // Init failed, so shutdown
-                        m_terminal.reset();
-                        m_terminal.write( "Error mounting lua/rom" );
-                        m_terminal.setCursorPos( 0, 1 );
-                        m_terminal.write( "ComputerCraft may be installed incorrectly" );
-
-                        m_state = State.Running;
-                        stopComputer( false );
-                        return;
-                    }
-
-                    // Init lua
-                    initLua();
-                    if( m_machine == null )
-                    {
-                        m_terminal.reset();
-                        m_terminal.write( "Error loading bios.lua" );
-                        m_terminal.setCursorPos( 0, 1 );
-                        m_terminal.write( "ComputerCraft may be installed incorrectly" );
-
-                        // Init failed, so shutdown
-                        m_state = State.Running;
-                        stopComputer( false );
-                        return;
-                    }
-
-                    // Start a new state
-                    m_state = State.Running;
-                    externalOutputChanged.set( true );
-                    synchronized( m_machine )
-                    {
-                        m_machine.handleEvent( null, null );
-                    }
-                }
-            }
-        }, this );
-    }
-
-    private void stopComputer( final boolean reboot )
-    {
-        synchronized( this )
-        {
-            if( m_state != State.Running )
-            {
-                return;
-            }
-            m_state = State.Stopping;
-            externalOutputChanged.set( true );
-        }
-
-        // Turn the computercraft off
-        ComputerThread.queueTask( new ITask()
-        {
-            @Nonnull
-            @Override
-            public Computer getOwner()
-            {
-                return Computer.this;
-            }
-
-            @Override
-            public void execute()
-            {
-                synchronized( this )
-                {
-                    if( m_state != State.Stopping )
-                    {
-                        return;
-                    }
-
-                    // Shutdown our APIs
-                    synchronized( m_apis )
-                    {
-                        for( ILuaAPI api : m_apis )
-                        {
-                            api.shutdown();
-                        }
-                    }
-
-                    // Shutdown terminal and filesystem
-                    if( m_fileSystem != null )
-                    {
-                        m_fileSystem.unload();
-                        m_fileSystem = null;
-                    }
-
-                    if( m_machine != null )
-                    {
-                        m_terminal.reset();
-
-                        synchronized( m_machine )
-                        {
-                            m_machine.close();
-                            m_machine = null;
-                        }
-                    }
-
-                    // Reset redstone output
-                    m_internalEnvironment.resetOutput();
-
-                    m_state = State.Off;
-                    externalOutputChanged.set( true );
-                    if( reboot )
-                    {
-                        m_startRequested = true;
-                    }
-                }
-            }
-        }, this );
-    }
-
-    public void queueEvent( final String event, final Object[] arguments )
-    {
-        synchronized( this )
-        {
-            if( m_state != State.Running )
-            {
-                return;
-            }
-        }
-
-        ComputerThread.queueTask( new ITask()
-        {
-            @Nonnull
-            @Override
-            public Computer getOwner()
-            {
-                return Computer.this;
-            }
-
-            @Override
-            public void execute()
-            {
-                synchronized( this )
-                {
-                    if( m_state != State.Running )
-                    {
-                        return;
-                    }
-                }
-
-                synchronized( m_machine )
-                {
-                    m_machine.handleEvent( event, arguments );
-                    if( m_machine.isFinished() )
-                    {
-                        m_terminal.reset();
-                        m_terminal.write( "Error resuming bios.lua" );
-                        m_terminal.setCursorPos( 0, 1 );
-                        m_terminal.write( "ComputerCraft may be installed incorrectly" );
-
-                        stopComputer( false );
-                    }
-                }
-            }
-        }, this );
+        executor.addApi( api );
     }
 
     @Deprecated
     public IPeripheral getPeripheral( int side )
     {
-        return m_internalEnvironment.getPeripheral( side );
+        return internalEnvironment.getPeripheral( side );
     }
 
     @Deprecated
     public void setPeripheral( int side, IPeripheral peripheral )
     {
-        m_internalEnvironment.setPeripheral( side, peripheral );
+        internalEnvironment.setPeripheral( side, peripheral );
     }
 
     @Deprecated
     public void addAPI( dan200.computercraft.core.apis.ILuaAPI api )
     {
-        addAPI( (ILuaAPI) api );
+        addApi( api );
     }
 
     @Deprecated
@@ -549,5 +221,6 @@ public class Computer
         tick();
     }
 
+    @Deprecated
     public static final String[] s_sideNames = IAPIEnvironment.SIDE_NAMES;
 }

--- a/src/main/java/dan200/computercraft/core/computer/ComputerExecutor.java
+++ b/src/main/java/dan200/computercraft/core/computer/ComputerExecutor.java
@@ -1,0 +1,574 @@
+/*
+ * This file is part of ComputerCraft - http://www.computercraft.info
+ * Copyright Daniel Ratcliffe, 2011-2019. Do not distribute without permission.
+ * Send enquiries to dratcliffe@gmail.com
+ */
+
+package dan200.computercraft.core.computer;
+
+import dan200.computercraft.ComputerCraft;
+import dan200.computercraft.api.filesystem.IMount;
+import dan200.computercraft.api.filesystem.IWritableMount;
+import dan200.computercraft.api.lua.ILuaAPI;
+import dan200.computercraft.api.lua.ILuaAPIFactory;
+import dan200.computercraft.core.apis.*;
+import dan200.computercraft.core.filesystem.FileSystem;
+import dan200.computercraft.core.filesystem.FileSystemException;
+import dan200.computercraft.core.lua.CobaltLuaMachine;
+import dan200.computercraft.core.lua.ILuaMachine;
+import dan200.computercraft.core.terminal.Terminal;
+import dan200.computercraft.shared.util.IoUtil;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.InputStream;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * The main task queue and executor for a single computer. This handles turning on and off a computer, as well as
+ * running events.
+ *
+ * When the computer is instructed to turn on or off, or handle an event, we queue a task and register this to be
+ * executed on the {@link ComputerThread}. Note, as we may be starting many events in a single tick, the external
+ * cannot lock on anything which may be held for a long time.
+ *
+ * The executor is effectively composed of two separate queues. Firstly, we have a "single element" queue
+ * {@link #command} which determines which state the computer should transition too. This is set by
+ * {@link #queueStart()} and {@link #queueStop(boolean, boolean)}.
+ *
+ * When a computer is on, we simply push any events onto to the {@link #eventQueue}.
+ *
+ * Both queues are run from the {@link #work()} method, which tries to execute a command if one exists, or resumes the
+ * machine with an event otherwise.
+ *
+ * One final responsibility for the executor is calling {@link ILuaAPI#update()} every tick, via the {@link #tick()}
+ * method. This should only be called when the computer is actually on ({@link #isOn}).
+ */
+final class ComputerExecutor
+{
+    private static final int QUEUE_LIMIT = 256;
+
+    private static IMount romMount;
+    private static final Object romMountLock = new Object();
+
+    private final Computer computer;
+    private final List<ILuaAPI> apis = new ArrayList<>();
+    final TimeoutFlags timeout = new TimeoutFlags();
+
+    private FileSystem fileSystem;
+
+    private ILuaMachine machine;
+
+    /**
+     * Whether the computer is currently on. This is set to false when a shutdown starts, or when turning on completes
+     * (but just before the Lua machine is started).
+     *
+     * @see #isOnLock
+     */
+    private volatile boolean isOn = false;
+
+    /**
+     * The lock to acquire when you need to modify the "on state" of a computer.
+     *
+     * We hold this lock when running any command, and attempt to hold it when updating APIs. This ensures you don't
+     * update APIs while also starting/stopping them.
+     *
+     * @see #isOn
+     * @see #tick()
+     * @see #turnOn()
+     * @see #shutdown()
+     */
+    private final ReentrantLock isOnLock = new ReentrantLock();
+
+    /**
+     * A lock used for any changes to {@link #eventQueue}, {@link #command} or {@link #onComputerQueue}. This will be
+     * used on the main thread, so locks should be kept as brief as possible.
+     */
+    private final Object queueLock = new Object();
+
+    /**
+     * Determines if this executer is present within {@link ComputerThread}.
+     */
+    volatile boolean onComputerQueue = false;
+
+    /**
+     * The command that {@link #work()} should execute on the computer thread.
+     *
+     * One sets the command with {@link #queueStart()} and {@link #queueStop(boolean, boolean)}. Neither of these will
+     * queue a new event if there is an existing one in the queue.
+     *
+     * Note, if command is not {@code null}, then some command is scheduled to be executed. Otherwise it is not
+     * currently in the queue (or is currently being executed).
+     */
+    private volatile StateCommand command;
+
+    /**
+     * The queue of events which should be executed when this computer is on.
+     *
+     * Note, this should be empty if this computer is off - it is cleared on shutdown and when turning on again.
+     */
+    private final Queue<Event> eventQueue = new ArrayDeque<>();
+
+    /**
+     * Whether this executor has been closed, and will no longer accept any incoming commands or events.
+     *
+     * @see #queueStop(boolean, boolean)
+     */
+    private boolean closed;
+
+    private IWritableMount rootMount;
+
+    /**
+     * {@code true} when inside {@link #work()}. We use this to ensure we're only doing one bit of work at one time.
+     */
+    private final AtomicBoolean isExecuting = new AtomicBoolean( false );
+
+    ComputerExecutor( Computer computer )
+    {
+        // Ensure the computer thread is running as required.
+        ComputerThread.start();
+
+        this.computer = computer;
+
+        Environment environment = computer.getEnvironment();
+
+        // Add all default APIs to the loaded list.
+        apis.add( new TermAPI( environment ) );
+        apis.add( new RedstoneAPI( environment ) );
+        apis.add( new FSAPI( environment ) );
+        apis.add( new PeripheralAPI( environment ) );
+        apis.add( new OSAPI( environment ) );
+        if( ComputerCraft.http_enable ) apis.add( new HTTPAPI( environment ) );
+
+        // Load in the externally registered APIs.
+        for( ILuaAPIFactory factory : ApiFactories.getAll() )
+        {
+            ComputerSystem system = new ComputerSystem( environment );
+            ILuaAPI api = factory.create( system );
+            if( api != null ) apis.add( new ApiWrapper( api, system ) );
+        }
+    }
+
+    boolean isOn()
+    {
+        return isOn;
+    }
+
+    FileSystem getFileSystem()
+    {
+        return fileSystem;
+    }
+
+    Computer getComputer()
+    {
+        return computer;
+    }
+
+    void addApi( ILuaAPI api )
+    {
+        apis.add( api );
+    }
+
+    /**
+     * Schedule this computer to be started if not already on.
+     */
+    void queueStart()
+    {
+        synchronized( queueLock )
+        {
+            // We should only schedule a start if we're not currently on and there's turn on.
+            if( closed || isOn || this.command != null ) return;
+
+            command = StateCommand.TURN_ON;
+            enqueue();
+        }
+    }
+
+    /**
+     * Schedule this computer to be stopped if not already on.
+     *
+     * @param reboot Reboot the computer after stopping
+     * @param close  Close the computer after stopping.
+     * @see #closed
+     */
+    void queueStop( boolean reboot, boolean close )
+    {
+        synchronized( queueLock )
+        {
+            if( closed ) return;
+            this.closed = close;
+
+            StateCommand newCommand = reboot ? StateCommand.REBOOT : StateCommand.SHUTDOWN;
+
+            // We should only schedule a stop if we're currently on and there's no shutdown pending.
+            if( !isOn || command != null )
+            {
+                // If we're closing, set the command just in case.
+                if( close ) command = newCommand;
+                return;
+            }
+
+            command = newCommand;
+            enqueue();
+        }
+    }
+
+    /**
+     * Queue an event if the computer is on
+     *
+     * @param event The event's name
+     * @param args  The event's arguments
+     */
+    void queueEvent( @Nonnull String event, @Nullable Object[] args )
+    {
+        // Events should be skipped if we're not on.
+        if( !isOn ) return;
+
+        synchronized( queueLock )
+        {
+            // And if we've got some command in the pipeline, then don't queue events - they'll
+            // probably be disposed of anyway.
+            // We also limit the number of events which can be queued.
+            if( closed || command != null || eventQueue.size() >= QUEUE_LIMIT ) return;
+
+            eventQueue.offer( new Event( event, args ) );
+            enqueue();
+        }
+    }
+
+    /**
+     * Add this executor to the {@link ComputerThread} if not already there.
+     */
+    private void enqueue()
+    {
+        synchronized( queueLock )
+        {
+            if( onComputerQueue ) return;
+            onComputerQueue = true;
+            ComputerThread.queue( this );
+        }
+    }
+
+    /**
+     * Re-add this executor to the {@link ComputerThread}, or remove it if we have no more work.
+     */
+    void requeue()
+    {
+        timeout.resetAbort();
+
+        synchronized( queueLock )
+        {
+            if( eventQueue.isEmpty() && command == null )
+            {
+                onComputerQueue = false;
+            }
+            else
+            {
+                ComputerThread.queue( this );
+            }
+        }
+    }
+
+    /**
+     * Update the internals of the executor.
+     */
+    void tick()
+    {
+        if( isOn && isOnLock.tryLock() )
+        {
+            // This horrific structure means we don't try to update APIs while the state is being changed
+            // (and so they may be running startup/shutdown).
+            // We use tryLock here, as it has minimal delay, and it doesn't matter if we miss an advance at the
+            // beginning or end of a computer's lifetime.
+            try
+            {
+                if( isOn )
+                {
+                    // Advance our APIs.
+                    for( ILuaAPI api : apis ) api.update();
+                }
+            }
+            finally
+            {
+                isOnLock.unlock();
+            }
+        }
+    }
+
+    private IMount getRomMount()
+    {
+        if( romMount != null ) return romMount;
+
+        synchronized( romMountLock )
+        {
+            if( romMount != null ) return romMount;
+            return romMount = computer.getComputerEnvironment().createResourceMount( "computercraft", "lua/rom" );
+        }
+    }
+
+    private FileSystem createFileSystem()
+    {
+        if( rootMount == null )
+        {
+            rootMount = computer.getComputerEnvironment().createSaveDirMount(
+                "computer/" + computer.assignID(),
+                computer.getComputerEnvironment().getComputerSpaceLimit()
+            );
+        }
+
+        FileSystem filesystem = null;
+        try
+        {
+            filesystem = new FileSystem( "hdd", rootMount );
+
+            IMount romMount = getRomMount();
+            if( romMount == null )
+            {
+                displayFailure( "Cannot mount rom" );
+                return null;
+            }
+
+            filesystem.mount( "rom", "rom", romMount );
+            return filesystem;
+        }
+        catch( FileSystemException e )
+        {
+            if( filesystem != null ) filesystem.close();
+            ComputerCraft.log.error( "Cannot mount computer filesystem", e );
+
+            displayFailure( "Cannot mount computer system" );
+            return null;
+        }
+    }
+
+    private ILuaMachine createLuaMachine()
+    {
+        // Load the bios resource
+        InputStream biosStream = null;
+        try
+        {
+            biosStream = computer.getComputerEnvironment().createResourceFile( "computercraft", "lua/bios.lua" );
+        }
+        catch( Exception ignored )
+        {
+        }
+
+        if( biosStream == null )
+        {
+            displayFailure( "Error loading bios.lua" );
+            return null;
+        }
+
+        // Create the lua machine
+        ILuaMachine machine = new CobaltLuaMachine( computer, timeout );
+
+        // Add the APIs
+        for( ILuaAPI api : apis ) machine.addAPI( api );
+
+        // Start the machine running the bios resource
+        machine.loadBios( biosStream );
+        IoUtil.closeQuietly( biosStream );
+
+        if( machine.isFinished() )
+        {
+            machine.close();
+            displayFailure( "Error starting bios.lua" );
+            return null;
+        }
+
+        return machine;
+    }
+
+    private void turnOn() throws InterruptedException
+    {
+        isOnLock.lockInterruptibly();
+        try
+        {
+            // Reset the terminal and event queue
+            computer.getTerminal().reset();
+            synchronized( queueLock )
+            {
+                eventQueue.clear();
+            }
+
+            // Init filesystem
+            if( (this.fileSystem = createFileSystem()) == null )
+            {
+                shutdown();
+                return;
+            }
+
+            // Init APIs
+            for( ILuaAPI api : apis ) api.startup();
+
+            // Init lua
+            if( (this.machine = createLuaMachine()) == null )
+            {
+                shutdown();
+                return;
+            }
+
+            // Initialisation has finished, so let's mark ourselves as on.
+            isOn = true;
+            computer.markChanged();
+        }
+        finally
+        {
+            isOnLock.unlock();
+        }
+
+        // Now actually start the computer, now that everything is set up.
+        machine.handleEvent( null, null );
+    }
+
+    private void shutdown() throws InterruptedException
+    {
+        isOnLock.lockInterruptibly();
+        try
+        {
+            isOn = false;
+            synchronized( queueLock )
+            {
+                eventQueue.clear();
+            }
+
+            // Shutdown Lua machine
+            if( machine != null )
+            {
+                machine.close();
+                machine = null;
+            }
+
+            // Shutdown our APIs
+            for( ILuaAPI api : apis ) api.shutdown();
+
+            // Unload filesystem
+            if( fileSystem != null )
+            {
+                fileSystem.close();
+                fileSystem = null;
+            }
+
+            computer.getEnvironment().resetOutput();
+            computer.markChanged();
+        }
+        finally
+        {
+            isOnLock.unlock();
+        }
+    }
+
+    /**
+     * The main worker function, called by {@link ComputerThread}.
+     *
+     * This either executes a {@link StateCommand} or attempts to run an event
+     *
+     * @throws InterruptedException If various locks could not be acquired.
+     * @see #command
+     * @see #eventQueue
+     */
+    void work() throws InterruptedException
+    {
+        if( isExecuting.getAndSet( true ) )
+        {
+            throw new IllegalStateException( "Multiple threads running on computer the same time" );
+        }
+
+        try
+        {
+            StateCommand command;
+            Event event = null;
+            synchronized( queueLock )
+            {
+                command = this.command;
+                this.command = null;
+
+                // If we've no command, pull something from the event queue instead.
+                if( command == null )
+                {
+                    if( !isOn )
+                    {
+                        // We're not on and had no command, but we had work queued. This should never happen, so clear
+                        // the event queue just in case.
+                        eventQueue.clear();
+                        return;
+                    }
+
+                    event = eventQueue.poll();
+                }
+            }
+
+            if( command != null )
+            {
+                switch( command )
+                {
+                    case TURN_ON:
+                        if( isOn ) return;
+                        turnOn();
+                        break;
+
+                    case SHUTDOWN:
+
+                        if( !isOn ) return;
+                        computer.getTerminal().reset();
+                        shutdown();
+                        break;
+
+                    case REBOOT:
+                        if( !isOn ) return;
+                        computer.getTerminal().reset();
+                        shutdown();
+
+                        computer.turnOn();
+                        break;
+                }
+            }
+            else
+            {
+                machine.handleEvent( event.name, event.args );
+                if( machine.isFinished() )
+                {
+                    displayFailure( "Error resuming bios.lua" );
+                    shutdown();
+                }
+            }
+        }
+        finally
+        {
+            isExecuting.set( false );
+        }
+    }
+
+    private void displayFailure( String message )
+    {
+        Terminal terminal = computer.getTerminal();
+        terminal.reset();
+        terminal.write( message );
+        terminal.setCursorPos( 0, 1 );
+        terminal.write( "ComputerCraft may be installed incorrectly" );
+    }
+
+    private enum StateCommand
+    {
+        TURN_ON,
+        SHUTDOWN,
+        REBOOT,
+    }
+
+    private static class Event
+    {
+        final String name;
+        final Object[] args;
+
+        private Event( String name, Object[] args )
+        {
+            this.name = name;
+            this.args = args;
+        }
+    }
+}

--- a/src/main/java/dan200/computercraft/core/computer/ITask.java
+++ b/src/main/java/dan200/computercraft/core/computer/ITask.java
@@ -6,8 +6,11 @@
 
 package dan200.computercraft.core.computer;
 
+import javax.annotation.Nonnull;
+
 public interface ITask
 {
+    @Nonnull
     Computer getOwner();
 
     void execute();

--- a/src/main/java/dan200/computercraft/core/computer/TimeoutFlags.java
+++ b/src/main/java/dan200/computercraft/core/computer/TimeoutFlags.java
@@ -45,8 +45,6 @@ public final class TimeoutFlags
      */
     void hardAbort()
     {
-        // TODO: Queue a shutdown or something - if we don't halt when hard aborting, we'll never actually shut
-        //  the thing down.
         softAbort = hardAbort = true;
     }
 

--- a/src/main/java/dan200/computercraft/core/computer/TimeoutFlags.java
+++ b/src/main/java/dan200/computercraft/core/computer/TimeoutFlags.java
@@ -1,0 +1,60 @@
+/*
+ * This file is part of ComputerCraft - http://www.computercraft.info
+ * Copyright Daniel Ratcliffe, 2011-2019. Do not distribute without permission.
+ * Send enquiries to dratcliffe@gmail.com
+ */
+
+package dan200.computercraft.core.computer;
+
+/**
+ * Represents what flags have currently been set on the computer timeout
+ *
+ * @see ComputerThread
+ * @see dan200.computercraft.core.lua.ILuaMachine
+ */
+public final class TimeoutFlags
+{
+    public static final String ABORT_MESSAGE = "Too long without yielding";
+
+    private volatile boolean softAbort;
+    private volatile boolean hardAbort;
+
+    /**
+     * If the machine should be passively aborted.
+     */
+    public boolean isSoftAborted()
+    {
+        return softAbort;
+    }
+
+    /**
+     * If the machine should be forcibly aborted.
+     */
+    public boolean isHardAborted()
+    {
+        return hardAbort;
+    }
+
+    void softAbort()
+    {
+        softAbort = true;
+    }
+
+    /**
+     * If the machine should be forcibly aborted.
+     */
+    void hardAbort()
+    {
+        // TODO: Queue a shutdown or something - if we don't halt when hard aborting, we'll never actually shut
+        //  the thing down.
+        softAbort = hardAbort = true;
+    }
+
+    /**
+     * Reset all other flags
+     */
+    void resetAbort()
+    {
+        softAbort = hardAbort = false;
+    }
+}

--- a/src/main/java/dan200/computercraft/core/filesystem/FileSystem.java
+++ b/src/main/java/dan200/computercraft/core/filesystem/FileSystem.java
@@ -330,7 +330,7 @@ public class FileSystem
         mountWritable( rootLabel, "", rootMount );
     }
 
-    public void unload()
+    public void close()
     {
         // Close all dangling open files
         synchronized( m_openFiles )

--- a/src/main/java/dan200/computercraft/core/lua/ILuaMachine.java
+++ b/src/main/java/dan200/computercraft/core/lua/ILuaMachine.java
@@ -9,7 +9,6 @@ package dan200.computercraft.core.lua;
 import dan200.computercraft.api.lua.ILuaAPI;
 
 import java.io.InputStream;
-import java.io.OutputStream;
 
 public interface ILuaMachine
 {
@@ -19,15 +18,7 @@ public interface ILuaMachine
 
     void handleEvent( String eventName, Object[] arguments );
 
-    void softAbort( String abortMessage );
-
-    void hardAbort( String abortMessage );
-
-    boolean saveState( OutputStream output );
-
-    boolean restoreState( InputStream input );
-
     boolean isFinished();
 
-    void unload();
+    void close();
 }

--- a/src/main/java/dan200/computercraft/shared/computer/core/ServerComputer.java
+++ b/src/main/java/dan200/computercraft/shared/computer/core/ServerComputer.java
@@ -105,7 +105,7 @@ public class ServerComputer extends ServerTerminal implements IComputer, IComput
     public void update()
     {
         super.update();
-        m_computer.advance();
+        m_computer.tick();
 
         m_changedLastFrame = m_computer.pollAndResetChanged() || m_changed;
         m_changed = false;

--- a/src/main/java/dan200/computercraft/shared/computer/core/ServerComputer.java
+++ b/src/main/java/dan200/computercraft/shared/computer/core/ServerComputer.java
@@ -204,16 +204,6 @@ public class ServerComputer extends ServerTerminal implements IComputer, IComput
         NetworkHandler.sendToAllPlayers( new ComputerDeletedClientMessage( getInstanceID() ) );
     }
 
-    public IWritableMount getRootMount()
-    {
-        return m_computer.getRootMount();
-    }
-
-    public int assignID()
-    {
-        return m_computer.assignID();
-    }
-
     public void setID( int id )
     {
         m_computer.setID( id );
@@ -303,7 +293,7 @@ public class ServerComputer extends ServerTerminal implements IComputer, IComput
 
     public void addAPI( ILuaAPI api )
     {
-        m_computer.addAPI( api );
+        m_computer.addApi( api );
     }
 
     @Deprecated

--- a/src/test/java/dan200/computercraft/core/computer/BasicEnvironment.java
+++ b/src/test/java/dan200/computercraft/core/computer/BasicEnvironment.java
@@ -1,0 +1,155 @@
+/*
+ * This file is part of ComputerCraft - http://www.computercraft.info
+ * Copyright Daniel Ratcliffe, 2011-2019. Do not distribute without permission.
+ * Send enquiries to dratcliffe@gmail.com
+ */
+
+package dan200.computercraft.core.computer;
+
+import dan200.computercraft.ComputerCraft;
+import dan200.computercraft.api.filesystem.IMount;
+import dan200.computercraft.api.filesystem.IWritableMount;
+import dan200.computercraft.core.filesystem.FileMount;
+import dan200.computercraft.core.filesystem.JarMount;
+import dan200.computercraft.core.filesystem.MemoryMount;
+import net.minecraftforge.fml.common.Loader;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+/**
+ * A very basic environment
+ */
+public class BasicEnvironment implements IComputerEnvironment
+{
+    private final IWritableMount mount;
+
+    public BasicEnvironment()
+    {
+        this( new MemoryMount() );
+    }
+
+    public BasicEnvironment( IWritableMount mount )
+    {
+        this.mount = mount;
+    }
+
+    @Override
+    public int assignNewID()
+    {
+        return 0;
+    }
+
+    @Override
+    public IWritableMount createSaveDirMount( String path, long space )
+    {
+        return mount;
+    }
+
+    @Override
+    public int getDay()
+    {
+        return 0;
+    }
+
+    @Override
+    public double getTimeOfDay()
+    {
+        return 0;
+    }
+
+    @Override
+    public boolean isColour()
+    {
+        return true;
+    }
+
+    @Override
+    public long getComputerSpaceLimit()
+    {
+        return ComputerCraft.computerSpaceLimit;
+    }
+
+    @Override
+    public String getHostString()
+    {
+        return "ComputerCraft ${version} (Minecraft " + Loader.MC_VERSION + ")";
+    }
+
+    @Override
+    @Deprecated
+    public IMount createResourceMount( String domain, String subPath )
+    {
+        File file = getContainingFile();
+
+        String path = "assets/" + domain + "/" + subPath;
+
+        if( file.isFile() )
+        {
+            try
+            {
+                return new JarMount( file, path );
+            }
+            catch( IOException e )
+            {
+                throw new UncheckedIOException( e );
+            }
+        }
+        else
+        {
+            File wholeFile = new File( file, path );
+
+            // If we don't exist, walk up the tree looking for resource folders
+            File baseFile = file;
+            while( baseFile != null && !wholeFile.exists() )
+            {
+                baseFile = baseFile.getParentFile();
+                wholeFile = new File( baseFile, "resources/main/" + path );
+            }
+
+            if( !wholeFile.exists() ) throw new IllegalStateException( "Cannot find ROM mount at " + file );
+
+            return new FileMount( wholeFile, 0 );
+        }
+    }
+
+    @Override
+    public InputStream createResourceFile( String domain, String subPath )
+    {
+        return ComputerCraft.class.getClassLoader().getResourceAsStream( "assets/" + domain + "/" + subPath );
+    }
+
+    private static File getContainingFile()
+    {
+        String path = ComputerCraft.class.getProtectionDomain().getCodeSource().getLocation().getPath();
+        int bangIndex = path.indexOf( "!" );
+
+        // Plain old file, so step up from dan200.computercraft.
+        if( bangIndex < 0 ) return new File( path );
+
+        path = path.substring( 0, bangIndex );
+        URL url;
+        try
+        {
+            url = new URL( path );
+        }
+        catch( MalformedURLException e )
+        {
+            throw new IllegalStateException( e );
+        }
+
+        try
+        {
+            return new File( url.toURI() );
+        }
+        catch( URISyntaxException e )
+        {
+            return new File( url.getPath() );
+        }
+    }
+}

--- a/src/test/java/dan200/computercraft/core/computer/ComputerBootstrap.java
+++ b/src/test/java/dan200/computercraft/core/computer/ComputerBootstrap.java
@@ -1,0 +1,154 @@
+/*
+ * This file is part of ComputerCraft - http://www.computercraft.info
+ * Copyright Daniel Ratcliffe, 2011-2019. Do not distribute without permission.
+ * Send enquiries to dratcliffe@gmail.com
+ */
+
+package dan200.computercraft.core.computer;
+
+import dan200.computercraft.ComputerCraft;
+import dan200.computercraft.api.lua.ILuaAPI;
+import dan200.computercraft.api.lua.ILuaContext;
+import dan200.computercraft.api.lua.LuaException;
+import dan200.computercraft.core.apis.ArgumentHelper;
+import dan200.computercraft.core.filesystem.MemoryMount;
+import dan200.computercraft.core.terminal.Terminal;
+import org.apache.logging.log4j.LogManager;
+import org.junit.Assert;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Helper class to run a program on a computer.
+ */
+public class ComputerBootstrap
+{
+    private static final int TPS = 20;
+    private static final int MAX_TIME = 10;
+
+    public static void run( String program )
+    {
+        run( program, -1 );
+    }
+
+    public static void run( String program, int shutdownAfter )
+    {
+        ComputerCraft.logPeripheralErrors = true;
+        ComputerCraft.log = LogManager.getLogger( ComputerCraft.MOD_ID );
+
+        MemoryMount mount = new MemoryMount()
+            .addFile( "test.lua", program )
+            .addFile( "startup", "assertion.assert(pcall(loadfile('test.lua', _ENV))) os.shutdown()" );
+
+        Terminal term = new Terminal( ComputerCraft.terminalWidth_computer, ComputerCraft.terminalHeight_computer );
+        final Computer computer = new Computer( new BasicEnvironment( mount ), term, 0 );
+
+        AssertApi api = new AssertApi();
+        computer.addAPI( api );
+
+        try
+        {
+            computer.turnOn();
+            boolean everOn = false;
+
+            for( int tick = 0; tick < TPS * MAX_TIME; tick++ )
+            {
+                long start = System.currentTimeMillis();
+
+                computer.tick();
+                MainThread.executePendingTasks();
+
+                if( api.message != null )
+                {
+                    ComputerCraft.log.debug( "Shutting down due to error" );
+                    computer.shutdown();
+                    Assert.fail( api.message );
+                    return;
+                }
+
+                long remaining = (1000 / TPS) - (System.currentTimeMillis() - start);
+                if( remaining > 0 ) Thread.sleep( remaining );
+
+                // Break if the computer was once on, and is now off.
+                everOn |= computer.isOn();
+                if( (everOn || tick > TPS) && !computer.isOn() ) break;
+
+                // Shutdown the computer after a period of time
+                if( shutdownAfter > 0 && tick != 0 && tick % shutdownAfter == 0 )
+                {
+                    ComputerCraft.log.info( "Shutting down: shutdown after {}", shutdownAfter );
+                    computer.shutdown();
+                }
+            }
+
+            if( computer.isOn() || !api.didAssert )
+            {
+                StringBuilder builder = new StringBuilder().append( "Did not correctly" );
+                if( !api.didAssert ) builder.append( " assert" );
+                if( computer.isOn() ) builder.append( " shutdown" );
+                builder.append( "\n" );
+
+                for( int line = 0; line < 19; line++ )
+                {
+                    builder.append( String.format( "%2d | %" + term.getWidth() + "s |\n", line + 1, term.getLine( line ) ) );
+                }
+
+                computer.shutdown();
+                Assert.fail( builder.toString() );
+            }
+        }
+        catch( InterruptedException ignored )
+        {
+            Thread.currentThread().interrupt();
+        }
+        finally
+        {
+            ComputerThread.stop();
+        }
+    }
+
+    private static class AssertApi implements ILuaAPI
+    {
+        boolean didAssert;
+        String message;
+
+        @Override
+        public String[] getNames()
+        {
+            return new String[] { "assertion" };
+        }
+
+        @Nonnull
+        @Override
+        public String[] getMethodNames()
+        {
+            return new String[] { "assert" };
+        }
+
+        @Nullable
+        @Override
+        public Object[] callMethod( @Nonnull ILuaContext context, int method, @Nonnull Object[] arguments ) throws LuaException, InterruptedException
+        {
+            switch( method )
+            {
+                case 0: // assert
+                {
+                    didAssert = true;
+
+                    Object arg = arguments.length >= 1 ? arguments[0] : null;
+                    if( arg == null || arg == Boolean.FALSE )
+                    {
+                        message = ArgumentHelper.optString( arguments, 1, "Assertion failed" );
+                        throw new LuaException( message );
+                    }
+
+                    return arguments;
+                }
+
+                default:
+                    return null;
+            }
+        }
+    }
+}

--- a/src/test/java/dan200/computercraft/core/computer/ComputerBootstrap.java
+++ b/src/test/java/dan200/computercraft/core/computer/ComputerBootstrap.java
@@ -45,7 +45,7 @@ public class ComputerBootstrap
         final Computer computer = new Computer( new BasicEnvironment( mount ), term, 0 );
 
         AssertApi api = new AssertApi();
-        computer.addAPI( api );
+        computer.addApi( api );
 
         try
         {

--- a/src/test/java/dan200/computercraft/core/computer/ComputerTest.java
+++ b/src/test/java/dan200/computercraft/core/computer/ComputerTest.java
@@ -1,0 +1,29 @@
+/*
+ * This file is part of ComputerCraft - http://www.computercraft.info
+ * Copyright Daniel Ratcliffe, 2011-2019. Do not distribute without permission.
+ * Send enquiries to dratcliffe@gmail.com
+ */
+
+package dan200.computercraft.core.computer;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ComputerTest
+{
+    @Test( timeout = 20_000 )
+    public void testTimeout()
+    {
+        try
+        {
+            ComputerBootstrap.run( "print('Hello') while true do end" );
+        }
+        catch( AssertionError e )
+        {
+            if( e.getMessage().equals( "test.lua:1: Too long without yielding" ) ) return;
+            throw e;
+        }
+
+        Assert.fail( "Expected computer to timeout" );
+    }
+}

--- a/src/test/java/dan200/computercraft/core/filesystem/MemoryMount.java
+++ b/src/test/java/dan200/computercraft/core/filesystem/MemoryMount.java
@@ -1,0 +1,143 @@
+/*
+ * This file is part of ComputerCraft - http://www.computercraft.info
+ * Copyright Daniel Ratcliffe, 2011-2019. Do not distribute without permission.
+ * Send enquiries to dratcliffe@gmail.com
+ */
+
+package dan200.computercraft.core.filesystem;
+
+import dan200.computercraft.api.filesystem.IWritableMount;
+
+import javax.annotation.Nonnull;
+import java.io.*;
+import java.util.*;
+
+/**
+ * Mounts in memory
+ */
+public class MemoryMount implements IWritableMount
+{
+    private final Map<String, byte[]> files = new HashMap<>();
+    private final Set<String> directories = new HashSet<>();
+
+    public MemoryMount()
+    {
+        directories.add( "" );
+    }
+
+
+    @Override
+    public void makeDirectory( @Nonnull String path )
+    {
+        File file = new File( path );
+        while( file != null )
+        {
+            directories.add( file.getPath() );
+            file = file.getParentFile();
+        }
+    }
+
+    @Override
+    public void delete( @Nonnull String path )
+    {
+        if( files.containsKey( path ) )
+        {
+            files.remove( path );
+        }
+        else
+        {
+            directories.remove( path );
+            for( String file : files.keySet().toArray( new String[0] ) )
+            {
+                if( file.startsWith( path ) )
+                {
+                    files.remove( file );
+                }
+            }
+
+            File parent = new File( path ).getParentFile();
+            if( parent != null ) delete( parent.getPath() );
+        }
+    }
+
+    @Override
+    @Deprecated
+    public OutputStream openForWrite( @Nonnull final String path )
+    {
+        return new ByteArrayOutputStream()
+        {
+            @Override
+            public void close() throws IOException
+            {
+                super.close();
+                files.put( path, toByteArray() );
+            }
+        };
+    }
+
+    @Override
+    @Deprecated
+    public OutputStream openForAppend( @Nonnull final String path ) throws IOException
+    {
+        ByteArrayOutputStream stream = new ByteArrayOutputStream()
+        {
+            @Override
+            public void close() throws IOException
+            {
+                super.close();
+                files.put( path, toByteArray() );
+            }
+        };
+
+        byte[] current = files.get( path );
+        if( current != null ) stream.write( current );
+
+        return stream;
+    }
+
+    @Override
+    public long getRemainingSpace()
+    {
+        return 1000000L;
+    }
+
+    @Override
+    public boolean exists( @Nonnull String path )
+    {
+        return files.containsKey( path ) || directories.contains( path );
+    }
+
+    @Override
+    public boolean isDirectory( @Nonnull String path )
+    {
+        return directories.contains( path );
+    }
+
+    @Override
+    public void list( @Nonnull String path, @Nonnull List<String> files )
+    {
+        for( String file : this.files.keySet() )
+        {
+            if( file.startsWith( path ) ) files.add( file );
+        }
+    }
+
+    @Override
+    public long getSize( String path )
+    {
+        throw new RuntimeException( "Not implemented" );
+    }
+
+    @Override
+    @Deprecated
+    public InputStream openForRead( String path )
+    {
+        return new ByteArrayInputStream( files.get( path ) );
+    }
+
+    public MemoryMount addFile( String file, String contents )
+    {
+        files.put( file, contents.getBytes() );
+        return this;
+    }
+}


### PR DESCRIPTION
Extracts the non-preemption related code from #119.

### Highlights
 - Timeouts are implemented by a POD class, which means you can set a timeout before the machine has been booted up, and it'll actually apply.
 - Computer execution code (turn on/off, event handling) is now done within `ComputerExecutor`.
 - Task queue is handled by the executor, rather than having a map of computers to queues.

### Still to do
 - Possibly remove the whole task queue, and just have `.work` either run the command or pull an event.
 - Document and test everything. I'd like this to be both more solid, and more understandable when people approach it in the future.
 - Shutdown computers if they hard abort.