### PR TITLE
Configureable turtle speed

### DIFF
--- a/src/main/java/dan200/computercraft/ComputerCraft.java
+++ b/src/main/java/dan200/computercraft/ComputerCraft.java
@@ -143,6 +143,7 @@ public class ComputerCraft
     public static boolean turtlesObeyBlockProtection = true;
     public static boolean turtlesCanPush = true;
     public static EnumSet<TurtleAction> turtleDisabledActions = EnumSet.noneOf( TurtleAction.class );
+    public static int turtleAnimationDuration = 8;
 
     public static final int terminalWidth_computer = 51;
     public static final int terminalHeight_computer = 19;

--- a/src/main/java/dan200/computercraft/shared/Config.java
+++ b/src/main/java/dan200/computercraft/shared/Config.java
@@ -76,6 +76,7 @@ public final class Config
     private static Property turtlesObeyBlockProtection;
     private static Property turtlesCanPush;
     private static Property turtleDisabledActions;
+    private static Property turtleAnimationDuration;
 
     private Config() {}
 
@@ -303,9 +304,12 @@ public final class Config
             turtleDisabledActions = config.get( CATEGORY_TURTLE, "disabled_actions", new String[0] );
             turtleDisabledActions.setComment( "A list of turtle actions which are disabled." );
 
+            turtleAnimationDuration = config.get( CATEGORY_TURTLE, "animation_duration", ComputerCraft.turtleAnimationDuration );
+            turtleAnimationDuration.setComment( "How fast the turtle moves and digs, lower values are faster. Some values may make turtles hard to chase." );
+
             setOrder(
                 CATEGORY_TURTLE,
-                turtlesNeedFuel, turtleFuelLimit, advancedTurtleFuelLimit, turtlesObeyBlockProtection, turtlesCanPush, turtleDisabledActions
+                turtlesNeedFuel, turtleFuelLimit, advancedTurtleFuelLimit, turtlesObeyBlockProtection, turtlesCanPush, turtleDisabledActions, turtleAnimationDuration
             );
         }
 
@@ -480,6 +484,8 @@ public final class Config
                 ComputerCraft.log.error( "Unknown turtle action " + value );
             }
         }
+
+        ComputerCraft.turtleAnimationDuration = turtleAnimationDuration.getInt();
 
         config.save();
     }

--- a/src/main/java/dan200/computercraft/shared/turtle/core/TurtleBrain.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/core/TurtleBrain.java
@@ -44,7 +44,7 @@ import java.util.concurrent.TimeUnit;
 
 public class TurtleBrain implements ITurtleAccess
 {
-    private static final int ANIM_DURATION = 8;
+    private static final int ANIM_DURATION = ComputerCraft.turtleAnimationDuration;
 
     private TileTurtle m_owner;
     private ComputerProxy m_proxy;
@@ -637,8 +637,8 @@ public class TurtleBrain implements ITurtleAccess
         m_animation = animation;
         if( m_animation == TurtleAnimation.ShortWait )
         {
-            m_animationProgress = ANIM_DURATION / 2;
-            m_lastAnimationProgress = ANIM_DURATION / 2;
+            m_animationProgress = ComputerCraft.turtleAnimationDuration / 2;
+            m_lastAnimationProgress = ComputerCraft.turtleAnimationDuration / 2;
         }
         else
         {
@@ -960,7 +960,7 @@ public class TurtleBrain implements ITurtleAccess
                     double maxY = minY + 1.0;
                     double maxZ = minZ + 1.0;
 
-                    float pushFrac = 1.0f - (float) (m_animationProgress + 1) / ANIM_DURATION;
+                    float pushFrac = 1.0f - (float) (m_animationProgress + 1) / ComputerCraft.turtleAnimationDuration;
                     float push = Math.max( pushFrac + 0.0125f, 0.0f );
                     if( moveDir.getXOffset() < 0 )
                     {
@@ -993,7 +993,7 @@ public class TurtleBrain implements ITurtleAccess
                     List<Entity> list = world.getEntitiesWithinAABB( Entity.class, aabb, EntitySelectors.NOT_SPECTATING );
                     if( !list.isEmpty() )
                     {
-                        double pushStep = 1.0f / ANIM_DURATION;
+                        double pushStep = 1.0f / ComputerCraft.turtleAnimationDuration;
                         double pushStepX = moveDir.getXOffset() * pushStep;
                         double pushStepY = moveDir.getYOffset() * pushStep;
                         double pushStepZ = moveDir.getZOffset() * pushStep;
@@ -1030,7 +1030,7 @@ public class TurtleBrain implements ITurtleAccess
 
             // Wait for anim completion
             m_lastAnimationProgress = m_animationProgress;
-            if( ++m_animationProgress >= ANIM_DURATION )
+            if( ++m_animationProgress >= ComputerCraft.turtleAnimationDuration )
             {
                 m_animation = TurtleAnimation.None;
                 m_animationProgress = 0;
@@ -1041,8 +1041,8 @@ public class TurtleBrain implements ITurtleAccess
 
     private float getAnimationFraction( float f )
     {
-        float next = (float) m_animationProgress / ANIM_DURATION;
-        float previous = (float) m_lastAnimationProgress / ANIM_DURATION;
+        float next = (float) m_animationProgress / ComputerCraft.turtleAnimationDuration;
+        float previous = (float) m_lastAnimationProgress / ComputerCraft.turtleAnimationDuration;
         return previous + (next - previous) * f;
     }
 }

--- a/src/main/java/dan200/computercraft/shared/turtle/core/TurtleBrain.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/core/TurtleBrain.java
@@ -44,8 +44,6 @@ import java.util.concurrent.TimeUnit;
 
 public class TurtleBrain implements ITurtleAccess
 {
-    private static final int ANIM_DURATION = ComputerCraft.turtleAnimationDuration;
-
     private TileTurtle m_owner;
     private ComputerProxy m_proxy;
     private GameProfile m_owningPlayer;

--- a/src/main/resources/assets/computercraft/lang/en_us.lang
+++ b/src/main/resources/assets/computercraft/lang/en_us.lang
@@ -193,3 +193,4 @@ gui.computercraft:config.turtle.advanced_fuel_limit=Advanced Turtle fuel limit
 gui.computercraft:config.turtle.obey_block_protection=Turtles obey block protection
 gui.computercraft:config.turtle.can_push=Turtles can push entities
 gui.computercraft:config.turtle.disabled_actions=Disabled turtle actions
+gui.computercraft:config.turtle.animation_duration=Turtle Animation Duration


### PR DESCRIPTION
A turtle's ability to move and interact with the world are two of its greatest strengths, so what would help people who are writing programs which do a lot of moving more than allowing them to make the turtle move faster?

Basically someone wanted to be able to test their mining program and found that the turtle moving slowly was tedious.

Draft pull request as I need to figure out how to get the config menu to be a bit nicer (localisation strings probably)