### PR TITLE
Basic CraftTweaker support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,10 @@ repositories {
         name "Amadornes"
         url "https://maven.amadornes.com/"
     }
+    maven {
+        name "CraftTweaker"
+        url "https://maven.blamejared.com/"
+    }
 }
 
 configurations {
@@ -70,9 +74,10 @@ configurations {
 dependencies {
     checkstyle "com.puppycrawl.tools:checkstyle:8.25"
 
+    deobfProvided "CraftTweaker2:CraftTweaker2-MC1120-Main:1.12-4.1.20.554"
+    deobfProvided "MCMultiPart2:MCMultiPart:2.5.3"
     deobfProvided "mezz.jei:jei_1.12.2:4.15.0.269:api"
     deobfProvided "pl.asie:Charset-Lib:0.5.4.6"
-    deobfProvided "MCMultiPart2:MCMultiPart:2.5.3"
 
     runtime "mezz.jei:jei_1.12.2:4.15.0.269"
 

--- a/src/main/java/dan200/computercraft/shared/integration/crafttweaker/TurtleTweaker.java
+++ b/src/main/java/dan200/computercraft/shared/integration/crafttweaker/TurtleTweaker.java
@@ -1,0 +1,70 @@
+/*
+ * This file is part of ComputerCraft - http://www.computercraft.info
+ * Copyright Daniel Ratcliffe, 2011-2019. Do not distribute without permission.
+ * Send enquiries to dratcliffe@gmail.com
+ */
+
+package dan200.computercraft.shared.integration.crafttweaker;
+
+import crafttweaker.CraftTweakerAPI;
+import crafttweaker.annotations.ModOnly;
+import crafttweaker.annotations.ZenDoc;
+import crafttweaker.annotations.ZenRegister;
+import crafttweaker.api.item.IItemStack;
+import crafttweaker.api.minecraft.CraftTweakerMC;
+import dan200.computercraft.ComputerCraft;
+import dan200.computercraft.shared.integration.crafttweaker.actions.AddTurtleTool;
+import dan200.computercraft.shared.integration.crafttweaker.actions.RemoveTurtleUpgradeByItem;
+import dan200.computercraft.shared.integration.crafttweaker.actions.RemoveTurtleUpgradeByName;
+import stanhebben.zenscript.annotations.ZenClass;
+import stanhebben.zenscript.annotations.ZenMethod;
+
+@ZenRegister
+@ZenClass( "dan200.computercraft.turtle" )
+@ModOnly( ComputerCraft.MOD_ID )
+public class TurtleTweaker
+{
+    @ZenMethod
+    @ZenDoc( "Remove a turtle upgrade with the given id" )
+    public static void removeUpgrade( String upgrade )
+    {
+        CraftTweakerAPI.apply( new RemoveTurtleUpgradeByName( upgrade ) );
+    }
+
+    @ZenMethod
+    @ZenDoc( "Remove a turtle upgrade crafted with the given item stack" )
+    public static void removeUpgrade( IItemStack stack )
+    {
+        CraftTweakerAPI.apply( new RemoveTurtleUpgradeByItem( CraftTweakerMC.getItemStack( stack ) ) );
+    }
+
+    @ZenMethod
+    @ZenDoc( "Add a new turtle tool with the given id, which crafts and acts using the given stack." )
+    public static void addTool( String id, IItemStack stack )
+    {
+        addTool( id, stack, stack, "tool" );
+    }
+
+    @ZenMethod
+    @ZenDoc( "Add a new turtle tool with the given id, which is crafted with one item, and uses another." )
+    public static void addTool( String id, IItemStack craftingStack, IItemStack toolStack )
+    {
+        addTool( id, craftingStack, toolStack, "tool" );
+    }
+
+    @ZenMethod
+    @ZenDoc( "Add a new turtle tool with the given id, which crafts and acts using the given stack. You may also" +
+        "specify a 'kind' of tool, which limits what blocks the turtle can break (for instance, an 'axe' may only break wood)." )
+    public static void addTool( String id, IItemStack stack, String kind )
+    {
+        addTool( id, stack, stack, kind );
+    }
+
+    @ZenMethod
+    @ZenDoc( "Add a new turtle tool with the given id, which is crafted with one item, and uses another. You may also" +
+        "specify a 'kind' of tool, which limits what blocks the turtle can break (for instance, an 'axe' may only break wood)." )
+    public static void addTool( String id, IItemStack craftingStack, IItemStack toolStack, String kind )
+    {
+        CraftTweakerAPI.apply( new AddTurtleTool( id, CraftTweakerMC.getItemStack( craftingStack ), CraftTweakerMC.getItemStack( toolStack ), kind ) );
+    }
+}

--- a/src/main/java/dan200/computercraft/shared/integration/crafttweaker/actions/AddTurtleTool.java
+++ b/src/main/java/dan200/computercraft/shared/integration/crafttweaker/actions/AddTurtleTool.java
@@ -1,0 +1,96 @@
+/*
+ * This file is part of ComputerCraft - http://www.computercraft.info
+ * Copyright Daniel Ratcliffe, 2011-2019. Do not distribute without permission.
+ * Send enquiries to dratcliffe@gmail.com
+ */
+
+package dan200.computercraft.shared.integration.crafttweaker.actions;
+
+import dan200.computercraft.ComputerCraft;
+import dan200.computercraft.shared.TurtleUpgrades;
+import dan200.computercraft.shared.turtle.upgrades.*;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Register a new turtle tool.
+ */
+public class AddTurtleTool implements IAction
+{
+    private interface Factory
+    {
+        TurtleTool create( ResourceLocation location, ItemStack craftItem, ItemStack toolItem );
+    }
+
+    private static final Map<String, Factory> kinds = new HashMap<>();
+
+    static
+    {
+        kinds.put( "tool", TurtleTool::new );
+        kinds.put( "axe", TurtleAxe::new );
+        kinds.put( "hoe", TurtleHoe::new );
+        kinds.put( "shovel", TurtleShovel::new );
+        kinds.put( "sword", TurtleSword::new );
+    }
+
+    private final String id;
+    private final ItemStack craftItem;
+    private final ItemStack toolItem;
+    private final String kind;
+
+    public AddTurtleTool( String id, ItemStack craftItem, ItemStack toolItem, String kind )
+    {
+        this.id = id;
+        this.craftItem = craftItem;
+        this.toolItem = toolItem;
+        this.kind = kind;
+    }
+
+    @Override
+    public void apply()
+    {
+        Factory factory = kinds.get( kind );
+        if( factory == null )
+        {
+            ComputerCraft.log.error( "Unknown turtle upgrade kind '{}' (this should have been rejected by verify!)", kind );
+            return;
+        }
+
+        try
+        {
+            TurtleUpgrades.register( factory.create( new ResourceLocation( id ), craftItem, toolItem ) );
+        }
+        catch( RuntimeException e )
+        {
+            ComputerCraft.log.error( "Registration of turtle tool failed", e );
+        }
+    }
+
+    @Override
+    public String describe()
+    {
+        return String.format( "Add new turtle %s '%s' (crafted with '%s', uses a '%s')", kind, id, craftItem, toolItem );
+    }
+
+    public Optional<String> getValidationProblem()
+    {
+        if( craftItem.isEmpty() ) return Optional.of( "Crafting item stack is empty." );
+        if( craftItem.hasTagCompound() && !craftItem.getTagCompound().isEmpty() )
+        {
+            return Optional.of( "Crafting item has NBT." );
+        }
+        if( toolItem.isEmpty() ) return Optional.of( "Tool item stack is empty." );
+        if( !kinds.containsKey( kind ) ) return Optional.of( String.format( "Unknown kind '%s'.", kind ) );
+
+        if( TurtleUpgrades.get( id ) != null )
+        {
+            return Optional.of( String.format( "An upgrade with the same name ('%s') has already been registered.", id ) );
+        }
+
+        return Optional.empty();
+    }
+}

--- a/src/main/java/dan200/computercraft/shared/integration/crafttweaker/actions/IAction.java
+++ b/src/main/java/dan200/computercraft/shared/integration/crafttweaker/actions/IAction.java
@@ -1,0 +1,32 @@
+/*
+ * This file is part of ComputerCraft - http://www.computercraft.info
+ * Copyright Daniel Ratcliffe, 2011-2019. Do not distribute without permission.
+ * Send enquiries to dratcliffe@gmail.com
+ */
+
+package dan200.computercraft.shared.integration.crafttweaker.actions;
+
+import java.util.Optional;
+
+/**
+ * An extension of {@link IAction} with a single validation function, rather than two.
+ */
+public interface IAction extends crafttweaker.IAction
+{
+    default Optional<String> getValidationProblem()
+    {
+        return Optional.empty();
+    }
+
+    @Override
+    default boolean validate()
+    {
+        return !getValidationProblem().isPresent();
+    }
+
+    @Override
+    default String describeInvalid()
+    {
+        return getValidationProblem().orElse( "No problems found." );
+    }
+}

--- a/src/main/java/dan200/computercraft/shared/integration/crafttweaker/actions/RemoveTurtleUpgradeByItem.java
+++ b/src/main/java/dan200/computercraft/shared/integration/crafttweaker/actions/RemoveTurtleUpgradeByItem.java
@@ -1,0 +1,50 @@
+/*
+ * This file is part of ComputerCraft - http://www.computercraft.info
+ * Copyright Daniel Ratcliffe, 2011-2019. Do not distribute without permission.
+ * Send enquiries to dratcliffe@gmail.com
+ */
+
+package dan200.computercraft.shared.integration.crafttweaker.actions;
+
+import dan200.computercraft.api.turtle.ITurtleUpgrade;
+import dan200.computercraft.shared.TurtleUpgrades;
+import net.minecraft.item.ItemStack;
+
+import java.util.Optional;
+
+/**
+ * Removes a turtle upgrade crafted with the given stack.
+ */
+public class RemoveTurtleUpgradeByItem implements IAction
+{
+    private final ItemStack stack;
+
+    public RemoveTurtleUpgradeByItem( ItemStack stack )
+    {
+        this.stack = stack;
+    }
+
+    @Override
+    public void apply()
+    {
+        ITurtleUpgrade upgrade = TurtleUpgrades.get( stack );
+        if( upgrade != null ) TurtleUpgrades.disable( upgrade );
+    }
+
+    @Override
+    public String describe()
+    {
+        return String.format( "Remove turtle upgrades crafted with '%s'", stack );
+    }
+
+    @Override
+    public Optional<String> getValidationProblem()
+    {
+        if( TurtleUpgrades.get( stack ) == null )
+        {
+            return Optional.of( String.format( "Unknown turtle upgrade crafted with '%s'.", stack ) );
+        }
+
+        return Optional.empty();
+    }
+}

--- a/src/main/java/dan200/computercraft/shared/integration/crafttweaker/actions/RemoveTurtleUpgradeByName.java
+++ b/src/main/java/dan200/computercraft/shared/integration/crafttweaker/actions/RemoveTurtleUpgradeByName.java
@@ -1,0 +1,49 @@
+/*
+ * This file is part of ComputerCraft - http://www.computercraft.info
+ * Copyright Daniel Ratcliffe, 2011-2019. Do not distribute without permission.
+ * Send enquiries to dratcliffe@gmail.com
+ */
+
+package dan200.computercraft.shared.integration.crafttweaker.actions;
+
+import dan200.computercraft.api.turtle.ITurtleUpgrade;
+import dan200.computercraft.shared.TurtleUpgrades;
+
+import java.util.Optional;
+
+/**
+ * Removes a turtle upgrade with the given id.
+ */
+public class RemoveTurtleUpgradeByName implements IAction
+{
+    private final String id;
+
+    public RemoveTurtleUpgradeByName( String id )
+    {
+        this.id = id;
+    }
+
+    @Override
+    public void apply()
+    {
+        ITurtleUpgrade upgrade = TurtleUpgrades.get( id );
+        if( upgrade != null ) TurtleUpgrades.disable( upgrade );
+    }
+
+    @Override
+    public String describe()
+    {
+        return String.format( "Remove turtle upgrade '%s'", id );
+    }
+
+    @Override
+    public Optional<String> getValidationProblem()
+    {
+        if( TurtleUpgrades.get( id ) == null )
+        {
+            return Optional.of( String.format( "Unknown turtle upgrade '%s'.", id ) );
+        }
+
+        return Optional.empty();
+    }
+}

--- a/src/main/java/dan200/computercraft/shared/turtle/items/ItemTurtleBase.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/items/ItemTurtleBase.java
@@ -48,13 +48,11 @@ public abstract class ItemTurtleBase extends ItemComputerBase implements ITurtle
         ItemStack normalStack = TurtleItemFactory.create( -1, null, -1, family, null, null, 0, null );
         if( !normalStack.isEmpty() && normalStack.getItem() == this ) list.add( normalStack );
 
-        for( ITurtleUpgrade upgrade : TurtleUpgrades.getVanillaUpgrades() )
-        {
-            if( !TurtleUpgrades.suitableForFamily( family, upgrade ) ) continue;
-
-            ItemStack stack = TurtleItemFactory.create( -1, null, -1, family, null, upgrade, 0, null );
-            if( !stack.isEmpty() && stack.getItem() == this ) list.add( stack );
-        }
+        TurtleUpgrades.getVanillaUpgrades()
+            .filter( x -> TurtleUpgrades.suitableForFamily( family, x ) )
+            .map( x -> TurtleItemFactory.create( -1, null, -1, family, null, x, 0, null ) )
+            .filter( x -> !x.isEmpty() && x.getItem() == this )
+            .forEach( list::add );
     }
 
     @Nonnull

--- a/src/main/java/dan200/computercraft/shared/turtle/upgrades/TurtleAxe.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/upgrades/TurtleAxe.java
@@ -7,6 +7,7 @@
 package dan200.computercraft.shared.turtle.upgrades;
 
 import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 
 public class TurtleAxe extends TurtleTool
@@ -19,6 +20,11 @@ public class TurtleAxe extends TurtleTool
     public TurtleAxe( ResourceLocation id, int legacyId, Item item )
     {
         super( id, legacyId, item );
+    }
+
+    public TurtleAxe( ResourceLocation id, ItemStack craftItem, ItemStack toolItem )
+    {
+        super( id, craftItem, toolItem );
     }
 
     @Override

--- a/src/main/java/dan200/computercraft/shared/turtle/upgrades/TurtleHoe.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/upgrades/TurtleHoe.java
@@ -35,6 +35,11 @@ public class TurtleHoe extends TurtleTool
         super( id, legacyId, item );
     }
 
+    public TurtleHoe( ResourceLocation id, ItemStack craftItem, ItemStack toolItem )
+    {
+        super( id, craftItem, toolItem );
+    }
+
     @Override
     protected boolean canBreakBlock( IBlockState state, World world, BlockPos pos, TurtlePlayer player )
     {

--- a/src/main/java/dan200/computercraft/shared/turtle/upgrades/TurtleShovel.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/upgrades/TurtleShovel.java
@@ -35,6 +35,11 @@ public class TurtleShovel extends TurtleTool
         super( id, legacyId, item );
     }
 
+    public TurtleShovel( ResourceLocation id, ItemStack craftItem, ItemStack toolItem )
+    {
+        super( id, craftItem, toolItem );
+    }
+
     @Override
     protected boolean canBreakBlock( IBlockState state, World world, BlockPos pos, TurtlePlayer player )
     {

--- a/src/main/java/dan200/computercraft/shared/turtle/upgrades/TurtleSword.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/upgrades/TurtleSword.java
@@ -10,6 +10,7 @@ import dan200.computercraft.shared.turtle.core.TurtlePlayer;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
@@ -24,6 +25,11 @@ public class TurtleSword extends TurtleTool
     public TurtleSword( ResourceLocation id, int legacyId, Item item )
     {
         super( id, legacyId, item );
+    }
+
+    public TurtleSword( ResourceLocation id, ItemStack craftItem, ItemStack toolItem )
+    {
+        super( id, craftItem, toolItem );
     }
 
     @Override

--- a/src/main/java/dan200/computercraft/shared/turtle/upgrades/TurtleTool.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/upgrades/TurtleTool.java
@@ -62,6 +62,12 @@ public class TurtleTool extends AbstractTurtleUpgrade
         this.item = new ItemStack( item, 1, 0 );
     }
 
+    public TurtleTool( ResourceLocation id, ItemStack craftItem, ItemStack toolItem )
+    {
+        super( id, -1, TurtleUpgradeType.Tool, craftItem );
+        this.item = toolItem;
+    }
+
     @Nonnull
     @Override
     @SideOnly( Side.CLIENT )
@@ -76,7 +82,7 @@ public class TurtleTool extends AbstractTurtleUpgrade
         );
         Minecraft mc = Minecraft.getMinecraft();
         return Pair.of(
-            mc.getRenderItem().getItemModelMesher().getItemModel( item ),
+            mc.getRenderItem().getItemModelMesher().getItemModel( getCraftingItem() ),
             transform
         );
     }


### PR DESCRIPTION
This adds some very basic CraftTweaker support, largely focused on turtle methods. We currently provide the following methods:

 - `dan200.computercraft.turtle.removeUpgrade(id: String)`
 - `dan200.computercraft.turtle.removeUpgrade(stack: IItemStack)`
 - `dan200.computercraft.turtle.addTool(id: String, craftItem: IItemStack[, toolItem: IItemStack][, kind: string])`

While it's pretty minimal, it should allow for a reasonable amount of functionality. If people want to play with it, [there's a download here][dl].

[dl]: http://tweaked.cc/dl/cc-tweaked-1.12.2-1.85.2-ct.jar