### PR TITLE
Simplify monitor TBO shader

### DIFF
--- a/src/main/java/dan200/computercraft/client/render/MonitorTextureBufferShader.java
+++ b/src/main/java/dan200/computercraft/client/render/MonitorTextureBufferShader.java
@@ -13,7 +13,6 @@ import dan200.computercraft.shared.util.Palette;
 import net.minecraft.client.renderer.OpenGlHelper;
 import org.apache.commons.io.IOUtils;
 import org.lwjgl.BufferUtils;
-import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL13;
 import org.lwjgl.opengl.GL20;
 

--- a/src/main/java/dan200/computercraft/client/render/MonitorTextureBufferShader.java
+++ b/src/main/java/dan200/computercraft/client/render/MonitorTextureBufferShader.java
@@ -27,11 +27,7 @@ class MonitorTextureBufferShader
 {
     static final int TEXTURE_INDEX = GL13.GL_TEXTURE3;
 
-    private static final FloatBuffer MATRIX_BUFFER = BufferUtils.createFloatBuffer( 16 );
     private static final FloatBuffer PALETTE_BUFFER = BufferUtils.createFloatBuffer( 16 * 3 );
-
-    private static int uniformMv;
-    private static int uniformP;
 
     private static int uniformFont;
     private static int uniformWidth;
@@ -45,16 +41,6 @@ class MonitorTextureBufferShader
 
     static void setupUniform( int width, int height, Palette palette, boolean greyscale )
     {
-        MATRIX_BUFFER.rewind();
-        GL11.glGetFloat( GL11.GL_MODELVIEW_MATRIX, MATRIX_BUFFER );
-        MATRIX_BUFFER.rewind();
-        OpenGlHelper.glUniformMatrix4( uniformMv, false, MATRIX_BUFFER );
-
-        MATRIX_BUFFER.rewind();
-        GL11.glGetFloat( GL11.GL_PROJECTION_MATRIX, MATRIX_BUFFER );
-        MATRIX_BUFFER.rewind();
-        OpenGlHelper.glUniformMatrix4( uniformP, false, MATRIX_BUFFER );
-
         OpenGlHelper.glUniform1i( uniformWidth, width );
         OpenGlHelper.glUniform1i( uniformHeight, height );
 
@@ -122,9 +108,6 @@ class MonitorTextureBufferShader
             OpenGlHelper.glDeleteShader( fragmentShader );
 
             if( !ok ) return false;
-
-            uniformMv = getUniformLocation( program, "u_mv" );
-            uniformP = getUniformLocation( program, "u_p" );
 
             uniformFont = getUniformLocation( program, "u_font" );
             uniformWidth = getUniformLocation( program, "u_width" );

--- a/src/main/resources/assets/computercraft/shaders/monitor.vert
+++ b/src/main/resources/assets/computercraft/shaders/monitor.vert
@@ -1,13 +1,10 @@
 #version 140
 
-uniform mat4 u_mv;
-uniform mat4 u_p;
-
 in vec3 v_pos;
 
 out vec2 f_pos;
 
 void main() {
-    gl_Position = u_p * u_mv * vec4(v_pos.x, v_pos.y, 0, 1);
+    gl_Position = gl_ModelViewProjectionMatrix * vec4(v_pos.x, v_pos.y, 0, 1);
     f_pos = v_pos.xy;
 }


### PR DESCRIPTION
Not sure how I missed this in the initial PR, but the fixed-function pipeline's MVP matrix is exposed as the built-in shader variable `gl_ModelViewProjectionMatrix`, there's no need to retrieve it ourselves. This saves us some uniforms and `glGetFloat` calls, which can incur some overhead.