### PR TITLE
Remove / and \ at the start of shell.setDir()

### DIFF
--- a/src/main/resources/assets/computercraft/lua/rom/programs/shell.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/programs/shell.lua
@@ -194,8 +194,7 @@ function shell.setDir( _sDir )
     if not fs.isDir( _sDir ) then
         error( "Not a directory", 2 )
     end
-    _sDir = fs.combine(_sDir, "")
-    sDir = _sDir
+    sDir = fs.combine(_sDir, "")
 end
 
 function shell.path()

--- a/src/main/resources/assets/computercraft/lua/rom/programs/shell.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/programs/shell.lua
@@ -194,6 +194,10 @@ function shell.setDir( _sDir )
     if not fs.isDir( _sDir ) then
         error( "Not a directory", 2 )
     end
+    local sStartChar = string.sub( _sDir, 1, 1 )
+    if sStartChar == "/" or sStartChar == "\\" then
+        _sDir = _sDir:sub( 2 )
+    end
     sDir = _sDir
 end
 

--- a/src/main/resources/assets/computercraft/lua/rom/programs/shell.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/programs/shell.lua
@@ -194,10 +194,7 @@ function shell.setDir( _sDir )
     if not fs.isDir( _sDir ) then
         error( "Not a directory", 2 )
     end
-    local sStartChar = string.sub( _sDir, 1, 1 )
-    if sStartChar == "/" or sStartChar == "\\" then
-        _sDir = _sDir:sub( 2 )
-    end
+    _sDir = fs.combine(_sDir, "")
     sDir = _sDir
 end
 


### PR DESCRIPTION
If you change the directory with the cd command, it will remove / or \ at the start of a path. With this PR, the prompt of the shell will look the same, if you use shell.setDir().