### PR TITLE
Fix os.time() and os.day() behavior on 1.13

### DIFF
--- a/src/main/java/dan200/computercraft/shared/computer/core/ServerComputer.java
+++ b/src/main/java/dan200/computercraft/shared/computer/core/ServerComputer.java
@@ -311,13 +311,13 @@ public class ServerComputer extends ServerTerminal implements IComputer, IComput
     @Override
     public double getTimeOfDay()
     {
-        return (m_world.getGameTime() + 6000) % 24000 / 1000.0;
+        return (m_world.getDayTime() + 6000) % 24000 / 1000.0;
     }
 
     @Override
     public int getDay()
     {
-        return (int) ((m_world.getGameTime() + 6000) / 24000) + 1;
+        return (int) ((m_world.getDayTime() + 6000) / 24000) + 1;
     }
 
     @Override


### PR DESCRIPTION
Same as #291, but for the `mc-1.13.x` branch.