### PR TITLE
Return the peripheral name when wrapping

### DIFF
--- a/src/main/resources/assets/computercraft/lua/rom/apis/peripheral.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/apis/peripheral.lua
@@ -154,6 +154,7 @@ function wrap(name)
             return peripheral.call(name, method, ...)
         end
     end
+    result.name = name
     return result
 end
 

--- a/src/main/resources/assets/computercraft/lua/rom/apis/peripheral.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/apis/peripheral.lua
@@ -173,7 +173,7 @@ function wrap(name)
     local result = setmetatable({}, {
         __name = "peripheral",
         name = name,
-        type = peripheral.getType(name)
+        type = peripheral.getType(name),
     })
     for _, method in ipairs(methods) do
         result[method] = function(...)

--- a/src/main/resources/assets/computercraft/lua/rom/apis/peripheral.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/apis/peripheral.lua
@@ -113,7 +113,7 @@ function getName(peripheral)
     expect(1, peripheral, "table")
     local mt = getmetatable(peripheral)
     if not mt or mt.__name ~= "peripheral" or type(mt.name) ~= "string" then
-        error("Could not get peripheral name")
+        error("bad argument #1 (table is not a peripheral)", 2)
     end
     return mt.name
 end
@@ -167,7 +167,6 @@ function wrap(name)
             return peripheral.call(name, method, ...)
         end
     end
-    result.name = name
     return result
 end
 

--- a/src/main/resources/assets/computercraft/lua/rom/apis/peripheral.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/apis/peripheral.lua
@@ -64,24 +64,33 @@ function isPresent(name)
     return false
 end
 
---- Get the type of the peripheral with the given name.
+--- Get the type of a wrapped peripheral, or a peripheral with the given name.
 --
--- @tparam string name The name of the peripheral to find.
+-- @tparam string|table peripheral The name of the peripheral to find, or a
+-- wrapped peripheral instance.
 -- @treturn string|nil The peripheral's type, or `nil` if it is not present.
-function getType(name)
-    expect(1, name, "string")
-    if native.isPresent(name) then
-        return native.getType(name)
-    end
-    for n = 1, #sides do
-        local side = sides[n]
-        if native.getType(side) == "modem" and not native.call(side, "isWireless") and
-            native.call(side, "isPresentRemote", name)
-        then
-            return native.call(side, "getTypeRemote", name)
+function getType(peripheral)
+    expect(1, peripheral, "string", "table")
+    if type(peripheral) == "string" then -- Peripheral name passed
+        if native.isPresent(peripheral) then
+            return native.getType(peripheral)
         end
+        for n = 1, #sides do
+            local side = sides[n]
+            if native.getType(side) == "modem" and not native.call(side, "isWireless") and
+                native.call(side, "isPresentRemote", peripheral)
+            then
+                return native.call(side, "getTypeRemote", peripheral)
+            end
+        end
+        return nil
+    else
+        local mt = getmetatable(peripheral)
+        if not mt or mt.__name ~= "peripheral" or type(mt.type) ~= "string" then
+            error("bad argument #1 (table is not a peripheral)", 2)
+        end
+        return mt.type
     end
-    return nil
 end
 
 --- Get all available methods for the peripheral with the given name.
@@ -161,7 +170,11 @@ function wrap(name)
         return nil
     end
 
-    local result = setmetatable({}, { __name = "peripheral", name = name })
+    local result = setmetatable({}, {
+        __name = "peripheral",
+        name = name,
+        type = peripheral.getType(name)
+    })
     for _, method in ipairs(methods) do
         result[method] = function(...)
             return peripheral.call(name, method, ...)

--- a/src/main/resources/assets/computercraft/lua/rom/apis/peripheral.lua
+++ b/src/main/resources/assets/computercraft/lua/rom/apis/peripheral.lua
@@ -105,6 +105,19 @@ function getMethods(name)
     return nil
 end
 
+--- Get the name of a peripheral wrapped with @{peripheral.wrap}.
+--
+-- @tparam table peripheral The peripheral to get the name of.
+-- @treturn string The name of the given peripheral.
+function getName(peripheral)
+    expect(1, peripheral, "table")
+    local mt = getmetatable(peripheral)
+    if not mt or mt.__name ~= "peripheral" or type(mt.name) ~= "string" then
+        error("Could not get peripheral name")
+    end
+    return mt.name
+end
+
 --- Call a method on the peripheral with the given name.
 --
 -- @tparam string name The name of the peripheral to invoke the method on.
@@ -148,7 +161,7 @@ function wrap(name)
         return nil
     end
 
-    local result = {}
+    local result = setmetatable({}, { __name = "peripheral", name = name })
     for _, method in ipairs(methods) do
         result[method] = function(...)
             return peripheral.call(name, method, ...)

--- a/src/main/resources/assets/computercraft/lua/rom/help/peripheral.txt
+++ b/src/main/resources/assets/computercraft/lua/rom/help/peripheral.txt
@@ -3,6 +3,7 @@ The peripheral API is for interacting with external peripheral devices. Type "he
 Functions in the peripheral API:
 peripheral.getNames()
 peripheral.isPresent( name )
+peripheral.getName( peripheral )
 peripheral.getType( name )
 peripheral.getMethods( name )
 peripheral.call( name, methodName, param1, param2, etc )

--- a/src/test/resources/test-rom/spec/apis/peripheral_spec.lua
+++ b/src/test/resources/test-rom/spec/apis/peripheral_spec.lua
@@ -8,10 +8,30 @@ describe("The peripheral library", function()
         end)
     end)
 
+    describe("peripheral.getName", function()
+        it("validates arguments", function()
+            expect.error(peripheral.getName, nil):eq("bad argument #1 (expected table, got nil)")
+            expect.error(peripheral.getName, {}):eq("bad argument #1 (table is not a peripheral)")
+        end)
+
+        it_modem("can get the name of a wrapped peripheral", function()
+            expect(peripheral.getName(peripheral.wrap("top"))):eq("top")
+        end)
+    end)
+
     describe("peripheral.getType", function()
         it("validates arguments", function()
             peripheral.getType("")
-            expect.error(peripheral.getType, nil):eq("bad argument #1 (expected string, got nil)")
+            expect.error(peripheral.getType, nil):eq("bad argument #1 (expected string or table, got nil)")
+            expect.error(peripheral.getType, {}):eq("bad argument #1 (table is not a peripheral)")
+        end)
+
+        it_modem("can get the type of a peripheral by side", function()
+            expect(peripheral.getType("top")):eq("modem")
+        end)
+
+        it_modem("can get the type of a wrapped peripheral", function()
+            expect(peripheral.getType(peripheral.wrap("top"))):eq("modem")
         end)
     end)
 


### PR DESCRIPTION
This is an incredibly simple, extremely useful, but potentially controversial change. This returns the name of the peripheral when wrapping it. This is useful when performing `peripheral.find()`, especially in bulk, to get the side name of the peripheral that was wrapped, for example:

```lua
local disks = table.pack(peripheral.find("drive"))

print("Found", disks.n, "disk drives."))

for _, disk in pairs(disks) do
    print("Disk drive", disk.name, disk.isDiskPresent() and "has a disk." or "does not have a disk.")
end
```

This implementation is extremely naïve, so this PR is more of a request for comments than anything. It shadows any peripheral methods called `name`, and while I'm not aware of any, this could potentially be bizarre or breaking behaviour in an extreme edge case. As such, it could perhaps be moved to run before the methods are populated when wrapping, or named to something else, such as `peripheralName`. Curious to hear your thoughts.