### PR TITLE
Fixed turtle cable duping

### DIFF
--- a/src/main/java/dan200/computercraft/shared/turtle/upgrades/TurtleTool.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/upgrades/TurtleTool.java
@@ -246,7 +246,7 @@ public class TurtleTool extends AbstractTurtleUpgrade
         boolean canHarvest = state.getBlock().canHarvestBlock( world, blockPosition, turtlePlayer );
         boolean canBreak = state.getBlock().removedByPlayer( state, world, blockPosition, turtlePlayer, canHarvest );
         if( canBreak ) state.getBlock().onPlayerDestroy( world, blockPosition, state );
-        if( canHarvest )
+        if( canHarvest && canBreak )
         {
             state.getBlock().harvestBlock( world, turtlePlayer, blockPosition, state, tile, turtlePlayer.getHeldItemMainhand() );
         }


### PR DESCRIPTION
#273 
When harvesting a block, Block.removedByPlayer() is supposed to be able to cancel Block.harvestBlock() by returning false. Although BlockCable relies on that behavior to act like a multiblock, turtles don't follow it.

http://greyminecraftcoder.blogspot.com/2015/01/summary-of-logic-flow-when-mining-blocks.html