### PR TITLE
 Add a monitor renderer using TBOs

### DIFF
--- a/src/main/java/dan200/computercraft/client/gui/FixedWidthFontRenderer.java
+++ b/src/main/java/dan200/computercraft/client/gui/FixedWidthFontRenderer.java
@@ -50,12 +50,12 @@ public final class FixedWidthFontRenderer
     {
     }
 
-    private static float toGreyscale( double[] rgb )
+    public static float toGreyscale( double[] rgb )
     {
         return (float) ((rgb[0] + rgb[1] + rgb[2]) / 3);
     }
 
-    private static int getColour( char c, Colour def )
+    public static int getColour( char c, Colour def )
     {
         return 15 - Terminal.getColour( c, def );
     }

--- a/src/main/java/dan200/computercraft/client/render/MonitorTextureBufferShader.java
+++ b/src/main/java/dan200/computercraft/client/render/MonitorTextureBufferShader.java
@@ -1,0 +1,176 @@
+/*
+ * This file is part of ComputerCraft - http://www.computercraft.info
+ * Copyright Daniel Ratcliffe, 2011-2020. Do not distribute without permission.
+ * Send enquiries to dratcliffe@gmail.com
+ */
+
+package dan200.computercraft.client.render;
+
+import com.google.common.base.Strings;
+import dan200.computercraft.ComputerCraft;
+import dan200.computercraft.client.gui.FixedWidthFontRenderer;
+import dan200.computercraft.shared.util.Palette;
+import net.minecraft.client.renderer.OpenGlHelper;
+import org.apache.commons.io.IOUtils;
+import org.lwjgl.BufferUtils;
+import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL13;
+import org.lwjgl.opengl.GL20;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.FloatBuffer;
+
+class MonitorTextureBufferShader
+{
+    static final int TEXTURE_INDEX = GL13.GL_TEXTURE3;
+
+    private static final FloatBuffer MATRIX_BUFFER = BufferUtils.createFloatBuffer( 16 );
+    private static final FloatBuffer PALETTE_BUFFER = BufferUtils.createFloatBuffer( 16 * 3 );
+
+    private static int uniformMv;
+    private static int uniformP;
+
+    private static int uniformFont;
+    private static int uniformWidth;
+    private static int uniformHeight;
+    private static int uniformTbo;
+    private static int uniformPalette;
+
+    private static boolean initialised;
+    private static boolean ok;
+    private static int program;
+
+    static void setupUniform( int width, int height, Palette palette, boolean greyscale )
+    {
+        MATRIX_BUFFER.rewind();
+        GL11.glGetFloat( GL11.GL_MODELVIEW_MATRIX, MATRIX_BUFFER );
+        MATRIX_BUFFER.rewind();
+        OpenGlHelper.glUniformMatrix4( uniformMv, false, MATRIX_BUFFER );
+
+        MATRIX_BUFFER.rewind();
+        GL11.glGetFloat( GL11.GL_PROJECTION_MATRIX, MATRIX_BUFFER );
+        MATRIX_BUFFER.rewind();
+        OpenGlHelper.glUniformMatrix4( uniformP, false, MATRIX_BUFFER );
+
+        OpenGlHelper.glUniform1i( uniformWidth, width );
+        OpenGlHelper.glUniform1i( uniformHeight, height );
+
+        PALETTE_BUFFER.rewind();
+        for( int i = 0; i < 16; i++ )
+        {
+            double[] colour = palette.getColour( i );
+            if( greyscale )
+            {
+                float f = FixedWidthFontRenderer.toGreyscale( colour );
+                PALETTE_BUFFER.put( f ).put( f ).put( f );
+            }
+            else
+            {
+                PALETTE_BUFFER.put( (float) colour[0] ).put( (float) colour[1] ).put( (float) colour[2] );
+            }
+        }
+        PALETTE_BUFFER.flip();
+        OpenGlHelper.glUniform3( uniformPalette, PALETTE_BUFFER );
+    }
+
+    static boolean use()
+    {
+        if( initialised )
+        {
+            if( ok ) OpenGlHelper.glUseProgram( program );
+            return ok;
+        }
+
+        if( ok = load() )
+        {
+            GL20.glUseProgram( program );
+            OpenGlHelper.glUniform1i( uniformFont, 0 );
+            OpenGlHelper.glUniform1i( uniformTbo, TEXTURE_INDEX - GL13.GL_TEXTURE0 );
+        }
+
+        return ok;
+    }
+
+    private static boolean load()
+    {
+        initialised = true;
+
+        try
+        {
+            int vertexShader = loadShader( GL20.GL_VERTEX_SHADER, "assets/computercraft/shaders/monitor.vert" );
+            int fragmentShader = loadShader( GL20.GL_FRAGMENT_SHADER, "assets/computercraft/shaders/monitor.frag" );
+
+            program = OpenGlHelper.glCreateProgram();
+            OpenGlHelper.glAttachShader( program, vertexShader );
+            OpenGlHelper.glAttachShader( program, fragmentShader );
+            GL20.glBindAttribLocation( program, 0, "v_pos" );
+
+            OpenGlHelper.glLinkProgram( program );
+            boolean ok = OpenGlHelper.glGetProgrami( program, GL20.GL_LINK_STATUS ) != 0;
+            String log = OpenGlHelper.glGetProgramInfoLog( program, Short.MAX_VALUE ).trim();
+            if( !Strings.isNullOrEmpty( log ) )
+            {
+                ComputerCraft.log.warn( "Problems when linking monitor shader: {}", log );
+            }
+
+            GL20.glDetachShader( program, vertexShader );
+            GL20.glDetachShader( program, fragmentShader );
+            OpenGlHelper.glDeleteShader( vertexShader );
+            OpenGlHelper.glDeleteShader( fragmentShader );
+
+            if( !ok ) return false;
+
+            uniformMv = getUniformLocation( program, "u_mv" );
+            uniformP = getUniformLocation( program, "u_p" );
+
+            uniformFont = getUniformLocation( program, "u_font" );
+            uniformWidth = getUniformLocation( program, "u_width" );
+            uniformHeight = getUniformLocation( program, "u_height" );
+            uniformTbo = getUniformLocation( program, "u_tbo" );
+            uniformPalette = getUniformLocation( program, "u_palette" );
+
+            ComputerCraft.log.info( "Loaded monitor shader." );
+            return true;
+        }
+        catch( Exception e )
+        {
+            ComputerCraft.log.error( "Cannot load monitor shaders", e );
+            return false;
+        }
+    }
+
+    private static int loadShader( int kind, String path ) throws IOException
+    {
+        InputStream stream = TileEntityMonitorRenderer.class.getClassLoader().getResourceAsStream( path );
+        if( stream == null ) throw new IllegalArgumentException( "Cannot find " + path );
+        byte[] contents = IOUtils.toByteArray( new BufferedInputStream( stream ) );
+        ByteBuffer buffer = BufferUtils.createByteBuffer( contents.length );
+        buffer.put( contents );
+        buffer.position( 0 );
+
+        int shader = OpenGlHelper.glCreateShader( kind );
+
+        OpenGlHelper.glShaderSource( shader, buffer );
+        OpenGlHelper.glCompileShader( shader );
+
+        boolean ok = OpenGlHelper.glGetShaderi( shader, GL20.GL_COMPILE_STATUS ) != 0;
+        String log = OpenGlHelper.glGetShaderInfoLog( shader, Short.MAX_VALUE ).trim();
+        if( !Strings.isNullOrEmpty( log ) )
+        {
+            ComputerCraft.log.warn( "Problems when loading monitor shader {}: {}", path, log );
+        }
+
+        if( !ok ) throw new IllegalStateException( "Cannot compile shader " + path );
+        return shader;
+    }
+
+    private static int getUniformLocation( int program, String name )
+    {
+        int uniform = OpenGlHelper.glGetUniformLocation( program, name );
+        if( uniform == -1 ) throw new IllegalStateException( "Cannot find uniform " + name );
+        return uniform;
+    }
+}

--- a/src/main/java/dan200/computercraft/client/render/TileEntityMonitorRenderer.java
+++ b/src/main/java/dan200/computercraft/client/render/TileEntityMonitorRenderer.java
@@ -8,23 +8,28 @@ package dan200.computercraft.client.render;
 import dan200.computercraft.client.FrameInfo;
 import dan200.computercraft.client.gui.FixedWidthFontRenderer;
 import dan200.computercraft.core.terminal.Terminal;
+import dan200.computercraft.core.terminal.TextBuffer;
 import dan200.computercraft.shared.peripheral.monitor.ClientMonitor;
 import dan200.computercraft.shared.peripheral.monitor.MonitorRenderer;
 import dan200.computercraft.shared.peripheral.monitor.TileMonitor;
+import dan200.computercraft.shared.util.Colour;
 import dan200.computercraft.shared.util.DirectionUtil;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.BufferBuilder;
-import net.minecraft.client.renderer.GlStateManager;
-import net.minecraft.client.renderer.OpenGlHelper;
-import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.client.renderer.*;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
+import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.client.renderer.vertex.VertexBuffer;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL13;
+import org.lwjgl.opengl.GL15;
+import org.lwjgl.opengl.GL31;
 
 import javax.annotation.Nonnull;
+import java.nio.ByteBuffer;
 
+import static dan200.computercraft.client.gui.FixedWidthFontRenderer.*;
 import static dan200.computercraft.shared.peripheral.monitor.TileMonitor.RENDER_MARGIN;
 
 public class TileEntityMonitorRenderer extends TileEntitySpecialRenderer<TileMonitor>
@@ -97,8 +102,8 @@ public class TileEntityMonitorRenderer extends TileEntitySpecialRenderer<TileMon
         if( terminal != null )
         {
             // Draw a terminal
-            double xScale = xSize / (terminal.getWidth() * FixedWidthFontRenderer.FONT_WIDTH);
-            double yScale = ySize / (terminal.getHeight() * FixedWidthFontRenderer.FONT_HEIGHT);
+            double xScale = xSize / (terminal.getWidth() * FONT_WIDTH);
+            double yScale = ySize / (terminal.getHeight() * FONT_HEIGHT);
 
             GlStateManager.pushMatrix();
             GlStateManager.scale( (float) xScale, (float) -yScale, 1.0f );
@@ -147,6 +152,52 @@ public class TileEntityMonitorRenderer extends TileEntitySpecialRenderer<TileMon
 
         switch( renderer )
         {
+            case TBO:
+            {
+                if( !MonitorTextureBufferShader.use() ) return;
+
+                Terminal terminal = monitor.getTerminal();
+                int width = terminal.getWidth(), height = terminal.getHeight();
+                int pixelWidth = width * FONT_WIDTH, pixelHeight = height * FONT_HEIGHT;
+
+                if( redraw )
+                {
+                    ByteBuffer monitorBuffer = GLAllocation.createDirectByteBuffer( width * height * 3 );
+                    for( int y = 0; y < height; y++ )
+                    {
+                        TextBuffer text = terminal.getLine( y ), textColour = terminal.getTextColourLine( y ), background = terminal.getBackgroundColourLine( y );
+                        for( int x = 0; x < width; x++ )
+                        {
+                            monitorBuffer.put( (byte) (text.charAt( x ) & 0xFF) );
+                            monitorBuffer.put( (byte) getColour( textColour.charAt( x ), Colour.White ) );
+                            monitorBuffer.put( (byte) getColour( background.charAt( x ), Colour.Black ) );
+                        }
+                    }
+                    monitorBuffer.flip();
+
+                    OpenGlHelper.glBindBuffer( GL31.GL_TEXTURE_BUFFER, monitor.tboBuffer );
+                    OpenGlHelper.glBufferData( GL31.GL_TEXTURE_BUFFER, monitorBuffer, GL15.GL_STATIC_DRAW );
+                    OpenGlHelper.glBindBuffer( GL31.GL_TEXTURE_BUFFER, 0 );
+                }
+
+                // Nobody knows what they're doing!
+                GlStateManager.setActiveTexture( MonitorTextureBufferShader.TEXTURE_INDEX );
+                GL11.glBindTexture( GL31.GL_TEXTURE_BUFFER, monitor.tboTexture );
+                GlStateManager.setActiveTexture( GL13.GL_TEXTURE0 );
+
+                MonitorTextureBufferShader.setupUniform( width, height, terminal.getPalette(), !monitor.isColour() );
+
+                buffer.begin( GL11.GL_TRIANGLE_STRIP, DefaultVertexFormats.POSITION );
+                buffer.pos( -xMargin, -yMargin, 0 ).endVertex();
+                buffer.pos( -xMargin, pixelHeight + yMargin, 0 ).endVertex();
+                buffer.pos( pixelWidth + xMargin, -yMargin, 0 ).endVertex();
+                buffer.pos( pixelWidth + xMargin, pixelHeight + yMargin, 0 ).endVertex();
+                tessellator.draw();
+
+                OpenGlHelper.glUseProgram( 0 );
+                break;
+            }
+
             case VBO:
             {
                 VertexBuffer vbo = monitor.buffer;

--- a/src/main/java/dan200/computercraft/client/render/TileEntityMonitorRenderer.java
+++ b/src/main/java/dan200/computercraft/client/render/TileEntityMonitorRenderer.java
@@ -180,7 +180,7 @@ public class TileEntityMonitorRenderer extends TileEntitySpecialRenderer<TileMon
                     OpenGlHelper.glBindBuffer( GL31.GL_TEXTURE_BUFFER, 0 );
                 }
 
-                // Nobody knows what they're doing!
+                // Bind TBO texture and set up the uniforms. We've already set up the main font above.
                 GlStateManager.setActiveTexture( MonitorTextureBufferShader.TEXTURE_INDEX );
                 GL11.glBindTexture( GL31.GL_TEXTURE_BUFFER, monitor.tboTexture );
                 GlStateManager.setActiveTexture( GL13.GL_TEXTURE0 );

--- a/src/main/java/dan200/computercraft/shared/peripheral/monitor/ClientMonitor.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/monitor/ClientMonitor.java
@@ -32,10 +32,10 @@ public final class ClientMonitor extends ClientTerminal
     public long lastRenderFrame = -1;
     public BlockPos lastRenderPos = null;
 
-    public VertexBuffer buffer;
-    public int displayList = 0;
     public int tboBuffer;
     public int tboTexture;
+    public VertexBuffer buffer;
+    public int displayList = 0;
 
     public ClientMonitor( boolean colour, TileMonitor origin )
     {
@@ -68,8 +68,6 @@ public final class ClientMonitor extends ClientTerminal
 
                 tboBuffer = OpenGlHelper.glGenBuffers();
                 OpenGlHelper.glBindBuffer( GL31.GL_TEXTURE_BUFFER, tboBuffer );
-                // TODO: DYNAMIC? Probably not, but worth profiling. After all, it only needs to be fast on /my/
-                //  graphics card.
                 GL15.glBufferData( GL31.GL_TEXTURE_BUFFER, 0, GL15.GL_STATIC_DRAW );
                 tboTexture = GlStateManager.generateTexture();
                 GL11.glBindTexture( GL31.GL_TEXTURE_BUFFER, tboTexture );
@@ -142,7 +140,7 @@ public final class ClientMonitor extends ClientTerminal
     @SideOnly( Side.CLIENT )
     public void destroy()
     {
-        if( buffer != null || tboBuffer != 0 || displayList != 0 )
+        if( tboBuffer != 0 || buffer != null || displayList != 0 )
         {
             synchronized( allMonitors )
             {

--- a/src/main/resources/assets/computercraft/lang/en_us.lang
+++ b/src/main/resources/assets/computercraft/lang/en_us.lang
@@ -187,6 +187,7 @@ gui.computercraft:config.peripheral.modem_high_altitude_range_during_storm=Modem
 gui.computercraft:config.peripheral.max_notes_per_tick=Maximum notes that a computer can play at once
 gui.computercraft:config.peripheral.monitor_renderer=Monitor renderer
 gui.computercraft:config.peripheral.monitor_renderer.best=Best
+gui.computercraft:config.peripheral.monitor_renderer.tbo=Texture Buffers
 gui.computercraft:config.peripheral.monitor_renderer.vbo=Vertex Buffers
 gui.computercraft:config.peripheral.monitor_renderer.display_list=Display Lists
 

--- a/src/main/resources/assets/computercraft/shaders/monitor.frag
+++ b/src/main/resources/assets/computercraft/shaders/monitor.frag
@@ -1,0 +1,38 @@
+#version 140
+
+#define FONT_WIDTH 6.0
+#define FONT_HEIGHT 9.0
+
+uniform sampler2D u_font;
+uniform int u_width;
+uniform int u_height;
+uniform samplerBuffer u_tbo;
+uniform vec3 u_palette[16];
+
+in vec2 f_pos;
+
+vec2 texture_corner(int index) {
+    float x = 1.0 + float(index % 16) * (FONT_WIDTH + 2.0);
+    float y = 1.0 + float(index / 16) * (FONT_HEIGHT + 2.0);
+    return vec2(x, y);
+}
+
+void main() {
+    vec2 term_pos = vec2(f_pos.x / FONT_WIDTH, f_pos.y / FONT_HEIGHT);
+    vec2 corner = floor(term_pos);
+
+    ivec2 cell = ivec2(corner);
+    int index = 3 * (clamp(cell.x, 0, u_width - 1) + clamp(cell.y, 0, u_height - 1) * u_width);
+
+    // 1 if 0 <= x, y < width, height, 0 otherwise
+    vec2 outside = step(ivec2(0, 0), cell) * step(cell, ivec2(u_width - 1, u_height - 1));
+    float mult = outside.x * outside.y;
+
+    int character = int(texelFetch(u_tbo, index).r * 255.0);
+    int fg = int(texelFetch(u_tbo, index + 1).r * 255.0);
+    int bg = int(texelFetch(u_tbo, index + 2).r * 255.0);
+
+    vec2 pos = (term_pos - corner) * vec2(FONT_WIDTH, FONT_HEIGHT);
+    vec4 img = texture2D(u_font, (texture_corner(character) + pos) / 256.0);
+    gl_FragColor = vec4(mix(u_palette[bg], img.rgb * u_palette[fg], img.a * mult), 1.0);
+}

--- a/src/main/resources/assets/computercraft/shaders/monitor.frag
+++ b/src/main/resources/assets/computercraft/shaders/monitor.frag
@@ -11,6 +11,8 @@ uniform vec3 u_palette[16];
 
 in vec2 f_pos;
 
+out vec4 colour;
+
 vec2 texture_corner(int index) {
     float x = 1.0 + float(index % 16) * (FONT_WIDTH + 2.0);
     float y = 1.0 + float(index / 16) * (FONT_HEIGHT + 2.0);
@@ -25,7 +27,7 @@ void main() {
     int index = 3 * (clamp(cell.x, 0, u_width - 1) + clamp(cell.y, 0, u_height - 1) * u_width);
 
     // 1 if 0 <= x, y < width, height, 0 otherwise
-    vec2 outside = step(ivec2(0, 0), cell) * step(cell, ivec2(u_width - 1, u_height - 1));
+    vec2 outside = step(vec2(0.0, 0.0), vec2(cell)) * step(vec2(cell), vec2(float(u_width) - 1.0, float(u_height) - 1.0));
     float mult = outside.x * outside.y;
 
     int character = int(texelFetch(u_tbo, index).r * 255.0);
@@ -34,5 +36,5 @@ void main() {
 
     vec2 pos = (term_pos - corner) * vec2(FONT_WIDTH, FONT_HEIGHT);
     vec4 img = texture2D(u_font, (texture_corner(character) + pos) / 256.0);
-    gl_FragColor = vec4(mix(u_palette[bg], img.rgb * u_palette[fg], img.a * mult), 1.0);
+    colour = vec4(mix(u_palette[bg], img.rgb * u_palette[fg], img.a * mult), 1.0);
 }

--- a/src/main/resources/assets/computercraft/shaders/monitor.vert
+++ b/src/main/resources/assets/computercraft/shaders/monitor.vert
@@ -1,0 +1,13 @@
+#version 140
+
+uniform mat4 u_mv;
+uniform mat4 u_p;
+
+in vec3 v_pos;
+
+out vec2 f_pos;
+
+void main() {
+    gl_Position = u_p * u_mv * vec4(v_pos.x, v_pos.y, 0, 1);
+    f_pos = v_pos.xy;
+}


### PR DESCRIPTION
This is a backport of #441 for 1.12. See there for a description of the changes and improvements to performance.

This PR is almost identical - the only difference is we use `glGetFloatv` to fetch the model/view matrix, as it is not available to the client.