### PR TITLE
Oops! No standards compliance

### DIFF
--- a/src/main/resources/assets/computercraft/shaders/monitor.vert
+++ b/src/main/resources/assets/computercraft/shaders/monitor.vert
@@ -1,6 +1,4 @@
-#version 140
-
-#extension GL_ARB_compatibility : require
+#version 130
 
 in vec3 v_pos;
 

--- a/src/main/resources/assets/computercraft/shaders/monitor.vert
+++ b/src/main/resources/assets/computercraft/shaders/monitor.vert
@@ -1,5 +1,7 @@
 #version 140
 
+#extension GL_ARB_compatibility : require
+
 in vec3 v_pos;
 
 out vec2 f_pos;


### PR DESCRIPTION
As of #454, monitors no longer render on strict drivers (e.g. Windows AMD driver) since apparently `GL_ARB_compatibility` is disabled. This should normally be enabled in the compatibility profile, but for some reason it's not, so less permissive drivers fail to compile the shader.

This PR fixes this by explicitly requiring it in our vertex shader.