### PR TITLE
allow parallel to accept one table arg

### DIFF
--- a/src/main/resources/assets/computercraft/lua/rom/apis/parallel.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/apis/parallel.lua
@@ -1,6 +1,6 @@
 
-local function create( ... )
-    local tFns = table.pack(...)
+local function create( listOrFirst, ... )
+    local tFns = type( listOrFirst ) == "table" and listOrFirst or table.pack(listOrFirst, ...)
     local tCos = {}
     for i = 1, tFns.n, 1 do
         local fn = tFns[i]

--- a/src/test/resources/test-rom/spec/apis/parallel_spec.lua
+++ b/src/test/resources/test-rom/spec/apis/parallel_spec.lua
@@ -27,7 +27,7 @@ describe("The parallel library", function()
     describe("parallel.waitForAll", function()
         it("validates arguments", function()
             parallel.waitForAll(mock, mock)
-            parallel.waitForAll({mock,mock})
+            parallel.waitForAll({mock, mock})
 
             expect.error(parallel.waitForAll, nil):eq("bad argument #1 (expected function, got nil)")
             expect.error(parallel.waitForAll, mock, nil):eq("bad argument #2 (expected function, got nil)")

--- a/src/test/resources/test-rom/spec/apis/parallel_spec.lua
+++ b/src/test/resources/test-rom/spec/apis/parallel_spec.lua
@@ -16,8 +16,8 @@ describe("The parallel library", function()
             expect(parallel.waitForAny, mock, mock):eq(1)
             expect(parallel.waitForAny, {mock, mock}):eq(1)
             
-            expect(parallel.waitForAny, longMock, mock):eq(1)
-            expect(parallel.waitForAny, {longMock, mock}):eq(1)
+            expect(parallel.waitForAny, longMock, mock):eq(2)
+            expect(parallel.waitForAny, {longMock, mock}):eq(2)
             
             expect(parallel.waitForAny, mock, longMock):eq(1)
             expect(parallel.waitForAny, {mock, longMock}):eq(1)

--- a/src/test/resources/test-rom/spec/apis/parallel_spec.lua
+++ b/src/test/resources/test-rom/spec/apis/parallel_spec.lua
@@ -1,0 +1,48 @@
+local function mock() end
+local function longMock() os.pullEvent() end
+
+describe("The parallel library", function()
+    describe("parallel.waitForAny", function()
+        it("validates arguments", function()
+            parallel.waitForAny(mock, mock)
+            parallel.waitForAny({mock,mock})
+
+            expect.error(parallel.waitForAny, nil):eq("bad argument #1 (expected function, got nil)")
+            expect.error(parallel.waitForAny, mock, nil):eq("bad argument #2 (expected function, got nil)")
+            expect.error(parallel.waitForAny, {nil}):eq("bad argument #1 (expected function, got nil)")
+            expect.error(parallel.waitForAny, {mock, nil}):eq("bad argument #2 (expected function, got nil)")
+        end)
+        it("returns the arg number of the function which finished first", function()
+            expect(parallel.waitForAny, mock, mock):eq(1)
+            expect(parallel.waitForAny, {mock, mock}):eq(1)
+            
+            expect(parallel.waitForAny, longMock, mock):eq(1)
+            expect(parallel.waitForAny, {longMock, mock}):eq(1)
+            
+            expect(parallel.waitForAny, mock, longMock):eq(1)
+            expect(parallel.waitForAny, {mock, longMock}):eq(1)
+        end)
+    end)
+    
+    describe("parallel.waitForAll", function()
+        it("validates arguments", function()
+            parallel.waitForAll(mock, mock)
+            parallel.waitForAll({mock,mock})
+
+            expect.error(parallel.waitForAll, nil):eq("bad argument #1 (expected function, got nil)")
+            expect.error(parallel.waitForAll, mock, nil):eq("bad argument #2 (expected function, got nil)")
+            expect.error(parallel.waitForAll, {nil}):eq("bad argument #1 (expected function, got nil)")
+            expect.error(parallel.waitForAll, {mock, nil}):eq("bad argument #2 (expected function, got nil)")
+        end)
+        it("returns nil", function()
+            expect(parallel.waitForAll, mock, mock):eq(nil)
+            expect(parallel.waitForAll, {mock, mock}):eq(nil)
+            
+            expect(parallel.waitForAll, longMock, mock):eq(nil)
+            expect(parallel.waitForAll, {longMock, mock}):eq(nil)
+            
+            expect(parallel.waitForAll, mock, longMock):eq(nil)
+            expect(parallel.waitForAll, {mock, longMock}):eq(nil)
+        end)
+    end)
+end)

--- a/src/test/resources/test-rom/spec/apis/parallel_spec.lua
+++ b/src/test/resources/test-rom/spec/apis/parallel_spec.lua
@@ -5,7 +5,7 @@ describe("The parallel library", function()
     describe("parallel.waitForAny", function()
         it("validates arguments", function()
             parallel.waitForAny(mock, mock)
-            parallel.waitForAny({mock,mock})
+            parallel.waitForAny({mock, mock})
 
             expect.error(parallel.waitForAny, nil):eq("bad argument #1 (expected function, got nil)")
             expect.error(parallel.waitForAny, mock, nil):eq("bad argument #2 (expected function, got nil)")


### PR DESCRIPTION
this table is then used as the list of function to run in parallel instead of having each function passed as separate arguments

the old interface of separate arguments is still valid