### PR TITLE
Update CraftOS Version to 1.9

### DIFF
--- a/src/main/resources/assets/computercraft/lua/bios.lua
+++ b/src/main/resources/assets/computercraft/lua/bios.lua
@@ -98,7 +98,7 @@ end
 
 -- Install lua parts of the os api
 function os.version()
-    return "CraftOS 1.8"
+    return "CraftOS 1.9"
 end
 
 function os.pullEventRaw(sFilter)


### PR DESCRIPTION
I think CCT should use Version 1.9 to spot the difference between the old CC with 1.8 and the newer CCT.