### PR TITLE
Removed rightAlt from edit.lua

### DIFF
--- a/src/main/resources/assets/computercraft/lua/rom/programs/edit.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/programs/edit.lua
@@ -681,7 +681,7 @@ while bRunning do
 
             end
 
-        elseif param == keys.leftCtrl or param == keys.rightCtrl or param == keys.rightAlt then
+        elseif param == keys.leftCtrl or param == keys.rightCtrl then
             -- Menu toggle
             bMenu = not bMenu
             if bMenu then


### PR DESCRIPTION
Some keyboard layouts require rightAlt to type certain character, i.e. [, ], { and } for fr_CH