### PR TITLE
Update monitor.lua to add mouse_up events

### DIFF
--- a/src/main/resources/assets/computercraft/lua/rom/programs/monitor.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/programs/monitor.lua
@@ -39,49 +39,25 @@ local function resume( ... )
     return param
 end
 
-local timers = { n = 0 }
+local timers = {}
 
--- add a timer to the timers list with id 'id', xpos 'x', ypos 'y'
-local function addTimer( id, x, y )
-    timers.n = timers.n + 1
-    timers[timers.n] = { n = 3, id, x, y }
-end
-
--- remove a timer from the timers list with id 'id'
-local function removeTimer( id )
-    for i = 1, timers.n do
-        if timers[i][1] == id then
-            local x, y = table.unpack( timers[i], 2, timers[i].n )
-            table.remove( timers, i )
-            timers.n = timers.n - 1
-            return true, x, y
-        end
-    end
-    return false
-end
-
-local ok, param = pcall( parallel.waitForAny,
-function()
-    while true do
-        local _, id = os.pullEventRaw( "timer" )
-        -- when a timer is set off, check if it exists and remove it if so
-        -- also generate "mouse_up" event
-        local ok, x, y = removeTimer( id )
-            if ok then
-            os.queueEvent( "mouse_up", 1, x, y )
-        end
-    end
-end,
-function()
+local ok, param = pcall( function()
     local sFilter = resume()
     while coroutine.status( co ) ~= "dead" do
         local tEvent = table.pack( os.pullEventRaw() )
+        if tEvent[1] == "timer" and timers[tEvent[2]] then
+            local x, y = table.unpack(timers[tEvent[2]], 1, 2)
+            timers[tEvent[2]] = nil
+            tEvent = { n = 4, "mouse_up", 1, x, y }
+            -- hijack event, insert mouse_up event. Child process shouldn't know
+            -- timer event exists.
+        end
         if sFilter == nil or tEvent[1] == sFilter or tEvent[1] == "terminate" then
             sFilter = resume( table.unpack( tEvent, 1, tEvent.n ) )
         end
         if coroutine.status( co ) ~= "dead" and (sFilter == nil or sFilter == "mouse_click") then
             if tEvent[1] == "monitor_touch" and tEvent[2] == sName then
-                addTimer(os.startTimer(0.1), tEvent[3], tEvent[4])
+                timers[os.startTimer( 0.1 )] = { tEvent[3], tEvent[4] }
                 sFilter = resume( "mouse_click", 1, table.unpack( tEvent, 3, tEvent.n ) )
             end
         end

--- a/src/main/resources/assets/computercraft/lua/rom/programs/monitor.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/programs/monitor.lua
@@ -45,11 +45,6 @@ local ok, param = pcall( function()
     local sFilter = resume()
     while coroutine.status( co ) ~= "dead" do
         local tEvent = table.pack( os.pullEventRaw() )
-        if tEvent[1] == "timer" and timers[tEvent[2]] then
-            local x, y = table.unpack(timers[tEvent[2]], 1, 2)
-            timers[tEvent[2]] = nil
-            sFilter = resume( "mouse_up", 1, x, y )
-        end
         if sFilter == nil or tEvent[1] == sFilter or tEvent[1] == "terminate" then
             sFilter = resume( table.unpack( tEvent, 1, tEvent.n ) )
         end
@@ -63,6 +58,11 @@ local ok, param = pcall( function()
             if tEvent[1] == "monitor_resize" and tEvent[2] == sName then
                 sFilter = resume( "term_resize" )
             end
+        end
+        if tEvent[1] == "timer" and timers[tEvent[2]] then
+            local x, y = table.unpack(timers[tEvent[2]], 1, 2)
+            timers[tEvent[2]] = nil
+            sFilter = resume( "mouse_up", 1, x, y )
         end
     end
 end )

--- a/src/main/resources/assets/computercraft/lua/rom/programs/monitor.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/programs/monitor.lua
@@ -61,9 +61,8 @@ local ok, param = pcall( function()
         end
         if coroutine.status( co ) ~= "dead" and (sFilter == nil or sFilter == "mouse_up") then
             if tEvent[1] == "timer" and timers[tEvent[2]] then
-                local x, y = table.unpack(timers[tEvent[2]], 1, 2)
+                sFilter = resume( "mouse_up", 1, table.unpack( timers[tEvent[2]], 1, 2 ) )
                 timers[tEvent[2]] = nil
-                sFilter = resume( "mouse_up", 1, x, y )
             end
         end
     end

--- a/src/main/resources/assets/computercraft/lua/rom/programs/monitor.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/programs/monitor.lua
@@ -48,9 +48,7 @@ local ok, param = pcall( function()
         if tEvent[1] == "timer" and timers[tEvent[2]] then
             local x, y = table.unpack(timers[tEvent[2]], 1, 2)
             timers[tEvent[2]] = nil
-            tEvent = { n = 4, "mouse_up", 1, x, y }
-            -- hijack event, insert mouse_up event. Child process shouldn't know
-            -- timer event exists.
+            resume( "mouse_up", 1, x, y )
         end
         if sFilter == nil or tEvent[1] == sFilter or tEvent[1] == "terminate" then
             sFilter = resume( table.unpack( tEvent, 1, tEvent.n ) )

--- a/src/main/resources/assets/computercraft/lua/rom/programs/monitor.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/programs/monitor.lua
@@ -48,7 +48,7 @@ local ok, param = pcall( function()
         if tEvent[1] == "timer" and timers[tEvent[2]] then
             local x, y = table.unpack(timers[tEvent[2]], 1, 2)
             timers[tEvent[2]] = nil
-            resume( "mouse_up", 1, x, y )
+            sFilter = resume( "mouse_up", 1, x, y )
         end
         if sFilter == nil or tEvent[1] == sFilter or tEvent[1] == "terminate" then
             sFilter = resume( table.unpack( tEvent, 1, tEvent.n ) )

--- a/src/main/resources/assets/computercraft/lua/rom/programs/monitor.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/programs/monitor.lua
@@ -59,10 +59,12 @@ local ok, param = pcall( function()
                 sFilter = resume( "term_resize" )
             end
         end
-        if tEvent[1] == "timer" and timers[tEvent[2]] then
-            local x, y = table.unpack(timers[tEvent[2]], 1, 2)
-            timers[tEvent[2]] = nil
-            sFilter = resume( "mouse_up", 1, x, y )
+        if coroutine.status( co ) ~= "dead" and (sFilter == nil or sFilter == "mouse_up") then
+            if tEvent[1] == "timer" and timers[tEvent[2]] then
+                local x, y = table.unpack(timers[tEvent[2]], 1, 2)
+                timers[tEvent[2]] = nil
+                sFilter = resume( "mouse_up", 1, x, y )
+            end
         end
     end
 end )


### PR DESCRIPTION
Some programs as I've come to find out will act differently upon a long click, compared to a short click.  Others have buttons which act explicitly on the `mouse_up` event.

This change will send `mouse_up` events `0.1` seconds after the `mouse_click` event, allowing the programs which do the above to operate normally.

It will also be more "realistic" in the sense that a player hitting the monitor is essentially a "tap" where the mouse is down then back up in rapid succession.