### PR TITLE
make loadfile consistent with standard lua

### DIFF
--- a/src/main/resources/assets/computercraft/lua/bios.lua
+++ b/src/main/resources/assets/computercraft/lua/bios.lua
@@ -7,7 +7,7 @@ local expect
 
 do
     local h = fs.open("rom/modules/main/cc/expect.lua", "r")
-    local f, err = loadstring(h.readAll(), "@expect.lua")
+    local f, err = loadstring(h.readAll(), "@rom/modules/main/cc/expect.lua")
     h.close()
 
     if not f then error(err) end
@@ -500,7 +500,7 @@ function loadfile(filename, mode, env)
     local file = fs.open(filename, "r")
     if not file then return nil, "File not found" end
 
-    local func, err = load(file.readAll(), "@" .. fs.getName(filename), mode, env)
+    local func, err = load(file.readAll(), "@" .. filename, mode, env)
     file.close()
     return func, err
 end

--- a/src/test/resources/test-rom/spec/base_spec.lua
+++ b/src/test/resources/test-rom/spec/base_spec.lua
@@ -48,7 +48,7 @@ describe("The Lua base library", function()
 
         it("prefixes the filename with @", function()
             local info = debug.getinfo(loadfile("/rom/startup.lua"), "S")
-            expect(info):matches { short_src = "startup.lua", source = "@startup.lua" }
+            expect(info):matches { short_src = "/rom/startup.lua", source = "@/rom/startup.lua" }
         end)
 
         it("loads a file with the global environment", function()


### PR DESCRIPTION
A simple change to have loadfile include the full path to source. This is consistent with standard lua: see: https://www.lua.org/source/5.1/lauxlib.c.html#luaL_loadfile

This change will allow a debugger to easily find the corresponding source file.