### PR TITLE
Thread safe inventory interactions

### DIFF
--- a/src/main/java/dan200/computercraft/api/turtle/ITurtleAccess.java
+++ b/src/main/java/dan200/computercraft/api/turtle/ITurtleAccess.java
@@ -145,7 +145,9 @@ public interface ITurtleAccess
     GameProfile getOwningPlayer();
 
     /**
-     * Get the inventory of this turtle
+     * Get the inventory of this turtle.
+     *
+     * Note: this inventory should only be accessed and modified on the server thread.
      *
      * @return This turtle's inventory
      * @see #getItemHandler()
@@ -155,6 +157,8 @@ public interface ITurtleAccess
 
     /**
      * Get the inventory of this turtle as an {@link IItemHandlerModifiable}.
+     *
+     * Note: this inventory should only be accessed and modified on the server thread.
      *
      * @return This turtle's inventory
      * @see #getInventory()

--- a/src/main/java/dan200/computercraft/shared/peripheral/diskdrive/DiskDrivePeripheral.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/diskdrive/DiskDrivePeripheral.java
@@ -11,6 +11,7 @@ import dan200.computercraft.api.lua.LuaException;
 import dan200.computercraft.api.media.IMedia;
 import dan200.computercraft.api.peripheral.IComputerAccess;
 import dan200.computercraft.api.peripheral.IPeripheral;
+import dan200.computercraft.shared.MediaProviders;
 import dan200.computercraft.shared.media.items.ItemDiskLegacy;
 import dan200.computercraft.shared.util.StringUtil;
 import net.minecraft.item.Item;
@@ -20,11 +21,11 @@ import javax.annotation.Nonnull;
 
 import static dan200.computercraft.core.apis.ArgumentHelper.optString;
 
-public class DiskDrivePeripheral implements IPeripheral
+class DiskDrivePeripheral implements IPeripheral
 {
     private final TileDiskDrive m_diskDrive;
 
-    public DiskDrivePeripheral( TileDiskDrive diskDrive )
+    DiskDrivePeripheral( TileDiskDrive diskDrive )
     {
         m_diskDrive = diskDrive;
     }
@@ -56,7 +57,7 @@ public class DiskDrivePeripheral implements IPeripheral
     }
 
     @Override
-    public Object[] callMethod( @Nonnull IComputerAccess computer, @Nonnull ILuaContext context, int method, @Nonnull Object[] arguments ) throws LuaException
+    public Object[] callMethod( @Nonnull IComputerAccess computer, @Nonnull ILuaContext context, int method, @Nonnull Object[] arguments ) throws LuaException, InterruptedException
     {
         switch( method )
         {
@@ -64,21 +65,26 @@ public class DiskDrivePeripheral implements IPeripheral
                 return new Object[] { !m_diskDrive.getDiskStack().isEmpty() };
             case 1: // getDiskLabel
             {
-                IMedia media = m_diskDrive.getDiskMedia();
-                return media == null ? null : new Object[] { media.getLabel( m_diskDrive.getDiskStack() ) };
+                ItemStack stack = m_diskDrive.getDiskStack();
+                IMedia media = MediaProviders.get( stack );
+                return media == null ? null : new Object[] { media.getLabel( stack ) };
             }
             case 2: // setDiskLabel
             {
                 String label = optString( arguments, 0, null );
 
-                IMedia media = m_diskDrive.getDiskMedia();
-                if( media == null ) return null;
+                return context.executeMainThreadTask( () -> {
+                    ItemStack stack = m_diskDrive.getDiskStack();
+                    IMedia media = MediaProviders.get( stack );
+                    if( media == null ) return null;
 
-                ItemStack disk = m_diskDrive.getDiskStack();
-                label = StringUtil.normaliseLabel( label );
-                if( !media.setLabel( disk, label ) ) throw new LuaException( "Disk label cannot be changed" );
-                m_diskDrive.setDiskStack( disk );
-                return null;
+                    if( !media.setLabel( stack, StringUtil.normaliseLabel( label ) ) )
+                    {
+                        throw new LuaException( "Disk label cannot be changed" );
+                    }
+                    m_diskDrive.setDiskStack( stack );
+                    return null;
+                } );
             }
             case 3: // hasData
                 return new Object[] { m_diskDrive.getDiskMountPath( computer ) != null };
@@ -87,14 +93,16 @@ public class DiskDrivePeripheral implements IPeripheral
             case 5:
             {
                 // hasAudio
-                IMedia media = m_diskDrive.getDiskMedia();
-                return new Object[] { media != null && media.getAudio( m_diskDrive.getDiskStack() ) != null };
+                ItemStack stack = m_diskDrive.getDiskStack();
+                IMedia media = MediaProviders.get( stack );
+                return new Object[] { media != null && media.getAudio( stack ) != null };
             }
             case 6:
             {
                 // getAudioTitle
-                IMedia media = m_diskDrive.getDiskMedia();
-                return new Object[] { media != null ? media.getAudioTitle( m_diskDrive.getDiskStack() ) : false };
+                ItemStack stack = m_diskDrive.getDiskStack();
+                IMedia media = MediaProviders.get( stack );
+                return new Object[] { media != null ? media.getAudioTitle( stack ) : false };
             }
             case 7: // playAudio
                 m_diskDrive.playDiskAudio();
@@ -131,8 +139,7 @@ public class DiskDrivePeripheral implements IPeripheral
     @Override
     public boolean equals( IPeripheral other )
     {
-        if( this == other ) return true;
-        return other instanceof DiskDrivePeripheral && ((DiskDrivePeripheral) other).m_diskDrive == m_diskDrive;
+        return this == other || other instanceof DiskDrivePeripheral && ((DiskDrivePeripheral) other).m_diskDrive == m_diskDrive;
     }
 
     @Nonnull

--- a/src/main/java/dan200/computercraft/shared/peripheral/diskdrive/TileDiskDrive.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/diskdrive/TileDiskDrive.java
@@ -318,35 +318,31 @@ public class TileDiskDrive extends TilePeripheralBase implements DefaultInventor
     }
 
     @Nonnull
-    public ItemStack getDiskStack()
+    ItemStack getDiskStack()
     {
         return getStackInSlot( 0 );
     }
 
-    public void setDiskStack( @Nonnull ItemStack stack )
+    void setDiskStack( @Nonnull ItemStack stack )
     {
         setInventorySlotContents( 0, stack );
     }
 
-    public IMedia getDiskMedia()
+    private IMedia getDiskMedia()
     {
         return MediaProviders.get( getDiskStack() );
     }
 
-    public String getDiskMountPath( IComputerAccess computer )
+    String getDiskMountPath( IComputerAccess computer )
     {
         synchronized( this )
         {
-            if( m_computers.containsKey( computer ) )
-            {
-                MountInfo info = m_computers.get( computer );
-                return info.mountPath;
-            }
+            MountInfo info = m_computers.get( computer );
+            return info != null ? info.mountPath : null;
         }
-        return null;
     }
 
-    public void mount( IComputerAccess computer )
+    void mount( IComputerAccess computer )
     {
         synchronized( this )
         {
@@ -355,7 +351,7 @@ public class TileDiskDrive extends TilePeripheralBase implements DefaultInventor
         }
     }
 
-    public void unmount( IComputerAccess computer )
+    void unmount( IComputerAccess computer )
     {
         synchronized( this )
         {
@@ -364,7 +360,7 @@ public class TileDiskDrive extends TilePeripheralBase implements DefaultInventor
         }
     }
 
-    public void playDiskAudio()
+    void playDiskAudio()
     {
         synchronized( this )
         {
@@ -377,7 +373,7 @@ public class TileDiskDrive extends TilePeripheralBase implements DefaultInventor
         }
     }
 
-    public void stopDiskAudio()
+    void stopDiskAudio()
     {
         synchronized( this )
         {
@@ -386,7 +382,7 @@ public class TileDiskDrive extends TilePeripheralBase implements DefaultInventor
         }
     }
 
-    public void ejectDisk()
+    void ejectDisk()
     {
         synchronized( this )
         {

--- a/src/main/java/dan200/computercraft/shared/peripheral/printer/PrinterPeripheral.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/printer/PrinterPeripheral.java
@@ -51,8 +51,13 @@ public class PrinterPeripheral implements IPeripheral
     }
 
     @Override
-    public Object[] callMethod( @Nonnull IComputerAccess computer, @Nonnull ILuaContext context, int method, @Nonnull Object[] args ) throws LuaException
+    public Object[] callMethod( @Nonnull IComputerAccess computer, @Nonnull ILuaContext context, int method, @Nonnull Object[] args ) throws LuaException, InterruptedException
     {
+        // FIXME: There's a theoretical race condition here between getCurrentPage and then using the page. Ideally
+        //  we'd lock on the page, consume it, and unlock.
+
+        // FIXME: None of our page modification functions actually mark the tile as dirty, so the page may not be
+        //  persisted correctly.
         switch( method )
         {
             case 0: // write
@@ -89,10 +94,13 @@ public class PrinterPeripheral implements IPeripheral
                 return new Object[] { width, height };
             }
             case 4: // newPage
-                return new Object[] { m_printer.startNewPage() };
+                return context.executeMainThreadTask( () -> new Object[] { m_printer.startNewPage() } );
             case 5: // endPage
                 getCurrentPage();
-                return new Object[] { m_printer.endCurrentPage() };
+                return context.executeMainThreadTask( () -> {
+                    getCurrentPage();
+                    return new Object[] { m_printer.endCurrentPage() };
+                } );
             case 6: // getInkLevel
                 return new Object[] { m_printer.getInkLevel() };
             case 7:
@@ -123,13 +131,11 @@ public class PrinterPeripheral implements IPeripheral
         return m_printer;
     }
 
+    @Nonnull
     private Terminal getCurrentPage() throws LuaException
     {
         Terminal currentPage = m_printer.getCurrentPage();
-        if( currentPage == null )
-        {
-            throw new LuaException( "Page not started" );
-        }
+        if( currentPage == null ) throw new LuaException( "Page not started" );
         return currentPage;
     }
 }

--- a/src/main/java/dan200/computercraft/shared/turtle/FurnaceRefuelHandler.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/FurnaceRefuelHandler.java
@@ -33,7 +33,7 @@ public final class FurnaceRefuelHandler implements TurtleRefuelEvent.Handler
         int fuelSpaceLeft = turtle.getFuelLimit() - turtle.getFuelLevel();
         int fuelPerItem = getFuelPerItem( turtle.getItemHandler().getStackInSlot( slot ) );
         int fuelItemLimit = (int) Math.ceil( fuelSpaceLeft / (double) fuelPerItem );
-        if ( limit > fuelItemLimit ) limit = fuelItemLimit;
+        if( limit > fuelItemLimit ) limit = fuelItemLimit;
 
         ItemStack stack = turtle.getItemHandler().extractItem( slot, limit, false );
         int fuelToGive = fuelPerItem * stack.getCount();

--- a/src/main/java/dan200/computercraft/shared/turtle/apis/TurtleAPI.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/apis/TurtleAPI.java
@@ -334,9 +334,11 @@ public class TurtleAPI implements ILuaAPI
                 return tryCommand( context, new TurtleInspectCommand( InteractDirection.Up ) );
             case 40: // inspectDown
                 return tryCommand( context, new TurtleInspectCommand( InteractDirection.Down ) );
-            case 41:
+            case 41: // getItemDetail
             {
-                // getItemDetail
+                // FIXME: There's a race condition here if the stack is being modified (mutating NBT, etc...)
+                //  on another thread. The obvious solution is to move this into a command, but some programs rely
+                //  on this having a 0-tick delay.
                 int slot = parseOptionalSlotNumber( args, 0, m_turtle.getSelectedSlot() );
                 ItemStack stack = m_turtle.getInventory().getStackInSlot( slot );
                 if( stack.isEmpty() ) return new Object[] { null };

--- a/src/main/resources/assets/computercraft/lua/rom/programs/edit.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/programs/edit.lua
@@ -329,7 +329,7 @@ local tMenuFuncs = {
                 printer.setPageTitle( sName.." (page "..nPage..")" )
             end
 
-            while not printer.newPage()    do
+            while not printer.newPage() do
                 if printer.getInkLevel() < 1 then
                     sStatus = "Printer out of ink, please refill"
                 elseif printer.getPaperLevel() < 1 then
@@ -342,7 +342,6 @@ local tMenuFuncs = {
                 redrawMenu()
                 term.redirect( printerTerminal )
 
-                local timer = os.startTimer(0.5)
                 sleep(0.5)
             end
 


### PR DESCRIPTION
This is an attempt to inventory actions from peripherals (and other APIs) thread-safe.

 - [x] Disk drives
 - [x] Printers
 - [x] Turtles

This largely involves shifting some things to execute on the main thread, though I'm also taking the opportunity to clean up some of the `TileEntity` code.