### PR TITLE
Fix os.time() and os.day() behavior on 1.14

### DIFF
--- a/src/main/java/dan200/computercraft/shared/computer/core/ServerComputer.java
+++ b/src/main/java/dan200/computercraft/shared/computer/core/ServerComputer.java
@@ -311,13 +311,13 @@ public class ServerComputer extends ServerTerminal implements IComputer, IComput
     @Override
     public double getTimeOfDay()
     {
-        return (m_world.getGameTime() + 6000) % 24000 / 1000.0;
+        return (m_world.getDayTime() + 6000) % 24000 / 1000.0;
     }
 
     @Override
     public int getDay()
     {
-        return (int) ((m_world.getGameTime() + 6000) / 24000) + 1;
+        return (int) ((m_world.getDayTime() + 6000) / 24000) + 1;
     }
 
     @Override


### PR DESCRIPTION
(Originally reported for [cc-tweaked-fabric#2](https://github.com/mystiacraft/cc-tweaked-fabric/issues/2) and [#4](https://github.com/mystiacraft/cc-tweaked-fabric/pull/4), credit goes to **@[doomy64](https://github.com/doomy64)**)

Functions `os.time()` and `os.day()` on Minecraft 1.13/1.14 return the wrong time when a sudden time change occurs (by `/time` command or sleeping).

This patch fixes these behaviors.


## Patch details

| mcp 1.12 | srg | mcp 1.13/1.14 |
|-|-|-|
| getWorldTime | func_72820_D | getDayTime |
| getTotalWorldTime | func_82737_E | getGameTime |

It seems that `getWorldTime` in `ServerComputer.java` for [1.12](https://github.com/SquidDev-CC/CC-Tweaked/blob/a802f25dd6659826a3c2f82e7c5e36cd25c53651/src/main/java/dan200/computercraft/shared/computer/core/ServerComputer.java#L347) is accidentally mapped to `getGameTime` in 1.13 and 1.14 branches, which causes these problems.

So this PR fixes `getGameTime` to `getDayTime`.
