### PR TITLE
Add default path for programs and help

### DIFF
--- a/src/main/resources/assets/computercraft/lua/rom/startup.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/startup.lua
@@ -1,6 +1,6 @@
 
 -- Setup paths
-local sPath = ".:/rom/programs"
+local sPath = ".:/rom/programs:/programs"
 if term.isColor() then
     sPath = sPath..":/rom/programs/advanced"
 end
@@ -22,7 +22,7 @@ if http then
     sPath = sPath..":/rom/programs/http"
 end
 shell.setPath( sPath )
-help.setPath( "/rom/help" )
+help.setPath( "/rom/help:/help" )
 
 -- Setup aliases
 shell.setAlias( "ls", "list" )


### PR DESCRIPTION
I just added default paths. Programmers can place their programs and help files inside the path and it can be run from everywhere. I know, you can create a file in /startup to set the Path, but I thinks this is a little bit overkill. Default paths are the better way in my opinion.