### PR TITLE
Implement mouse_move event

### DIFF
--- a/src/main/java/dan200/computercraft/ComputerCraft.java
+++ b/src/main/java/dan200/computercraft/ComputerCraft.java
@@ -113,7 +113,7 @@ public class ComputerCraft
     public static String default_computer_settings = "";
     public static boolean debug_enable = true;
     public static boolean logPeripheralErrors = false;
-    public static long mouseMoveThrottle = 200;
+    public static long mouseMoveThrottle = 50;
 
     public static int computer_threads = 1;
     public static long maxMainGlobalTime = TimeUnit.MILLISECONDS.toNanos( 10 );

--- a/src/main/java/dan200/computercraft/ComputerCraft.java
+++ b/src/main/java/dan200/computercraft/ComputerCraft.java
@@ -113,7 +113,7 @@ public class ComputerCraft
     public static String default_computer_settings = "";
     public static boolean debug_enable = true;
     public static boolean logPeripheralErrors = false;
-    public static long mouseMoveThrottle = 50;
+    public static long mouseMoveThrottle = 1;
 
     public static int computer_threads = 1;
     public static long maxMainGlobalTime = TimeUnit.MILLISECONDS.toNanos( 10 );

--- a/src/main/java/dan200/computercraft/ComputerCraft.java
+++ b/src/main/java/dan200/computercraft/ComputerCraft.java
@@ -113,6 +113,7 @@ public class ComputerCraft
     public static String default_computer_settings = "";
     public static boolean debug_enable = true;
     public static boolean logPeripheralErrors = false;
+    public static long mouseMoveThrottle = 200;
 
     public static int computer_threads = 1;
     public static long maxMainGlobalTime = TimeUnit.MILLISECONDS.toNanos( 10 );

--- a/src/main/java/dan200/computercraft/client/gui/widgets/WidgetTerminal.java
+++ b/src/main/java/dan200/computercraft/client/gui/widgets/WidgetTerminal.java
@@ -34,8 +34,6 @@ public class WidgetTerminal extends Widget
 
     private int m_lastMouseX = -1;
     private int m_lastMouseY = -1;
-    private long m_lastMouseMove = -1;
-    private boolean m_mouseMoved = false;
 
     private boolean m_focus = false;
     private boolean m_allowFocusLoss = true;
@@ -215,9 +213,10 @@ public class WidgetTerminal extends Widget
     public void handleMouseInput( int mouseX, int mouseY )
     {
         IComputer computer = m_computer.getComputer();
+        if ( computer == null || !computer.isColour() ) return;
+
         if( mouseX >= getXPosition() && mouseX < getXPosition() + getWidth() &&
-            mouseY >= getYPosition() && mouseY < getYPosition() + getHeight() &&
-            computer != null && computer.isColour() )
+            mouseY >= getYPosition() && mouseY < getYPosition() + getHeight() )
         {
             Terminal term = computer.getTerminal();
             if( term != null )
@@ -229,12 +228,12 @@ public class WidgetTerminal extends Widget
 
                 handleMouseClick( computer, charX, charY );
                 handleMouseWheel( computer, charX, charY );
-                handleMouseMove( charX, charY );
+                handleMouseMove( computer, charX, charY );
             }
         }
         else // The mouse has moved out of the terminal, send a -1, -1 mouse_move event
         {
-            handleMouseMove( -1, -1 );
+            handleMouseMove( computer, -1, -1 );
         }
     }
 
@@ -275,15 +274,16 @@ public class WidgetTerminal extends Widget
         }
     }
 
-    private void handleMouseMove( int charX, int charY )
+    private void handleMouseMove( IComputer computer, int charX, int charY )
     {
+        // Avoid sending mouse movement events if the cursor is under the same character.
+        // Note that clients can also use the mouseMoveThrottle config options to disable
+        // sending their mouse movements to a server entirely.
         if( ComputerCraft.mouseMoveThrottle >= 0 && (m_lastMouseX != charX || m_lastMouseY != charY) )
         {
-            // Simply update the last mouse move location, the work is delegated to the update handler,
-            // which will deal with throttling too!
+            computer.mouseMove( charX, charY );
             m_lastMouseX = charX;
             m_lastMouseY = charY;
-            m_mouseMoved = true;
         }
     }
 
@@ -348,22 +348,6 @@ public class WidgetTerminal extends Widget
             m_terminateTimer = 0.0f;
             m_rebootTimer = 0.0f;
             m_shutdownTimer = 0.0f;
-        }
-
-        // Handle mouse movement
-        if( m_mouseMoved && System.currentTimeMillis() - ComputerCraft.mouseMoveThrottle > m_lastMouseMove )
-        {
-            IComputer computer = m_computer.getComputer();
-            if( computer != null )
-            {
-                computer.mouseMove(
-                    m_lastMouseX == -1 ? -1 : m_lastMouseX + 1,
-                    m_lastMouseY == -1 ? -1 : m_lastMouseY + 1
-                );
-            }
-
-            m_mouseMoved = false;
-            m_lastMouseMove = System.currentTimeMillis();
         }
     }
 

--- a/src/main/java/dan200/computercraft/client/gui/widgets/WidgetTerminal.java
+++ b/src/main/java/dan200/computercraft/client/gui/widgets/WidgetTerminal.java
@@ -226,51 +226,38 @@ public class WidgetTerminal extends Widget
                 charX = Math.min( Math.max( charX, 0 ), term.getWidth() - 1 );
                 charY = Math.min( Math.max( charY, 0 ), term.getHeight() - 1 );
 
-                handleMouseClick( computer, charX, charY );
-                handleMouseWheel( computer, charX, charY );
+                if( m_lastClickButton >= 0 && !Mouse.isButtonDown( m_lastClickButton ) )
+                {
+                    if( m_focus ) computer.mouseUp( m_lastClickButton + 1, charX + 1, charY + 1 );
+                    m_lastClickButton = -1;
+                }
+
+                int wheelChange = Mouse.getEventDWheel();
+                if( m_focus )
+                {
+                    if( wheelChange < 0 )
+                    {
+                        computer.mouseScroll( 1, charX + 1, charY + 1 );
+                    }
+                    else if( wheelChange > 0 )
+                    {
+                        computer.mouseScroll( -1, charX + 1, charY + 1 );
+                    }
+
+                    if( m_lastClickButton >= 0 && (charX != m_lastClickX || charY != m_lastClickY) )
+                    {
+                        computer.mouseDrag( m_lastClickButton + 1, charX + 1, charY + 1 );
+                        m_lastClickX = charX;
+                        m_lastClickY = charY;
+                    }
+                }
+
                 handleMouseMove( computer, charX, charY );
             }
         }
         else // The mouse has moved out of the terminal, send a -1, -1 mouse_move event
         {
             handleMouseMove( computer, -1, -1 );
-        }
-    }
-
-    private void handleMouseClick( IComputer computer, int charX, int charY )
-    {
-        if( m_lastClickButton >= 0 && !Mouse.isButtonDown( m_lastClickButton ) )
-        {
-            if( m_focus ) computer.mouseUp( m_lastClickButton + 1, charX + 1, charY + 1 );
-            m_lastClickButton = -1;
-        }
-    }
-
-    private void handleMouseWheel( IComputer computer, int charX, int charY )
-    {
-        int wheelChange = Mouse.getEventDWheel();
-        if( wheelChange == 0 && m_lastClickButton == -1 )
-        {
-            return;
-        }
-
-        if( m_focus )
-        {
-            if( wheelChange < 0 )
-            {
-                computer.mouseScroll( 1, charX + 1, charY + 1 );
-            }
-            else if( wheelChange > 0 )
-            {
-                computer.mouseScroll( -1, charX + 1, charY + 1 );
-            }
-
-            if( m_lastClickButton >= 0 && (charX != m_lastClickX || charY != m_lastClickY) )
-            {
-                computer.mouseDrag( m_lastClickButton + 1, charX + 1, charY + 1 );
-                m_lastClickX = charX;
-                m_lastClickY = charY;
-            }
         }
     }
 

--- a/src/main/java/dan200/computercraft/shared/Config.java
+++ b/src/main/java/dan200/computercraft/shared/Config.java
@@ -121,7 +121,7 @@ public final class Config
                 "This makes it easier for mod authors to debug problems, but may result in log spam should people use buggy methods." );
 
             mouseMoveThrottle = config.get( CATEGORY_GENERAL, "mouse_move_throttle", (int) ComputerCraft.mouseMoveThrottle );
-            mouseMoveThrottle.setComment( "The minimum time between sending mouse_move events, in milliseconds.\n" +
+            mouseMoveThrottle.setComment( "The minimum time between sending mouse_move events, in ticks.\n" +
                 "Set to -1 to disable mouse_move events entirely." );
 
             setOrder(

--- a/src/main/java/dan200/computercraft/shared/Config.java
+++ b/src/main/java/dan200/computercraft/shared/Config.java
@@ -47,6 +47,7 @@ public final class Config
     private static Property defaultComputerSettings;
     private static Property debugEnabled;
     private static Property logComputerErrors;
+    private static Property mouseMoveThrottle;
 
     private static Property computerThreads;
     private static Property maxMainGlobalTime;
@@ -119,10 +120,15 @@ public final class Config
             logComputerErrors.setComment( "Log exceptions thrown by peripherals and other Lua objects.\n" +
                 "This makes it easier for mod authors to debug problems, but may result in log spam should people use buggy methods." );
 
+            mouseMoveThrottle = config.get( CATEGORY_GENERAL, "mouse_move_throttle", (int) ComputerCraft.mouseMoveThrottle );
+            mouseMoveThrottle.setComment( "The minimum time between sending mouse_move events, in milliseconds.\n" +
+                "Set to -1 to disable mouse_move events entirely." );
+
             setOrder(
                 CATEGORY_GENERAL,
                 computerSpaceLimit, floppySpaceLimit, maximumFilesOpen,
-                disableLua51Features, defaultComputerSettings, debugEnabled, logComputerErrors
+                disableLua51Features, defaultComputerSettings, debugEnabled, logComputerErrors,
+                mouseMoveThrottle
             );
         }
 
@@ -441,6 +447,7 @@ public final class Config
         ComputerCraft.default_computer_settings = defaultComputerSettings.getString();
         ComputerCraft.debug_enable = debugEnabled.getBoolean();
         ComputerCraft.logPeripheralErrors = logComputerErrors.getBoolean();
+        ComputerCraft.mouseMoveThrottle = mouseMoveThrottle.getLong();
 
         // Execution
         ComputerCraft.computer_threads = computerThreads.getInt();

--- a/src/main/java/dan200/computercraft/shared/computer/core/ClientComputer.java
+++ b/src/main/java/dan200/computercraft/shared/computer/core/ClientComputer.java
@@ -149,6 +149,12 @@ public class ClientComputer extends ClientTerminal implements IComputer
         NetworkHandler.sendToServer( new MouseEventServerMessage( m_instanceID, MouseEventServerMessage.TYPE_SCROLL, direction, x, y ) );
     }
 
+    @Override
+    public void mouseMove( int x, int y )
+    {
+        NetworkHandler.sendToServer( new MouseEventServerMessage( m_instanceID, MouseEventServerMessage.TYPE_MOVE, x, y ) );
+    }
+
     public void setState( ComputerState state, NBTTagCompound userData )
     {
         boolean oldOn = m_on;

--- a/src/main/java/dan200/computercraft/shared/computer/core/InputHandler.java
+++ b/src/main/java/dan200/computercraft/shared/computer/core/InputHandler.java
@@ -44,4 +44,9 @@ public interface InputHandler
     {
         queueEvent( "mouse_scroll", new Object[] { direction, x, y } );
     }
+
+    default void mouseMove( int x, int y )
+    {
+        queueEvent( "mouse_move", new Object[] { x, y } );
+    }
 }

--- a/src/main/java/dan200/computercraft/shared/computer/core/InputHandler.java
+++ b/src/main/java/dan200/computercraft/shared/computer/core/InputHandler.java
@@ -47,6 +47,13 @@ public interface InputHandler
 
     default void mouseMove( int x, int y )
     {
-        queueEvent( "mouse_move", new Object[] { x, y } );
+        // Always send the first argument (e.g. button, direction) as 1, to maintain
+        // backwards compatibility with programs that perform blanket-handling for
+        // all mouse events. Off-screen mouse movements (-1) are translated to nil.
+        queueEvent( "mouse_move", new Object[] { 1, x == -1 ? null : x, y == -1 ? null : y } );
+    }
+
+    default void update()
+    {
     }
 }

--- a/src/main/java/dan200/computercraft/shared/computer/core/InputState.java
+++ b/src/main/java/dan200/computercraft/shared/computer/core/InputState.java
@@ -27,6 +27,7 @@ public class InputState implements InputHandler
     private int lastMouseMoveY = -1;
     private long lastMouseMove = -1;
     private boolean mouseMoved = false;
+    private long ticks = 0;
 
     public InputState( IContainerComputer owner )
     {
@@ -120,8 +121,10 @@ public class InputState implements InputHandler
     @Override
     public void update()
     {
+        ticks++;
+
         // Handle mouse_move throttling:
-        if( mouseMoved && System.currentTimeMillis() - ComputerCraft.mouseMoveThrottle > lastMouseMove )
+        if( mouseMoved && ticks - ComputerCraft.mouseMoveThrottle > lastMouseMove )
         {
             IComputer computer = owner.getComputer();
             if( computer != null )
@@ -133,7 +136,7 @@ public class InputState implements InputHandler
             }
 
             mouseMoved = false;
-            lastMouseMove = System.currentTimeMillis();
+            lastMouseMove = ticks;
         }
     }
 

--- a/src/main/java/dan200/computercraft/shared/computer/core/ServerComputerRegistry.java
+++ b/src/main/java/dan200/computercraft/shared/computer/core/ServerComputerRegistry.java
@@ -5,6 +5,11 @@
  */
 package dan200.computercraft.shared.computer.core;
 
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.inventory.Container;
+import net.minecraft.server.MinecraftServer;
+import net.minecraftforge.fml.common.FMLCommonHandler;
+
 import java.util.Iterator;
 
 public class ServerComputerRegistry extends ComputerRegistry<ServerComputer>
@@ -30,6 +35,21 @@ public class ServerComputerRegistry extends ComputerRegistry<ServerComputer>
                 {
                     computer.broadcastState( false );
                 }
+            }
+        }
+
+        // Check for computer containers to run InputState.update() on them
+        FMLCommonHandler handler = FMLCommonHandler.instance();
+        if( handler != null )
+        {
+            MinecraftServer server = handler.getMinecraftServerInstance();
+            for( EntityPlayerMP player : server.getPlayerList().getPlayers() )
+            {
+                Container container = player.openContainer;
+                if( !(container instanceof IContainerComputer) ) continue;
+
+                IContainerComputer computerContainer = (IContainerComputer) container;
+                computerContainer.getInput().update();
             }
         }
     }

--- a/src/main/java/dan200/computercraft/shared/network/server/MouseEventServerMessage.java
+++ b/src/main/java/dan200/computercraft/shared/network/server/MouseEventServerMessage.java
@@ -18,6 +18,7 @@ public class MouseEventServerMessage extends ComputerServerMessage
     public static final int TYPE_DRAG = 1;
     public static final int TYPE_UP = 2;
     public static final int TYPE_SCROLL = 3;
+    public static final int TYPE_MOVE = 4;
 
     private int type;
     private int x;
@@ -31,6 +32,11 @@ public class MouseEventServerMessage extends ComputerServerMessage
         this.arg = arg;
         this.x = x;
         this.y = y;
+    }
+
+    public MouseEventServerMessage( int instanceId, int type, int x, int y )
+    {
+        this( instanceId, type, 0, x, y );
     }
 
     public MouseEventServerMessage()
@@ -74,6 +80,9 @@ public class MouseEventServerMessage extends ComputerServerMessage
                 break;
             case TYPE_SCROLL:
                 input.mouseScroll( arg, x, y );
+                break;
+            case TYPE_MOVE:
+                input.mouseMove( x, y );
                 break;
         }
     }

--- a/src/main/resources/assets/computercraft/lang/de_de.lang
+++ b/src/main/resources/assets/computercraft/lang/de_de.lang
@@ -159,7 +159,7 @@ gui.computercraft:config.disable_lua51_features=Lua 5.1-Funktionen deaktivieren
 gui.computercraft:config.default_computer_settings=Computer-Standardeinstellungen
 gui.computercraft:config.debug_enabled=Debug-Library aktivieren
 gui.computercraft:config.log_computer_errors=Computerfehler loggen
-gui.computercraft:config.mouse_move_throttle=Zeit zwischen mouse_move Events (Millisekunden)
+gui.computercraft:config.mouse_move_throttle=Zeit zwischen mouse_move Events (Serverticks)
 
 gui.computercraft:config.execution=Ausführung
 gui.computercraft:config.execution.computer_threads=Computer Threads

--- a/src/main/resources/assets/computercraft/lang/de_de.lang
+++ b/src/main/resources/assets/computercraft/lang/de_de.lang
@@ -159,6 +159,7 @@ gui.computercraft:config.disable_lua51_features=Lua 5.1-Funktionen deaktivieren
 gui.computercraft:config.default_computer_settings=Computer-Standardeinstellungen
 gui.computercraft:config.debug_enabled=Debug-Library aktivieren
 gui.computercraft:config.log_computer_errors=Computerfehler loggen
+gui.computercraft:config.mouse_move_throttle=Zeit zwischen mouse_move Events (Millisekunden)
 
 gui.computercraft:config.execution=Ausführung
 gui.computercraft:config.execution.computer_threads=Computer Threads

--- a/src/main/resources/assets/computercraft/lang/en_us.lang
+++ b/src/main/resources/assets/computercraft/lang/en_us.lang
@@ -159,7 +159,7 @@ gui.computercraft:config.disable_lua51_features=Disable Lua 5.1 features
 gui.computercraft:config.default_computer_settings=Default Computer settings
 gui.computercraft:config.debug_enabled=Enable debug library
 gui.computercraft:config.log_computer_errors=Log computer errors
-gui.computercraft:config.mouse_move_throttle=Time between mouse_move events (millis)
+gui.computercraft:config.mouse_move_throttle=Time between mouse_move events (ticks)
 
 gui.computercraft:config.execution=Execution
 gui.computercraft:config.execution.computer_threads=Computer threads

--- a/src/main/resources/assets/computercraft/lang/en_us.lang
+++ b/src/main/resources/assets/computercraft/lang/en_us.lang
@@ -159,6 +159,7 @@ gui.computercraft:config.disable_lua51_features=Disable Lua 5.1 features
 gui.computercraft:config.default_computer_settings=Default Computer settings
 gui.computercraft:config.debug_enabled=Enable debug library
 gui.computercraft:config.log_computer_errors=Log computer errors
+gui.computercraft:config.mouse_move_throttle=Time between mouse_move events (millis)
 
 gui.computercraft:config.execution=Execution
 gui.computercraft:config.execution.computer_threads=Computer threads

--- a/src/main/resources/assets/computercraft/lang/es_es.lang
+++ b/src/main/resources/assets/computercraft/lang/es_es.lang
@@ -55,6 +55,7 @@ gui.computercraft:config.maximum_open_files=Archivos abiertos máximos por cada 
 gui.computercraft:config.disable_lua51_features=Deshabilitar funciones de Lua 5.1
 gui.computercraft:config.default_computer_settings=Configuración de Ordenador por defecto
 gui.computercraft:config.log_computer_errors=Grabar errores periféricos
+gui.computercraft:config.mouse_move_throttle=Tiempo entre los eventos mouse_move (milisegundos)
 
 gui.computercraft:config.http.enabled=Habilitar API de HTTP
 gui.computercraft:config.http.allowed_domains=Lista blanca de HTTP

--- a/src/main/resources/assets/computercraft/lang/es_es.lang
+++ b/src/main/resources/assets/computercraft/lang/es_es.lang
@@ -55,7 +55,7 @@ gui.computercraft:config.maximum_open_files=Archivos abiertos máximos por cada 
 gui.computercraft:config.disable_lua51_features=Deshabilitar funciones de Lua 5.1
 gui.computercraft:config.default_computer_settings=Configuración de Ordenador por defecto
 gui.computercraft:config.log_computer_errors=Grabar errores periféricos
-gui.computercraft:config.mouse_move_throttle=Tiempo entre los eventos mouse_move (milisegundos)
+gui.computercraft:config.mouse_move_throttle=Tiempo entre los eventos mouse_move (ticks)
 
 gui.computercraft:config.http.enabled=Habilitar API de HTTP
 gui.computercraft:config.http.allowed_domains=Lista blanca de HTTP

--- a/src/main/resources/assets/computercraft/lang/fr_fr.lang
+++ b/src/main/resources/assets/computercraft/lang/fr_fr.lang
@@ -55,6 +55,7 @@ gui.computercraft:config.maximum_open_files=Maximum de fichier ouvert par Ordina
 gui.computercraft:config.disable_lua51_features=Désactiver les particularités de Lua 5.1
 gui.computercraft:config.default_computer_settings=Configuration d'Ordinateur par défaut
 gui.computercraft:config.log_computer_errors=Journal d'erreur périphériques
+gui.computercraft:config.mouse_move_throttle=Limitation des events mouse_move (millis)
 
 gui.computercraft:config.http.enabled=Permettre l'API HTTP
 gui.computercraft:config.http.allowed_domains=HTTP liste blanche

--- a/src/main/resources/assets/computercraft/lang/fr_fr.lang
+++ b/src/main/resources/assets/computercraft/lang/fr_fr.lang
@@ -55,7 +55,7 @@ gui.computercraft:config.maximum_open_files=Maximum de fichier ouvert par Ordina
 gui.computercraft:config.disable_lua51_features=Désactiver les particularités de Lua 5.1
 gui.computercraft:config.default_computer_settings=Configuration d'Ordinateur par défaut
 gui.computercraft:config.log_computer_errors=Journal d'erreur périphériques
-gui.computercraft:config.mouse_move_throttle=Limitation des events mouse_move (millis)
+gui.computercraft:config.mouse_move_throttle=Limitation des events mouse_move (ticks)
 
 gui.computercraft:config.http.enabled=Permettre l'API HTTP
 gui.computercraft:config.http.allowed_domains=HTTP liste blanche

--- a/src/main/resources/assets/computercraft/lang/pt_br.lang
+++ b/src/main/resources/assets/computercraft/lang/pt_br.lang
@@ -57,6 +57,7 @@ gui.computercraft:config.disable_lua51_features=Desabilitar funcionalidade da Lu
 gui.computercraft:config.default_computer_settings=Configurações padrão para Computadores
 gui.computercraft:config.debug_enabled=Habilitar biblioteca de debug
 gui.computercraft:config.log_computer_errors=Registrar erros de computadores
+gui.computercraft:config.mouse_move_throttle=Tempo entre eventos mouse_move (milissegundos)
 
 gui.computercraft:config.execution.computer_threads=Threads por computador
 

--- a/src/main/resources/assets/computercraft/lang/pt_br.lang
+++ b/src/main/resources/assets/computercraft/lang/pt_br.lang
@@ -57,7 +57,7 @@ gui.computercraft:config.disable_lua51_features=Desabilitar funcionalidade da Lu
 gui.computercraft:config.default_computer_settings=Configurações padrão para Computadores
 gui.computercraft:config.debug_enabled=Habilitar biblioteca de debug
 gui.computercraft:config.log_computer_errors=Registrar erros de computadores
-gui.computercraft:config.mouse_move_throttle=Tempo entre eventos mouse_move (milissegundos)
+gui.computercraft:config.mouse_move_throttle=Tempo entre eventos mouse_move (ticks)
 
 gui.computercraft:config.execution.computer_threads=Threads por computador
 

--- a/src/main/resources/assets/computercraft/lang/zh_cn.lang
+++ b/src/main/resources/assets/computercraft/lang/zh_cn.lang
@@ -159,7 +159,7 @@ gui.computercraft:config.disable_lua51_features=禁用Lua 5.1功能
 gui.computercraft:config.default_computer_settings=默认计算机设置
 gui.computercraft:config.debug_enabled=启用debug库
 gui.computercraft:config.log_computer_errors=记录计算机错误
-gui.computercraft:config.mouse_move_throttle=mouse_event事件的间隔时间(毫秒)
+gui.computercraft:config.mouse_move_throttle=mouse_event事件的间隔时间(ticks)
 
 gui.computercraft:config.execution=执行
 gui.computercraft:config.execution.computer_threads=计算机线程数

--- a/src/main/resources/assets/computercraft/lang/zh_cn.lang
+++ b/src/main/resources/assets/computercraft/lang/zh_cn.lang
@@ -159,6 +159,7 @@ gui.computercraft:config.disable_lua51_features=禁用Lua 5.1功能
 gui.computercraft:config.default_computer_settings=默认计算机设置
 gui.computercraft:config.debug_enabled=启用debug库
 gui.computercraft:config.log_computer_errors=记录计算机错误
+gui.computercraft:config.mouse_move_throttle=mouse_event事件的间隔时间(毫秒)
 
 gui.computercraft:config.execution=执行
 gui.computercraft:config.execution.computer_threads=计算机线程数

--- a/src/main/resources/assets/computercraft/lua/rom/help/events.txt
+++ b/src/main/resources/assets/computercraft/lua/rom/help/events.txt
@@ -11,5 +11,6 @@ Events only on advanced computers:
 "mouse_drag" when a user moves the mouse when held. Arguments are button, xPos, yPos.
 "mouse_up" when a user releases the mouse button. Arguments are button, xPos, yPos.
 "mouse_scroll" when a user uses the scrollwheel on the mouse. Arguments are direction, xPos, yPos.
+"mouse_move" when a user moves the mouse within the terminal. Arguments xPos, yPos. xPos and yPos will be -1, -1 when the mouse is moved outside of the terminal.
 
 Other APIs and peripherals will emit their own events. See their respective help pages for details.

--- a/src/main/resources/assets/computercraft/lua/rom/help/events.txt
+++ b/src/main/resources/assets/computercraft/lua/rom/help/events.txt
@@ -11,6 +11,6 @@ Events only on advanced computers:
 "mouse_drag" when a user moves the mouse when held. Arguments are button, xPos, yPos.
 "mouse_up" when a user releases the mouse button. Arguments are button, xPos, yPos.
 "mouse_scroll" when a user uses the scrollwheel on the mouse. Arguments are direction, xPos, yPos.
-"mouse_move" when a user moves the mouse within the terminal. Arguments xPos, yPos. xPos and yPos will be -1, -1 when the mouse is moved outside of the terminal.
+"mouse_move" when a user moves the mouse within the terminal. Arguments xPos, yPos. xPos and yPos will be nil, nil when the mouse leaves the terminal.
 
 Other APIs and peripherals will emit their own events. See their respective help pages for details.

--- a/src/main/resources/assets/computercraft/lua/rom/help/events.txt
+++ b/src/main/resources/assets/computercraft/lua/rom/help/events.txt
@@ -11,6 +11,6 @@ Events only on advanced computers:
 "mouse_drag" when a user moves the mouse when held. Arguments are button, xPos, yPos.
 "mouse_up" when a user releases the mouse button. Arguments are button, xPos, yPos.
 "mouse_scroll" when a user uses the scrollwheel on the mouse. Arguments are direction, xPos, yPos.
-"mouse_move" when a user moves the mouse within the terminal. Arguments xPos, yPos. xPos and yPos will be nil, nil when the mouse leaves the terminal.
+"mouse_move" when a user moves the mouse within the terminal. Arguments are button, xPos, yPos. button is always 1. xPos and yPos will both be nil when the mouse leaves the terminal.
 
 Other APIs and peripherals will emit their own events. See their respective help pages for details.

--- a/src/main/resources/assets/computercraft/lua/rom/programs/advanced/multishell.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/programs/advanced/multishell.lua
@@ -387,10 +387,10 @@ while #tProcesses > 0 do
         elseif not (bShowMenu and y == 1) then
             -- Passthrough to current process
             if x == nil or y == nil then -- Handle mouse_move nil events
-				resumeProcess(nCurrentProcess, sEvent, p1, nil, nil)
+                resumeProcess(nCurrentProcess, sEvent, p1, nil, nil)
             else
-				resumeProcess(nCurrentProcess, sEvent, p1, x, bShowMenu and y - 1 or y)
-			end
+                resumeProcess(nCurrentProcess, sEvent, p1, x, bShowMenu and y - 1 or y)
+            end
 
             if cullProcess(nCurrentProcess) then
                 setMenuVisible(#tProcesses >= 2)

--- a/src/main/resources/assets/computercraft/lua/rom/programs/advanced/multishell.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/programs/advanced/multishell.lua
@@ -373,9 +373,14 @@ while #tProcesses > 0 do
             end
         end
 
-    elseif sEvent == "mouse_drag" or sEvent == "mouse_up" or sEvent == "mouse_scroll" then
+    elseif sEvent == "mouse_drag" or sEvent == "mouse_up" or sEvent == "mouse_scroll" or sEvent == "mouse_move" then
         -- Other mouse event
         local p1, x, y = tEventData[2], tEventData[3], tEventData[4]
+
+        if sEvent == "mouse_move" then
+        	p1, x, y = 0, tEventData[2], tEventData[3]
+        end
+
         if bShowMenu and sEvent == "mouse_scroll" and y == 1 then
             if p1 == -1 and nScrollPos ~= 1 then
                 nScrollPos = nScrollPos - 1
@@ -386,7 +391,12 @@ while #tProcesses > 0 do
             end
         elseif not (bShowMenu and y == 1) then
             -- Passthrough to current process
-            resumeProcess(nCurrentProcess, sEvent, p1, x, bShowMenu and y - 1 or y)
+            if sEvent == "mouse_move" then
+            	resumeProcess(nCurrentProcess, sEvent, x, bShowMenu and y - 1 or y)
+            else
+            	resumeProcess(nCurrentProcess, sEvent, p1, x, bShowMenu and y - 1 or y)
+            end
+
             if cullProcess(nCurrentProcess) then
                 setMenuVisible(#tProcesses >= 2)
                 redrawMenu()

--- a/src/main/resources/assets/computercraft/lua/rom/programs/advanced/multishell.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/programs/advanced/multishell.lua
@@ -376,11 +376,6 @@ while #tProcesses > 0 do
     elseif sEvent == "mouse_drag" or sEvent == "mouse_up" or sEvent == "mouse_scroll" or sEvent == "mouse_move" then
         -- Other mouse event
         local p1, x, y = tEventData[2], tEventData[3], tEventData[4]
-
-        if sEvent == "mouse_move" then
-        	p1, x, y = 0, tEventData[2], tEventData[3]
-        end
-
         if bShowMenu and sEvent == "mouse_scroll" and y == 1 then
             if p1 == -1 and nScrollPos ~= 1 then
                 nScrollPos = nScrollPos - 1
@@ -391,11 +386,11 @@ while #tProcesses > 0 do
             end
         elseif not (bShowMenu and y == 1) then
             -- Passthrough to current process
-            if sEvent == "mouse_move" then
-            	resumeProcess(nCurrentProcess, sEvent, x, bShowMenu and y - 1 or y)
+            if x == nil or y == nil then -- Handle mouse_move nil events
+				resumeProcess(nCurrentProcess, sEvent, p1, nil, nil)
             else
-            	resumeProcess(nCurrentProcess, sEvent, p1, x, bShowMenu and y - 1 or y)
-            end
+				resumeProcess(nCurrentProcess, sEvent, p1, x, bShowMenu and y - 1 or y)
+			end
 
             if cullProcess(nCurrentProcess) then
                 setMenuVisible(#tProcesses >= 2)


### PR DESCRIPTION
This implements the first half of #433. I'm not actually interested in implementing `term.getMousePosition()` from that issue out of fear of issues with multiple players, and having to implement some kind of polling system for that. Such a feature may be better suited for the `window` API.

When the cursor is moved within the terminal on any client, a `mouse_move` event is issued with the `xPos` and `yPos` parameters (in characters, as usual). If the cursor moves from inside to outside the terminal's region, the position `-1, -1` is sent. This allows the program to deactivate any element that is currently hovered. [This program](https://pastebin.com/nvttbria) demonstrates that by turning the screen red (with throttle disabled):

![mouse_move](https://user-images.githubusercontent.com/858456/80661341-4f5d8080-8a86-11ea-8437-9c4d8961ab3d.gif)

To solve the issue with bandwidth, there is a config option for throttling, `mouse_move_throttle`. By default, this is 200ms, and is implemented as a leading-edge debounce. 200ms will be fine for servers, as I wouldn't recommend anyone build programs with a 'cursor' anyway (due to issues raised in #409). Instead, this is more useful for things like buttons. The feature can be disabled entirely by setting the throttle time in the config to `-1`.

It's worth noting that `mouse_drag` does not have a throttle, but those events are less likely to happen compared to `mouse_move` events. It's simple to copy the code to implement a drag throttle if needed, though.

Multiple players in a computer works no differently to `mouse_drag`, that is - the events are simply multiplexed with no distinction between players. I think this will be _fine_, given that the events are only sent if the mouse actually moves.

One more concern is throttle configuration. I've simply used the same configuration as everything else at the moment. In my understanding of Forge, mod configs are synchronised to the player when they connect, but I don't know if there's anything that stops the player from reconfiguring it client-side. It may be worth reviewing this.

I've tested this on all kinds of computers (Computer, Pocket Computer, Turtle, Neural Interface). Basic computers do not transmit mouse events at all, so this works perfectly.

# TO-DO
- [x] Fix multishell/window API support
- [ ] Update CCEmuX
- [ ] Port to 1.14+

# Thoughts
- I'm not 100% sure about sending -1, -1 as the position for the mouse being outside the terminal. Perhaps `nil, nil` would be better, but it could break programs that perform blanket handling of mouse events? The other solution is another event, e.g. `lose_focus`.
- The multishell code is **ugly**, as a result of not sending the additional argument with the mouse event. Perhaps it should be sent, but always as `nil` or `0`, just to be fully compatible with all the other mouse events?

# Thanks
- [znepb](https://github.com/znepb) for #433 
- [Anavrins](https://github.com/Anavrins) for the French translation
- [Abigail](https://github.com/plt-hokusai) for the Portuguese translation
- [Repflez](https://github.com/Repflez) for the Spanish translation
- [1lann](https://github.com/1lann) for the Chinese translation