### PR TITLE
Fixed turtle property category

### DIFF
--- a/src/main/java/dan200/computercraft/shared/Config.java
+++ b/src/main/java/dan200/computercraft/shared/Config.java
@@ -277,7 +277,7 @@ public final class Config
             renameProperty( CATEGORY_GENERAL, "turtlesCanPush", CATEGORY_TURTLE, "can_push" );
             renameProperty( CATEGORY_GENERAL, "turtle_disabled_actions", CATEGORY_TURTLE, "disabled_actions" );
 
-            config.getCategory( CATEGORY_HTTP )
+            config.getCategory( CATEGORY_TURTLE )
                 .setComment( "Various options relating to turtles." );
 
             turtlesNeedFuel = config.get( CATEGORY_TURTLE, "need_fuel", ComputerCraft.turtlesNeedFuel );


### PR DESCRIPTION
Likely was a leftover from copy pasting and a tired programmer.

In for example the Forge settings GUI, the HTTP category description is overwritten with the description regarding to turtles. This should fix that.
