### PR TITLE
Make builded Jar downloadable

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -16,7 +16,15 @@ jobs:
         java-version: 1.8
 
     - name: Build with Gradle
-      run: ./gradlew build --no-daemon
+      run: |
+        ./gradlew build --no-daemon
+        mv build/libs/*.jar CC-Tweaked.jar
+
+    - name: Upload Jar
+      uses: actions/upload-artifact@v1
+      with:
+        name: CC-Tweaked
+        path: CC-Tweaked.jar
 
   lint-lua:
     name: Lint Lua

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -16,15 +16,13 @@ jobs:
         java-version: 1.8
 
     - name: Build with Gradle
-      run: |
-        ./gradlew build --no-daemon
-        mv build/libs/*.jar CC-Tweaked.jar
+      run: ./gradlew build --no-daemon
 
     - name: Upload Jar
       uses: actions/upload-artifact@v1
       with:
         name: CC-Tweaked
-        path: CC-Tweaked.jar
+        path: build/libs
 
   lint-lua:
     name: Lint Lua


### PR DESCRIPTION
The Jar that is builded with GitHub Actions can now be downloaded.