### PR TITLE
The Great Terminal Rewrite

### DIFF
--- a/src/main/java/dan200/computercraft/core/apis/TermAPI.java
+++ b/src/main/java/dan200/computercraft/core/apis/TermAPI.java
@@ -69,19 +69,19 @@ public class TermAPI implements ILuaAPI
         };
     }
 
-    public static int parseColour( Object[] args ) throws LuaException
+    public static byte parseColour( Object[] args ) throws LuaException
     {
         int colour = getInt( args, 0 );
         if( colour <= 0 )
         {
             throw new LuaException( "Colour out of range" );
         }
-        colour = getHighestBit( colour ) - 1;
-        if( colour < 0 || colour > 15 )
+        byte bit = (byte) (getHighestBit( colour ) - 1);
+        if( bit < 0 || bit > 15 )
         {
             throw new LuaException( "Colour out of range" );
         }
-        return colour;
+        return bit;
     }
 
     public static Object[] encodeColour( int colour ) throws LuaException
@@ -183,7 +183,7 @@ public class TermAPI implements ILuaAPI
             case 9:
             {
                 // setTextColour/setTextColor
-                int colour = parseColour( args );
+                byte colour = parseColour( args );
                 synchronized( m_terminal )
                 {
                     m_terminal.setTextColour( colour );
@@ -194,7 +194,7 @@ public class TermAPI implements ILuaAPI
             case 11:
             {
                 // setBackgroundColour/setBackgroundColor
-                int colour = parseColour( args );
+                byte colour = parseColour( args );
                 synchronized( m_terminal )
                 {
                     m_terminal.setBackgroundColour( colour );
@@ -283,9 +283,9 @@ public class TermAPI implements ILuaAPI
         }
     }
 
-    private static int getHighestBit( int group )
+    private static byte getHighestBit( int group )
     {
-        int bit = 0;
+        byte bit = 0;
         while( group > 0 )
         {
             group >>= 1;


### PR DESCRIPTION
# The Great Terminal Rewrite

This is a series of PRs which aims to improve terminal objects all round, with particular focus on:
- Memory usage
- Networking
- Rendering

For the majority of CC's lifetime, the current terminal implementation has worked fine. But recently, especially with the improvements brought by Cobalt, people have been pushing CC further and further to its absolute limits. We've seen this a lot on SwitchCraft, with a huge number of computers doing a lot of work at once. The Juroku cinema especially (rendering 480p video at 20FPS on 16x9 monitors) has prompted some urgent improvements to the system - players frequently time out due to the bulk of serialising monitors inefficiently with NBT. This series of PRs aims to fix all of this.

# The Plan

## Terminal internals rewrite

Terminals currently use [TextBuffers][TextBuffers] to store their data. This isn't an _awful_ data structure, because it makes it very convenient to access lines, but as terminals get bigger and more of them exist, this can become a 'death by a thousand paper cuts' problem, particularly with the class instance overhead.

This class will be removed entirely, and terminals will store just three 1-dimensional byte arrays: one for text (chars), one for the background colour (0-15), and one for the text colour (0-15). This structure has some great performance benefits in that it can be trivially copied from/to (using the native `System.arraycopy`), and this data can be passed directly to OpenGL in the form of a [Uniform Buffer Object][UBO] or [Buffer Texture][TBO] (more on this later). `term.blit` and `term.write` are now instantaneous operations with no loops involved (besides converting colour strings to byte arrays).

[TextBuffers]: https://github.com/SquidDev-CC/CC-Tweaked/blob/10a27a7a250eea160a8c172e63d8153c792bb53b/src/main/java/dan200/computercraft/core/terminal/TextBuffer.java
[UBO]: https://www.khronos.org/opengl/wiki/Uniform_Buffer_Object
[TBO]: https://www.khronos.org/opengl/wiki/Buffer_Texture

## Networking rewrite

Terminal serialisation is currently _terrifying_. If you've ever seen the printed pages NBT, you probably know what to expect. The entire terminal state (for monitors and computers) is serialised into NBT and sent to all clients in a structure that looks something like this:

```
bool colour: If the terminal supports colour
int  width: Terminal width in characters
int  height: Terminal height in characters

compound terminal:
  int   term_cursorX: The current cursor X position in characters
  int   term_cursorY: The current cursor Y position in characters
  bool  term_cursorBlink: Whether or not the cursor is blinking
  int   term_textColour: The current text colour (in bitmask form, so black is 32768)
  int   term_bgColour: The current background colour
  int[] term_palette: An integer array with palette colours 0-15 as RGB8 integers

  for each line in the terminal's height:
    str term_text_n: A blit string for this entire line's text
    str term_textColour_n: A blit string for this entire line's text colour (i.e. a hexadecimal string)
    str term_bgColour_n: A blit string for this entire line's background colour
```

This entire payload is recalculated every time anything on a terminal changes in a tick (I call this 'marked dirty'). As the terminal gets bigger and/or updates more frequently, the overhead of the nested blit tags is _not_ negligible (and gzip can only do so much). The key takeaway here, though, is that the _entire_ terminal state is re-sent to every player anytime _anything_ changes (even just the cursor position!).

**The new design is ultimately going to look something like this:**
- Avoid NBT (still under consideration).
- Split the terminal into 8x8 character "chunks".
- Only send the chunks that are marked dirty in a tick, instead of the entire terminal.
- Serialise each chunk as two fixed-size byte arrays, where:
  - The text is one 64-byte array.
  - Both text and background colour are stored as a single byte (since there are 16 colours, 4 bits, you can fit both colours in one byte).
  - A short (two bytes) at the start of each chunk denoting which chunk index it is.
- Payloads are calculated once per tick, cached, and re-sent to all players, instead of individually calculated for each.
- The entire terminal will only be sent to a player if their client requests it, e.g. they have just loaded the chunk (this implementation detail still needs to be figured out).
- `term.scroll` will be a separate packet or flag in the payload, so as to not require re-sending the entire state (as scrolling will mark every chunk dirty otherwise).
- Actions such as `term.setCursorPos` and `term.setCursorBlink` will send a minimal payload without invalidating any chunks if it is necessary.
- If a term is cleared, chunks will not be marked as dirty, but instead a separate `term.clear` payload will be sent.
- `term.setPaletteColour` will also be a separate packet/payload.

I believe that 8x8 chunks are a fair compromise in signal to noise ratio - there is only one (or two) additional byte per 64 characters in a terminal (thus, only 20/40 extra bytes in a regular computer terminal).

### Implementation details

With this payload design, it will be easy to perform the calculations necessary to reproduce the terminal. For example, a 51x19 terminal would be chunked like this:

![](https://i.lemmmy.pw/If4y.png)

All you need is the terminal's width and height, and you can calculate the position and dimensions of any given chunk from there:

```lua
local width, height = 51, 19
local chunksW, chunksH = math.ceil(width / 8), math.ceil(height / 8)

-- return the absolute x/y coordinates and width/height of a chunk by index
local function getChunk(id)
  local chunkX = id % chunksW
  local chunkY = math.floor(id / chunksW)

  local x = chunkX * 8
  local y = chunkY * 8

  local chunkWidth = chunkX == (math.floor(width / 8)) and (width % 8) or 8
  local chunkHeight = chunkY == (math.floor(height / 8)) and (height % 8) or 8
end
```

The payload for a single chunk will look something like this:
![](https://i.lemmmy.pw/F6fB.png)

The implementation for other packets, such as `term.scroll`, is yet to be decided.

**The focus of these changes are:**
- Reduce payload size.
- Don't send any character or colour data if we don't have to.
- Only send regions of the terminal that actually change, instead of everything at once.
- Optimise common operations such as scrolling and clearing to be smaller dedicated packets/payloads.

## Rendering rewrite (separate PR)

The final big change planned is a complete rewrite of the terminal renderer. The current renderer uses a messy mix of [Tessellator quads][font renderer] and [raw display lists][monitor renderer]. This is fine for [GUI terminals][terminal widget] and [map-like held terminals][pocket renderer], where there is only ever one on the screen at a time, and they aren't that large. However, monitors can get quite large, and there can be _many_ of them visible at once, and updating as fast as the server will allow them. As such, the main focus for the rendering change (and most of the changes in the terminal rewrite in general) is monitors.

[font renderer]: https://github.com/SquidDev-CC/CC-Tweaked/blob/10a27a7a250eea160a8c172e63d8153c792bb53b/src/main/java/dan200/computercraft/client/gui/FixedWidthFontRenderer.java#L49
[monitor renderer]: https://github.com/SquidDev-CC/CC-Tweaked/blob/10a27a7a250eea160a8c172e63d8153c792bb53b/src/main/java/dan200/computercraft/client/render/TileEntityMonitorRenderer.java#L133
[terminal widget]: https://github.com/SquidDev-CC/CC-Tweaked/blob/10a27a7a250eea160a8c172e63d8153c792bb53b/src/main/java/dan200/computercraft/client/gui/widgets/WidgetTerminal.java#L330
[pocket renderer]: https://github.com/SquidDev-CC/CC-Tweaked/blob/10a27a7a250eea160a8c172e63d8153c792bb53b/src/main/java/dan200/computercraft/client/render/ItemPocketRenderer.java#L192

### Hardware survey

After discussing a few ideas with [Lignum][Lignum], we decided to perform a [hardware survey][schws] amongst the SwitchCraft userbase. This has provided us with a good sample size for understanding the hardware support of 1.12 players. As of writing, we have received **62 responses**. Within those responses, 56 (90.3%) of users support OpenGL 3.1 or greater:

| OpenGL Version | Users | %    |
|----------------|-------|------|
| 2.1            | 3     | 4.8  |
| 3.0            | 3     | 4.8  |
| **3.3**        | 1     | 1.6  |
| **4.0**        | 5     | 8.1  |
| **4.3**        | 3     | 4.8  |
| **4.4**        | 1     | 1.6  |
| **4.5**        | 7     | 11.3 |
| **4.6**        | 39    | 62.9 |
<small>*Full statistics available [here][schws].*</small>

Thus, 56 (90.3%) of users support [Texture Buffer Objects][TBO] and [Uniform Buffer Objects][UBO] directly through these features being core in OpenGL 3.1. But, they are also available through their respective ARB and EXT extensions:

| Feature                              | Users | %    |
|--------------------------------------|-------|------|
| OpenGL 3.1                           | 56    | 90.3 |
| [ARB_texture_buffer_object][ARB TBO] | 47    | 75.8 |
| [EXT_texture_buffer_object][EXT TBO] | 41    | 66.1 |
| [ARB_uniform_buffer_object][ARB UBO] | 59    | 95.2 |
<small>*Full statistics available [here][schws].*</small>

It doesn't seem that there are any users who have TBOs provided to them solely through an extension. Everybody who has access to TBOs has access to OpenGL 3.1. On the other hand, there are 3 users who only have access to UBOs via the [ARB extension][ARB UBO]. As such, it's not impossible that there is a user who only has access to TBOs via the [ARB][ARB TBO] or [EXT][EXT TBO] extensions.

[Lignum]: https://github.com/Lignum
[schws]: https://hardware.switchcraft.pw/
[ARB TBO]: https://www.khronos.org/registry/OpenGL/extensions/ARB/ARB_texture_buffer_object.txt
[EXT TBO]: https://www.khronos.org/registry/OpenGL/extensions/EXT/EXT_texture_buffer_object.txt
[ARB UBO]: https://www.khronos.org/registry/OpenGL/extensions/ARB/ARB_uniform_buffer_object.txt

### The new renderer idea

So, why do we care about those features? The new plan for terminal rendering is kind of wacky, but very possible. We're hoping to move the entire terminal renderer into a single shader. This shader will take in the following inputs:

- The terminal font texture.
- The width and height of the terminal (in characters).
- The palette of the terminal.
- A [Buffer Texture][TBO] containing the *entire* Terminal state:
  - Each terminal character is a single pixel in the texture.
  - The red channel represents the characters (0-255).
  - The green channel represents the text colour (0-15).
  - The blue channel represents the background colour (0-15).
- When TBOs are not available, a [Uniform Buffer Object][UBO] will be used instead, with the same data as a TBO.

This will unify all of the terminal renderers into a single class that handles all of the rendering, and all of the work will be done by the GPU. As such, we won't have thousands of quads on the screen just for each monitor in the world. The buffer textures can be cached (similar to frame buffers), and discarded when the chunk is unloaded. We should also be able to use some [Buffer Object Streaming][streaming] techniques to update the TBOs/UBOs efficiently.

[streaming]: https://www.khronos.org/opengl/wiki/Buffer_Object_Streaming

### Fallback renderer

Within the hardware survey's sample, there are 6 users who don't have access to TBOs, and 3 who don't have access to UBOs. These are the OpenGL 2.1 users. Despite being released in [2006][GL 2.1], OpenGL 2.1 is still relatively common, particularly with users who are using open source graphics drivers, or Intel integrated graphics. Mojang raised the minimum OpenGL version to 2.1 in 1.8, so we don't have to worry about providing a fallback renderer for anything less than this. Regardless, UBOs and TBOs are still unavailable in a small number of cards, so we need to support something.

We decided that we still plan to scrap the current renderer, and as a fallback renderer, use [VBOs][VBO]. The Tessellator actually uses VBOs internally, regardless of the 'Use VBOs' option being turned off. As such, the current [font renderer][font renderer] also uses VBOs, with the exception of monitors, where it's a [half-VBO half-display list][monitor renderer] Frankenstein's monster. That said, there is a much more efficient way for these to be used, so we're going to be scrapping most of the existing code.

As such, our plan for rendering support looks something like this:

```
if version >= 3.1:
  // use GL3.1's native TBOs
else if GL_ARB_uniform_buffer_object:
  // use UBOs from ARB extension
else:
  // use GL2.1's native VBOs
```

There doesn't seem to be much point in supporting the extensions for TBOs at current usage, but if there seems to be appropriate demand, then it will look something like this:

```
if version >= 3.1:
  // use GL3.1's native TBOs
else if GL_ARB_texture_buffer_object:
  // use TBOs from ARB extension
else if GL_EXT_texture_buffer_object:
  // use TBOs from EXT extension
else if GL_ARB_uniform_buffer_object:
  // use UBOs from ARB extension
else:
  // use GL2.1's native VBOs
```

With an appropriate level of abstraction, all of this would be easy to manage, and all the terminal renderers would use a common class. It would be a matter of swapping out the function calls and changing a few arguments to support the TBO extensions.

[GL 2.1]: https://www.khronos.org/registry/OpenGL/specs/gl/glspec21.pdf
[VBO]: https://www.khronos.org/opengl/wiki/Vertex_Specification#Vertex_Buffer_Object

# The Roadmap

This PR is still very much a work in progress, and is currently not ready for review. It is mainly here as a marker for progress.

- [x] Remove [TextBuffer][TextBuffers] and replace them with 1-dimensional byte arrays. (95% complete)
- [ ] Adjust all APIs and existing terminal rendering code to use the new byte arrays.
- [ ] Write tests for the new terminal stuff.
- [ ] Rewrite the terminal network packet to use the new byte arrays.
- [ ] Implement the 'small' payloads for:
  - [ ] `term.clear`
  - [ ] `term.scroll`
  - [ ] `term.setCursorPos`
  - [ ] `term.setCursorBlink`
  - [ ] `term.setPaletteColour`
  - [ ] Terminal resizing
- [ ] Implement chunking/diffing.
- [ ] Rewrite the renderers and implement TBOs/UBOs (separate PR).

This PR will definitely need to be rebased later on.