### PR TITLE
Preserve computer ids on unlabelled computers

### DIFF
--- a/src/main/java/dan200/computercraft/shared/computer/blocks/BlockComputerBase.java
+++ b/src/main/java/dan200/computercraft/shared/computer/blocks/BlockComputerBase.java
@@ -128,7 +128,7 @@ public abstract class BlockComputerBase extends BlockDirectional
             if( tile instanceof TileComputerBase )
             {
                 TileComputerBase computer = (TileComputerBase) tile;
-                if( !player.capabilities.isCreativeMode || computer.getLabel() != null )
+                if( !player.capabilities.isCreativeMode || computer.getLabel() != null || computer.getComputerID() != -1 )
                 {
                     spawnAsEntity( world, pos, getItem( computer ) );
                 }

--- a/src/main/java/dan200/computercraft/shared/computer/items/ComputerItemFactory.java
+++ b/src/main/java/dan200/computercraft/shared/computer/items/ComputerItemFactory.java
@@ -19,9 +19,7 @@ public final class ComputerItemFactory
     @Nonnull
     public static ItemStack create( TileComputer tile )
     {
-        String label = tile.getLabel();
-        int id = label != null ? tile.getComputerID() : -1;
-        return create( id, label, tile.getFamily() );
+        return create( tile.getComputerID(), tile.getLabel(), tile.getFamily() );
     }
 
     @Nonnull

--- a/src/main/java/dan200/computercraft/shared/computer/items/ItemComputerBase.java
+++ b/src/main/java/dan200/computercraft/shared/computer/items/ItemComputerBase.java
@@ -39,7 +39,7 @@ public abstract class ItemComputerBase extends ItemBlock implements IComputerIte
     @Override
     public void addInformation( @Nonnull ItemStack stack, @Nullable World world, @Nonnull List<String> list, @Nonnull ITooltipFlag flag )
     {
-        if( flag.isAdvanced() )
+        if( flag.isAdvanced() || getLabel( stack ) == null )
         {
             int id = getComputerID( stack );
             if( id >= 0 ) list.add( StringUtil.translateFormatted( "gui.computercraft.tooltip.computer_id", id ) );

--- a/src/main/java/dan200/computercraft/shared/media/items/ItemDiskLegacy.java
+++ b/src/main/java/dan200/computercraft/shared/media/items/ItemDiskLegacy.java
@@ -80,7 +80,7 @@ public class ItemDiskLegacy extends Item implements IMedia, IColouredItem
     @Override
     public void addInformation( @Nonnull ItemStack stack, World world, List<String> list, ITooltipFlag flag )
     {
-        if( flag.isAdvanced() )
+        if( flag.isAdvanced() || getLabel( stack ) == null )
         {
             int id = getDiskID( stack );
             if( id >= 0 ) list.add( StringUtil.translateFormatted( "gui.computercraft.tooltip.disk_id", id ) );

--- a/src/main/java/dan200/computercraft/shared/pocket/items/ItemPocketComputer.java
+++ b/src/main/java/dan200/computercraft/shared/pocket/items/ItemPocketComputer.java
@@ -211,7 +211,7 @@ public class ItemPocketComputer extends Item implements IComputerItem, IMedia, I
     @Override
     public void addInformation( @Nonnull ItemStack stack, World world, List<String> list, ITooltipFlag flag )
     {
-        if( flag.isAdvanced() )
+        if( flag.isAdvanced() || getLabel( stack ) == null )
         {
             int id = getComputerID( stack );
             if( id >= 0 ) list.add( StringUtil.translateFormatted( "gui.computercraft.tooltip.computer_id", id ) );

--- a/src/main/java/dan200/computercraft/shared/turtle/items/TurtleItemFactory.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/items/TurtleItemFactory.java
@@ -6,6 +6,7 @@
 package dan200.computercraft.shared.turtle.items;
 
 import dan200.computercraft.ComputerCraft;
+import dan200.computercraft.api.turtle.ITurtleAccess;
 import dan200.computercraft.api.turtle.ITurtleUpgrade;
 import dan200.computercraft.api.turtle.TurtleSide;
 import dan200.computercraft.shared.computer.core.ComputerFamily;
@@ -22,18 +23,13 @@ public final class TurtleItemFactory
     @Nonnull
     public static ItemStack create( ITurtleTile turtle )
     {
-        ITurtleUpgrade leftUpgrade = turtle.getAccess().getUpgrade( TurtleSide.Left );
-        ITurtleUpgrade rightUpgrade = turtle.getAccess().getUpgrade( TurtleSide.Right );
+        ITurtleAccess access = turtle.getAccess();
 
-        String label = turtle.getLabel();
-        if( label == null )
-        {
-            return create( -1, null, turtle.getColour(), turtle.getFamily(), leftUpgrade, rightUpgrade, 0, turtle.getOverlay() );
-        }
-
-        int id = turtle.getComputerID();
-        int fuelLevel = turtle.getAccess().getFuelLevel();
-        return create( id, label, turtle.getColour(), turtle.getFamily(), leftUpgrade, rightUpgrade, fuelLevel, turtle.getOverlay() );
+        return create(
+            turtle.getComputerID(), turtle.getLabel(), turtle.getColour(), turtle.getFamily(),
+            access.getUpgrade( TurtleSide.Left ), access.getUpgrade( TurtleSide.Right ),
+            access.getFuelLevel(), turtle.getOverlay()
+        );
     }
 
     @Nonnull

--- a/src/main/resources/assets/computercraft/lang/da_dk.lang
+++ b/src/main/resources/assets/computercraft/lang/da_dk.lang
@@ -44,5 +44,5 @@ chat.computercraft.wired_modem.peripheral_disconnected=Perifer enhed "%s" koblet
 
 # Misc tooltips
 gui.computercraft.tooltip.copy=Kopier til udklipsholder
-gui.computercraft.tooltip.computer_id=(Computer-ID: %s)
-gui.computercraft.tooltip.disk_id=(Disk-ID: %s)
+gui.computercraft.tooltip.computer_id=Computer-ID: %s
+gui.computercraft.tooltip.disk_id=Disk-ID: %s

--- a/src/main/resources/assets/computercraft/lang/de_de.lang
+++ b/src/main/resources/assets/computercraft/lang/de_de.lang
@@ -148,8 +148,8 @@ tracking_field.computercraft.coroutines_dead.name=Koroutinen gelöscht
 
 # Misc tooltips
 gui.computercraft.tooltip.copy=In die Zwischenablage kopieren
-gui.computercraft.tooltip.computer_id=(Computer ID: %s)
-gui.computercraft.tooltip.disk_id=(Disketten ID: %s)
+gui.computercraft.tooltip.computer_id=Computer ID: %s
+gui.computercraft.tooltip.disk_id=Disketten ID: %s
 
 # Config options
 gui.computercraft:config.computer_space_limit=Speicherplatz von Computern (Bytes)

--- a/src/main/resources/assets/computercraft/lang/en_us.lang
+++ b/src/main/resources/assets/computercraft/lang/en_us.lang
@@ -148,8 +148,8 @@ tracking_field.computercraft.coroutines_dead.name=Coroutines disposed
 
 # Misc tooltips
 gui.computercraft.tooltip.copy=Copy to clipboard
-gui.computercraft.tooltip.computer_id=(Computer ID: %s)
-gui.computercraft.tooltip.disk_id=(Disk ID: %s)
+gui.computercraft.tooltip.computer_id=Computer ID: %s
+gui.computercraft.tooltip.disk_id=Disk ID: %s
 
 # Config options
 gui.computercraft:config.computer_space_limit=Computer space limit (bytes)

--- a/src/main/resources/assets/computercraft/lang/ko_kr.lang
+++ b/src/main/resources/assets/computercraft/lang/ko_kr.lang
@@ -148,8 +148,8 @@ tracking_field.computercraft.coroutines_dead.name=코루틴 처리됨
 
 # Misc tooltips
 gui.computercraft.tooltip.copy=클립보드에 복사
-gui.computercraft.tooltip.computer_id=(컴퓨터 ID: %s)
-gui.computercraft.tooltip.disk_id=(디스크 ID: %s)
+gui.computercraft.tooltip.computer_id=컴퓨터 ID: %s
+gui.computercraft.tooltip.disk_id=디스크 ID: %s
 
 # Config options
 gui.computercraft:config.computer_space_limit=컴퓨터 공간 제한 (바이트)

--- a/src/main/resources/assets/computercraft/lang/zh_cn.lang
+++ b/src/main/resources/assets/computercraft/lang/zh_cn.lang
@@ -148,8 +148,8 @@ tracking_field.computercraft.coroutines_dead.name=协同处理
 
 # Misc tooltips
 gui.computercraft.tooltip.copy=复制到剪贴板
-gui.computercraft.tooltip.computer_id=(计算机ID: %s)
-gui.computercraft.tooltip.disk_id=(磁盘ID: %s)
+gui.computercraft.tooltip.computer_id=计算机ID: %s
+gui.computercraft.tooltip.disk_id=磁盘ID: %s
 
 # Config options
 gui.computercraft:config.computer_space_limit=计算机空间限制(字节)


### PR DESCRIPTION
Breaking an unlabelled computer/turtle will now preserve all information about the computer, rather than resetting it.

In order to make things a little clearer, we display the id of unlabelled computers in the tooltip:

![Computer ID: 142](https://user-images.githubusercontent.com/4346137/80860697-4d034e00-8c61-11ea-85b2-f1ef548dcb94.png)

I'm not entirely happy with the tooltip - there's an argument it should be done in the label instead (i.e. `Advanced Computer #142`). I don't know which one is clearer.