### PR TITLE
Rotate commands

### DIFF
--- a/src/main/java/dan200/computercraft/api/turtle/event/TurtleAction.java
+++ b/src/main/java/dan200/computercraft/api/turtle/event/TurtleAction.java
@@ -81,4 +81,9 @@ public enum TurtleAction
      * Gather metdata about an item in the turtle's inventory.
      */
     INSPECT_ITEM,
+
+    /**
+     * Rotate a block in world
+     */
+    ROTATE,
 }

--- a/src/main/java/dan200/computercraft/api/turtle/event/TurtleBlockEvent.java
+++ b/src/main/java/dan200/computercraft/api/turtle/event/TurtleBlockEvent.java
@@ -232,4 +232,49 @@ public abstract class TurtleBlockEvent extends TurtlePlayerEvent
             data.putAll( newData );
         }
     }
+
+    /**
+     * Fired when a turtle gathers data on a block in world.
+     *
+     * You may prevent blocks being inspected, or add additional information to the result.
+     *
+     * @see TurtleAction#INSPECT
+     */
+    public static class Rotate extends TurtleBlockEvent
+    {
+        private final BlockState state;
+        private final Direction direction;
+
+        public Rotate( @Nonnull ITurtleAccess turtle, @Nonnull FakePlayer player, @Nonnull World world, @Nonnull BlockPos pos, @Nonnull BlockState state , @Nonnull Direction direction)
+        {
+            super( turtle, TurtleAction.ROTATE, player, world, pos );
+
+            Objects.requireNonNull( state, "state cannot be null" );
+            Objects.requireNonNull( state, "direction cannot be null" );
+            this.state = state;
+            this.direction = direction;
+        }
+
+        /**
+         * Get the block state which is being rotated.
+         *
+         * @return The inspected block state.
+         */
+        @Nonnull
+        public BlockState getState()
+        {
+            return state;
+        }
+
+        /**
+         * Get the block direction which is being rotated.
+         *
+         * @return The inspected block state.
+         */
+        @Nonnull
+        public Direction getDirection()
+        {
+            return direction;
+        }
+    }
 }

--- a/src/main/java/dan200/computercraft/api/turtle/event/TurtleBlockEvent.java
+++ b/src/main/java/dan200/computercraft/api/turtle/event/TurtleBlockEvent.java
@@ -234,11 +234,11 @@ public abstract class TurtleBlockEvent extends TurtlePlayerEvent
     }
 
     /**
-     * Fired when a turtle gathers data on a block in world.
+     * Fired when a turtle roates a block in the world
      *
-     * You may prevent blocks being inspected, or add additional information to the result.
+     * You may prevent blocks being rotated, or add additional information to the result.
      *
-     * @see TurtleAction#INSPECT
+     * @see TurtleAction#ROTATE
      */
     public static class Rotate extends TurtleBlockEvent
     {
@@ -258,7 +258,7 @@ public abstract class TurtleBlockEvent extends TurtlePlayerEvent
         /**
          * Get the block state which is being rotated.
          *
-         * @return The inspected block state.
+         * @return The rotated block state before rotation.
          */
         @Nonnull
         public BlockState getState()
@@ -269,7 +269,7 @@ public abstract class TurtleBlockEvent extends TurtlePlayerEvent
         /**
          * Get the block direction which is being rotated.
          *
-         * @return The inspected block state.
+         * @return The direction the block will be rotated to.
          */
         @Nonnull
         public Direction getDirection()

--- a/src/main/java/dan200/computercraft/shared/turtle/apis/TurtleAPI.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/apis/TurtleAPI.java
@@ -20,6 +20,7 @@ import dan200.computercraft.core.tracking.TrackingField;
 import dan200.computercraft.shared.turtle.core.*;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.math.Direction;
 import net.minecraftforge.common.MinecraftForge;
 
 import javax.annotation.Nonnull;
@@ -95,6 +96,9 @@ public class TurtleAPI implements ILuaAPI
             "inspectUp",
             "inspectDown",
             "getItemDetail",
+            "rotate",
+            "rotateUp",
+            "rotateDown",
         };
     }
 
@@ -121,6 +125,39 @@ public class TurtleAPI implements ILuaAPI
         int count = optInt( arguments, index, 64 );
         if( count < 0 || count > 64 ) throw new LuaException( "Item count " + count + " out of range" );
         return count;
+    }
+
+    private static Direction parseDirection( Object[] arguments ) throws LuaException
+    {
+        String side = optString( arguments, 0, null);
+        if ( side == null || side.equalsIgnoreCase("up") )
+        {
+            return Direction.UP;
+        }
+        else if ( side.equalsIgnoreCase( "down" ) )
+        {
+            return Direction.DOWN;
+        }
+        else if ( side.equalsIgnoreCase( "east" ) )
+        {
+            return Direction.EAST;
+        }
+        else if ( side.equalsIgnoreCase( "west ") )
+        {
+            return Direction.WEST;
+        }
+        else if ( side.equalsIgnoreCase( "north" ) )
+        {
+            return Direction.NORTH;
+        }
+        else if ( side.equalsIgnoreCase( "south" ) )
+        {
+            return Direction.SOUTH;
+        }
+        else
+        {
+            throw new LuaException( "Invalid Direction" );
+        }
     }
 
     @Nullable
@@ -358,6 +395,12 @@ public class TurtleAPI implements ILuaAPI
 
                 return new Object[] { table };
             }
+            case 42: // rotate
+                return tryCommand( context, new TurtleRotateCommand( InteractDirection.Forward, parseDirection( args ) ) );
+            case 43: // rotateUp
+                return tryCommand( context, new TurtleRotateCommand( InteractDirection.Up, parseDirection( args ) ) );
+            case 44: // rotateDown
+                return tryCommand( context, new TurtleRotateCommand( InteractDirection.Down, parseDirection( args ) ) );
 
             default:
                 return null;

--- a/src/main/java/dan200/computercraft/shared/turtle/core/TurtleRotateCommand.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/core/TurtleRotateCommand.java
@@ -1,0 +1,54 @@
+package dan200.computercraft.shared.turtle.core;
+
+import dan200.computercraft.api.turtle.ITurtleAccess;
+import dan200.computercraft.api.turtle.ITurtleCommand;
+import dan200.computercraft.api.turtle.TurtleCommandResult;
+import dan200.computercraft.api.turtle.event.TurtleBlockEvent;
+import net.minecraft.block.BlockState;
+import net.minecraft.state.property.Properties;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
+import net.minecraft.world.World;
+import net.minecraftforge.common.MinecraftForge;
+
+import javax.annotation.Nonnull;
+
+public class TurtleRotateCommand implements ITurtleCommand {
+
+    private final InteractDirection direction;
+    private final Direction target_direction;
+
+    public TurtleRotateCommand( InteractDirection direction, Direction target_direction )
+    {
+        this.direction = direction;
+        this.target_direction = target_direction;
+    }
+
+    @Nonnull
+    @Override
+    public TurtleCommandResult execute(@Nonnull ITurtleAccess turtle) {
+        // Get world direction from direction
+        Direction direction = this.direction.toWorldDir( turtle );
+
+        // Check if thing in front is air or not
+        World world = turtle.getWorld();
+        BlockPos oldPosition = turtle.getPosition();
+        BlockPos newPosition = oldPosition.offset( direction );
+
+        BlockState state = world.getBlockState( newPosition );
+        if( state.isAir() )
+        {
+            return TurtleCommandResult.failure( "No block to rotate" );
+        }
+
+        world.setBlockState(newPosition, state.with(Properties.FACING, this.target_direction));
+        world.updateNeighbor(newPosition, state.getBlock(), newPosition);
+
+        // Fire the event, exiting if it is cancelled
+        TurtlePlayer turtlePlayer = TurtlePlaceCommand.createPlayer( turtle, oldPosition, direction );
+        TurtleBlockEvent.Rotate event = new TurtleBlockEvent.Rotate( turtle, turtlePlayer, world, newPosition, state, this.target_direction );
+        if( MinecraftForge.EVENT_BUS.post( event ) ) return TurtleCommandResult.failure( event.getFailureMessage() );
+
+        return TurtleCommandResult.success();
+    }
+}


### PR DESCRIPTION
Adds 3 new commands to the TurtleAPI
`rotate`, `rotateUp` and `rotateDown` that are used to rotate blocks

```lua
turtle.rotateUp("EAST")
turtle.rotate("DOWN")
```