### PR TITLE
Fixed settings.load merge check

### DIFF
--- a/src/main/resources/assets/computercraft/lua/rom/apis/settings.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/apis/settings.lua
@@ -207,7 +207,7 @@ function load(sPath)
     for k, v in pairs(tFile) do
         local ty_v = type(k)
         if type(k) == "string" and (ty_v == "string" or ty_v == "number" or ty_v == "boolean" or ty_v == "table") then
-            local opt = details[name]
+            local opt = details[k]
             if not opt or not opt.type or ty_v == opt.type then
                 set_value(k, v)
             end


### PR DESCRIPTION
`settings.load` had a line that was using a deleted variable to index a table, resulting in it always returning `nil`, and thus the check never went through. I'm surprised this got by the linter. I've fixed it to use `k` instead of `name`.