### PR TITLE
Added Javadoc for currently undocumented functions

### DIFF
--- a/src/main/java/dan200/computercraft/core/apis/FSAPI.java
+++ b/src/main/java/dan200/computercraft/core/apis/FSAPI.java
@@ -298,6 +298,7 @@ public class FSAPI implements ILuaAPI
      * @param mode The mode to open the file with.
      * @return A file handle object for the file, or {@code nil} + an error message on error.
      * @throws LuaException If an invalid mode was specified.
+     * @cc.treturn Handle A file handle object for the file, or {@code nil} + an error message on error.
      */
     @LuaFunction
     public final Object[] open( String path, String mode ) throws LuaException
@@ -359,6 +360,7 @@ public class FSAPI implements ILuaAPI
      * @param path The path to get the drive of.
      * @return The name of the drive that the file is on; e.g. {@code hdd} for local files, or {@code rom} for ROM files.
      * @throws LuaException If the path doesn't exist.
+     * @cc.treturn string The name of the drive that the file is on; e.g. {@code hdd} for local files, or {@code rom} for ROM files.
      */
     @LuaFunction
     public final Object[] getDrive( String path ) throws LuaException

--- a/src/main/java/dan200/computercraft/core/apis/FSAPI.java
+++ b/src/main/java/dan200/computercraft/core/apis/FSAPI.java
@@ -61,6 +61,12 @@ public class FSAPI implements ILuaAPI
         fileSystem = null;
     }
 
+    /**
+     * Returns a list of files in a directory.
+     *
+     * @param path The path to list.
+     * @return A table with a list of files in the directory.
+     */
     @LuaFunction
     public final String[] list( String path ) throws LuaException
     {
@@ -75,24 +81,50 @@ public class FSAPI implements ILuaAPI
         }
     }
 
+    /**
+     * Combines two parts of a path into one full path, adding separators as
+     * needed.
+     *
+     * @param pathA The first part of the path. For example, a parent directory path.
+     * @param pathB The second part of the path. For example, a file name.
+     * @return The new path, with separators added between parts as needed.
+     */
     @LuaFunction
     public final String combine( String pathA, String pathB )
     {
         return fileSystem.combine( pathA, pathB );
     }
 
+    /**
+     * Returns the file name portion of a path.
+     *
+     * @param path The path to get the name from.
+     * @return The final part of the path (the file name).
+     */
     @LuaFunction
     public final String getName( String path )
     {
         return FileSystem.getName( path );
     }
 
+    /**
+     * Returns the parent directory portion of a path.
+     *
+     * @param path The path to get the directory from.
+     * @return The path with the final part removed (the parent directory).
+     */
     @LuaFunction
     public final String getDir( String path )
     {
         return FileSystem.getDirectory( path );
     }
 
+    /**
+     * Returns the size of the specified file.
+     *
+     * @param path The file to get the file size of.
+     * @return The size of the file, in bytes.
+     */
     @LuaFunction
     public final long getSize( String path ) throws LuaException
     {
@@ -106,6 +138,12 @@ public class FSAPI implements ILuaAPI
         }
     }
 
+    /**
+     * Returns whether the specified path exists.
+     *
+     * @param path The path to check the existence of.
+     * @return Whether the path exists.
+     */
     @LuaFunction
     public final boolean exists( String path )
     {
@@ -119,6 +157,12 @@ public class FSAPI implements ILuaAPI
         }
     }
 
+    /**
+     * Returns whether the specified path is a directory.
+     *
+     * @param path The path to check.
+     * @return Whether the path is a directory.
+     */
     @LuaFunction
     public final boolean isDir( String path )
     {
@@ -132,6 +176,12 @@ public class FSAPI implements ILuaAPI
         }
     }
 
+    /**
+     * Returns whether a path is read-only.
+     *
+     * @param path The path to check.
+     * @return Whether the path cannot be written to.
+     */
     @LuaFunction
     public final boolean isReadOnly( String path )
     {
@@ -145,6 +195,11 @@ public class FSAPI implements ILuaAPI
         }
     }
 
+    /**
+     * Creates a directory, and any missing parents, at the specified path.
+     *
+     * @param path The path to the directory to create.
+     */
     @LuaFunction
     public final void makeDir( String path ) throws LuaException
     {
@@ -159,6 +214,14 @@ public class FSAPI implements ILuaAPI
         }
     }
 
+    /**
+     * Moves a file or directory from one path to another.
+     *
+     * Any parent directories are created as needed.
+     *
+     * @param path The current file or directory to move from.
+     * @param dest The destination path for the file or directory.
+     */
     @LuaFunction
     public final void move( String path, String dest ) throws LuaException
     {
@@ -173,6 +236,14 @@ public class FSAPI implements ILuaAPI
         }
     }
 
+    /**
+     * Copies a file or directory to a new path.
+     *
+     * Any parent directories are created as needed.
+     *
+     * @param path The file or directory to copy.
+     * @param dest The path to the destination file or directory.
+     */
     @LuaFunction
     public final void copy( String path, String dest ) throws LuaException
     {
@@ -187,6 +258,14 @@ public class FSAPI implements ILuaAPI
         }
     }
 
+    /**
+     * Deletes a file or directory.
+     *
+     * If the path points to a directory, all of the enclosed files and
+     * subdirectories are also deleted.
+     *
+     * @param path The path to the file or directory to delete.
+     */
     @LuaFunction
     public final void delete( String path ) throws LuaException
     {
@@ -201,6 +280,18 @@ public class FSAPI implements ILuaAPI
         }
     }
 
+    /**
+     * Opens a file for reading or writing at a path.
+     *
+     * The mode parameter can be {@code r} to read, {@code w} to write (deleting
+     * all contents), or {@code a} to append (keeping contents). If {@code b} is
+     * added to the end, the file will be opened in binary mode; otherwise, it's
+     * opened in text mode.
+     *
+     * @param path The path to the file to open.
+     * @param mode The mode to open the file with.
+     * @return A file handle object for the file, or {@code nil} + an error message on error.
+     */
     @LuaFunction
     public final Object[] open( String path, String mode ) throws LuaException
     {
@@ -255,6 +346,12 @@ public class FSAPI implements ILuaAPI
         }
     }
 
+    /**
+     * Returns the name of the mount that the specified path is located on.
+     *
+     * @param path The path to get the drive of.
+     * @return The name of the drive that the file is on; e.g. {@code hdd} for local files, or {@code rom} for ROM files.
+     */
     @LuaFunction
     public final Object[] getDrive( String path ) throws LuaException
     {
@@ -268,6 +365,13 @@ public class FSAPI implements ILuaAPI
         }
     }
 
+    /**
+     * Returns the amount of free space available on the drive the path is
+     * located on.
+     *
+     * @param path The path to check the free space for.
+     * @return The amount of free space available, in bytes.
+     */
     @LuaFunction
     public final Object getFreeSpace( String path ) throws LuaException
     {
@@ -282,6 +386,17 @@ public class FSAPI implements ILuaAPI
         }
     }
 
+    /**
+     * Searches for files matching a string with wildcards.
+     *
+     * This string is formatted like a normal path string, but can include any
+     * number of wildcards ({@code *}) to look for files matching anything.
+     * For example, {@code rom/* /command*} will look for any path starting with
+     * {@code command} inside any subdirectory of {@code /rom}.
+     *
+     * @param path The wildcard-qualified path to search for.
+     * @return A list of paths that match the search string.
+     */
     @LuaFunction
     public final String[] find( String path ) throws LuaException
     {

--- a/src/main/java/dan200/computercraft/core/apis/FSAPI.java
+++ b/src/main/java/dan200/computercraft/core/apis/FSAPI.java
@@ -286,6 +286,8 @@ public class FSAPI implements ILuaAPI
         }
     }
 
+    // FIXME: Add individual handle type documentation
+
     /**
      * Opens a file for reading or writing at a path.
      *
@@ -298,7 +300,7 @@ public class FSAPI implements ILuaAPI
      * @param mode The mode to open the file with.
      * @return A file handle object for the file, or {@code nil} + an error message on error.
      * @throws LuaException If an invalid mode was specified.
-     * @cc.treturn Handle A file handle object for the file, or {@code nil} + an error message on error.
+     * @cc.treturn table A file handle object for the file, or {@code nil} + an error message on error.
      */
     @LuaFunction
     public final Object[] open( String path, String mode ) throws LuaException

--- a/src/main/java/dan200/computercraft/core/apis/FSAPI.java
+++ b/src/main/java/dan200/computercraft/core/apis/FSAPI.java
@@ -66,6 +66,7 @@ public class FSAPI implements ILuaAPI
      *
      * @param path The path to list.
      * @return A table with a list of files in the directory.
+     * @throws LuaException If the path doesn't exist.
      */
     @LuaFunction
     public final String[] list( String path ) throws LuaException
@@ -124,6 +125,7 @@ public class FSAPI implements ILuaAPI
      *
      * @param path The file to get the file size of.
      * @return The size of the file, in bytes.
+     * @throws LuaExeption If the path doesn't exist.
      */
     @LuaFunction
     public final long getSize( String path ) throws LuaException
@@ -199,6 +201,7 @@ public class FSAPI implements ILuaAPI
      * Creates a directory, and any missing parents, at the specified path.
      *
      * @param path The path to the directory to create.
+     * @throws LuaException If the directory couldn't be created.
      */
     @LuaFunction
     public final void makeDir( String path ) throws LuaException
@@ -221,6 +224,7 @@ public class FSAPI implements ILuaAPI
      *
      * @param path The current file or directory to move from.
      * @param dest The destination path for the file or directory.
+     * @throws LuaException If the file or directory couldn't be moved.
      */
     @LuaFunction
     public final void move( String path, String dest ) throws LuaException
@@ -243,6 +247,7 @@ public class FSAPI implements ILuaAPI
      *
      * @param path The file or directory to copy.
      * @param dest The path to the destination file or directory.
+     * @throws LuaException If the file or directory couldn't be copied.
      */
     @LuaFunction
     public final void copy( String path, String dest ) throws LuaException
@@ -265,6 +270,7 @@ public class FSAPI implements ILuaAPI
      * subdirectories are also deleted.
      *
      * @param path The path to the file or directory to delete.
+     * @throws LuaException If the file or directory couldn't be deleted.
      */
     @LuaFunction
     public final void delete( String path ) throws LuaException
@@ -291,6 +297,7 @@ public class FSAPI implements ILuaAPI
      * @param path The path to the file to open.
      * @param mode The mode to open the file with.
      * @return A file handle object for the file, or {@code nil} + an error message on error.
+     * @throws LuaException If an invalid mode was specified.
      */
     @LuaFunction
     public final Object[] open( String path, String mode ) throws LuaException
@@ -351,6 +358,7 @@ public class FSAPI implements ILuaAPI
      *
      * @param path The path to get the drive of.
      * @return The name of the drive that the file is on; e.g. {@code hdd} for local files, or {@code rom} for ROM files.
+     * @throws LuaExeption If the path doesn't exist.
      */
     @LuaFunction
     public final Object[] getDrive( String path ) throws LuaException
@@ -371,6 +379,7 @@ public class FSAPI implements ILuaAPI
      *
      * @param path The path to check the free space for.
      * @return The amount of free space available, in bytes.
+     * @throws LuaExeption If the path doesn't exist.
      */
     @LuaFunction
     public final Object getFreeSpace( String path ) throws LuaException
@@ -396,6 +405,7 @@ public class FSAPI implements ILuaAPI
      *
      * @param path The wildcard-qualified path to search for.
      * @return A list of paths that match the search string.
+     * @throws LuaExeption If the path doesn't exist.
      */
     @LuaFunction
     public final String[] find( String path ) throws LuaException

--- a/src/main/java/dan200/computercraft/core/apis/FSAPI.java
+++ b/src/main/java/dan200/computercraft/core/apis/FSAPI.java
@@ -125,7 +125,7 @@ public class FSAPI implements ILuaAPI
      *
      * @param path The file to get the file size of.
      * @return The size of the file, in bytes.
-     * @throws LuaExeption If the path doesn't exist.
+     * @throws LuaException If the path doesn't exist.
      */
     @LuaFunction
     public final long getSize( String path ) throws LuaException
@@ -358,7 +358,7 @@ public class FSAPI implements ILuaAPI
      *
      * @param path The path to get the drive of.
      * @return The name of the drive that the file is on; e.g. {@code hdd} for local files, or {@code rom} for ROM files.
-     * @throws LuaExeption If the path doesn't exist.
+     * @throws LuaException If the path doesn't exist.
      */
     @LuaFunction
     public final Object[] getDrive( String path ) throws LuaException
@@ -379,7 +379,7 @@ public class FSAPI implements ILuaAPI
      *
      * @param path The path to check the free space for.
      * @return The amount of free space available, in bytes.
-     * @throws LuaExeption If the path doesn't exist.
+     * @throws LuaException If the path doesn't exist.
      */
     @LuaFunction
     public final Object getFreeSpace( String path ) throws LuaException
@@ -405,7 +405,7 @@ public class FSAPI implements ILuaAPI
      *
      * @param path The wildcard-qualified path to search for.
      * @return A list of paths that match the search string.
-     * @throws LuaExeption If the path doesn't exist.
+     * @throws LuaException If the path doesn't exist.
      */
     @LuaFunction
     public final String[] find( String path ) throws LuaException

--- a/src/main/java/dan200/computercraft/core/apis/FSAPI.java
+++ b/src/main/java/dan200/computercraft/core/apis/FSAPI.java
@@ -300,7 +300,9 @@ public class FSAPI implements ILuaAPI
      * @param mode The mode to open the file with.
      * @return A file handle object for the file, or {@code nil} + an error message on error.
      * @throws LuaException If an invalid mode was specified.
-     * @cc.treturn table A file handle object for the file, or {@code nil} + an error message on error.
+     * @cc.treturn [1] table A file handle object for the file.
+     * @cc.treturn [2] nil If the file does not exist, or cannot be opened.
+     * @cc.treturn string|nil A message explaining why the file cannot be opened.
      */
     @LuaFunction
     public final Object[] open( String path, String mode ) throws LuaException
@@ -383,6 +385,7 @@ public class FSAPI implements ILuaAPI
      *
      * @param path The path to check the free space for.
      * @return The amount of free space available, in bytes.
+     * @cc.treturn number|"unlimited" The amount of free space available, in bytes, or "unlimited".
      * @throws LuaException If the path doesn't exist.
      */
     @LuaFunction

--- a/src/main/java/dan200/computercraft/core/apis/OSAPI.java
+++ b/src/main/java/dan200/computercraft/core/apis/OSAPI.java
@@ -266,6 +266,7 @@ public class OSAPI implements ILuaAPI
      * Returns the label of the computer, or {@code nil} if none is set.
      *
      * @return The label of the computer.
+     * @cc.treturn string The label of the computer.
      */
     @LuaFunction( { "getComputerLabel", "computerLabel" } )
     public final Object[] getComputerLabel()
@@ -312,7 +313,7 @@ public class OSAPI implements ILuaAPI
      *
      * @param args The locale of the time, or a table filled by {@code os.date("*t")} to decode. Defaults to {@code ingame} locale if not specified.
      * @return The hour of the selected locale, or a UNIX timestamp from the table, depending on the argument passed in.
-     * @cc.tparam [opt] string/table locale The locale of the time, or a table filled by {@code os.date("*t")} to decode. Defaults to {@code ingame} locale if not specified.
+     * @cc.tparam [opt] string|table locale The locale of the time, or a table filled by {@code os.date("*t")} to decode. Defaults to {@code ingame} locale if not specified.
      * @cc.treturn number The hour of the selected locale, or a UNIX timestamp from the table, depending on the argument passed in.
      * @see #date To get a date table that can be converted with this function.
      * @throws LuaException If an invalid locale is passed.

--- a/src/main/java/dan200/computercraft/core/apis/OSAPI.java
+++ b/src/main/java/dan200/computercraft/core/apis/OSAPI.java
@@ -158,7 +158,7 @@ public class OSAPI implements ILuaAPI
      * os.pullEvent.
      *
      * @param name The name of the event to queue.
-     * @cc.tparam[opt] any ... The parameters of the event.
+     * @cc.tparam[opt] any args The parameters of the event.
      * @cc.see os.pullEvent To pull the event queued
      */
     @LuaFunction
@@ -174,6 +174,7 @@ public class OSAPI implements ILuaAPI
      *
      * @param timer The number of seconds until the timer fires.
      * @return The ID of the new timer.
+     * @throws LuaException If the time is below zero.
      */
     @LuaFunction
     public final int startTimer( double timer ) throws LuaException
@@ -200,6 +201,7 @@ public class OSAPI implements ILuaAPI
      *
      * @param time The time at which to fire the alarm, in the range [0.0, 24.0).
      * @return The ID of the alarm that was set.
+     * @throws LuaException If the time is out of range.
      */
     @LuaFunction
     public final int setAlarm( double time ) throws LuaException
@@ -310,6 +312,7 @@ public class OSAPI implements ILuaAPI
      * @cc.tparam[opt] string/table locale The locale of the time, or a table filled by {@code os.date("*t")} to decode. Defaults to {@code ingame} locale if not specified.
      * @cc.treturn number The hour of the selected locale, or a UNIX timestamp from the table, depending on the argument passed in.
      * @see #date To get a date table that can be converted with this function.
+     * @throws LuaException If an invalid locale is passed.
      */
     @LuaFunction
     public final Object time( IArguments args ) throws LuaException
@@ -343,6 +346,7 @@ public class OSAPI implements ILuaAPI
      *
      * @cc.tparam[opt] string The locale to get the day for. Defaults to {@code ingame} if not set.
      * @cc.treturn number The day depending on the selected locale.
+     * @throws LuaException If an invalid locale is passed.
      */
     @LuaFunction
     public final int day( Optional<String> args ) throws LuaException
@@ -372,6 +376,7 @@ public class OSAPI implements ILuaAPI
      *
      * @cc.tparam[opt] string The locale to get the seconds for. Defaults to {@code ingame} if not set.
      * @cc.treturn number The seconds since the epoch depending on the selected locale.
+     * @throws LuaException If an invalid locale is passed.
      */
     @LuaFunction
     public final long epoch( Optional<String> args ) throws LuaException
@@ -419,6 +424,7 @@ public class OSAPI implements ILuaAPI
      * @cc.tparam[opt] string formatA The format of the string to return. This defaults to {@code %c}, which expands to a string similar to "Sat Dec 24 16:58:00 2011".
      * @cc.tparam[opt] number timeA The time to convert to a string. This defaults to the current time.
      * @cc.treturn string The resulting format string.
+     * @throws LuaException If an invalid format is passed.
      */
     @LuaFunction
     public final Object date( Optional<String> formatA, Optional<Long> timeA ) throws LuaException

--- a/src/main/java/dan200/computercraft/core/apis/OSAPI.java
+++ b/src/main/java/dan200/computercraft/core/apis/OSAPI.java
@@ -159,7 +159,7 @@ public class OSAPI implements ILuaAPI
      *
      * @param name The name of the event to queue.
      * @param args The parameters of the event.
-     * @cc.param[opt] ... The parameters of the event.
+     * @cc.param [opt] ... The parameters of the event.
      * @cc.see os.pullEvent To pull the event queued
      */
     @LuaFunction
@@ -222,7 +222,7 @@ public class OSAPI implements ILuaAPI
      * alarm from firing.
      *
      * @param token The ID of the alarm to cancel.
-     * @see #os.setAlarm To set an alarm.
+     * @see #setAlarm To set an alarm.
      */
     @LuaFunction
     public final void cancelAlarm( int token )
@@ -312,7 +312,7 @@ public class OSAPI implements ILuaAPI
      *
      * @param args The locale of the time, or a table filled by {@code os.date("*t")} to decode. Defaults to {@code ingame} locale if not specified.
      * @return The hour of the selected locale, or a UNIX timestamp from the table, depending on the argument passed in.
-     * @cc.tparam[opt] string/table locale The locale of the time, or a table filled by {@code os.date("*t")} to decode. Defaults to {@code ingame} locale if not specified.
+     * @cc.tparam [opt] string/table locale The locale of the time, or a table filled by {@code os.date("*t")} to decode. Defaults to {@code ingame} locale if not specified.
      * @cc.treturn number The hour of the selected locale, or a UNIX timestamp from the table, depending on the argument passed in.
      * @see #date To get a date table that can be converted with this function.
      * @throws LuaException If an invalid locale is passed.
@@ -349,7 +349,7 @@ public class OSAPI implements ILuaAPI
      *
      * @param args The locale to get the day for. Defaults to {@code ingame} if not set.
      * @return The day depending on the selected locale.
-     * @cc.tparam[opt] string The locale to get the day for. Defaults to {@code ingame} if not set.
+     * @cc.tparam [opt] string The locale to get the day for. Defaults to {@code ingame} if not set.
      * @cc.treturn number The day depending on the selected locale.
      * @throws LuaException If an invalid locale is passed.
      */
@@ -381,7 +381,7 @@ public class OSAPI implements ILuaAPI
      *
      * @param args The locale to get the seconds for. Defaults to {@code ingame} if not set.
      * @return The seconds since the epoch depending on the selected locale.
-     * @cc.tparam[opt] string The locale to get the seconds for. Defaults to {@code ingame} if not set.
+     * @cc.tparam [opt] string The locale to get the seconds for. Defaults to {@code ingame} if not set.
      * @cc.treturn number The seconds since the epoch depending on the selected locale.
      * @throws LuaException If an invalid locale is passed.
      */
@@ -431,8 +431,8 @@ public class OSAPI implements ILuaAPI
      * @param formatA The format of the string to return. This defaults to {@code %c}, which expands to a string similar to "Sat Dec 24 16:58:00 2011".
      * @param timeA The time to convert to a string. This defaults to the current time.
      * @return The resulting format string.
-     * @cc.tparam[opt] string formatA The format of the string to return. This defaults to {@code %c}, which expands to a string similar to "Sat Dec 24 16:58:00 2011".
-     * @cc.tparam[opt] number timeA The time to convert to a string. This defaults to the current time.
+     * @cc.tparam [opt] string formatA The format of the string to return. This defaults to {@code %c}, which expands to a string similar to "Sat Dec 24 16:58:00 2011".
+     * @cc.tparam [opt] number timeA The time to convert to a string. This defaults to the current time.
      * @cc.treturn string The resulting format string.
      * @throws LuaException If an invalid format is passed.
      */

--- a/src/main/java/dan200/computercraft/core/apis/OSAPI.java
+++ b/src/main/java/dan200/computercraft/core/apis/OSAPI.java
@@ -158,7 +158,8 @@ public class OSAPI implements ILuaAPI
      * os.pullEvent.
      *
      * @param name The name of the event to queue.
-     * @cc.tparam[opt] any args The parameters of the event.
+     * @param args The parameters of the event.
+     * @cc.param[opt] ... The parameters of the event.
      * @cc.see os.pullEvent To pull the event queued
      */
     @LuaFunction
@@ -309,6 +310,8 @@ public class OSAPI implements ILuaAPI
      * which will convert the date fields into a UNIX timestamp (number of
      * seconds since 1 January 1970).
      *
+     * @param args The locale of the time, or a table filled by {@code os.date("*t")} to decode. Defaults to {@code ingame} locale if not specified.
+     * @return The hour of the selected locale, or a UNIX timestamp from the table, depending on the argument passed in.
      * @cc.tparam[opt] string/table locale The locale of the time, or a table filled by {@code os.date("*t")} to decode. Defaults to {@code ingame} locale if not specified.
      * @cc.treturn number The hour of the selected locale, or a UNIX timestamp from the table, depending on the argument passed in.
      * @see #date To get a date table that can be converted with this function.
@@ -344,6 +347,8 @@ public class OSAPI implements ILuaAPI
      * * If called with {@code local}, returns the number of days since 1
      *   January 1970 in the server's local timezone.
      *
+     * @param args The locale to get the day for. Defaults to {@code ingame} if not set.
+     * @return The day depending on the selected locale.
      * @cc.tparam[opt] string The locale to get the day for. Defaults to {@code ingame} if not set.
      * @cc.treturn number The day depending on the selected locale.
      * @throws LuaException If an invalid locale is passed.
@@ -374,6 +379,8 @@ public class OSAPI implements ILuaAPI
      * * If called with {@code local}, returns the number of seconds since 1
      *   January 1970 in the server's local timezone.
      *
+     * @param args The locale to get the seconds for. Defaults to {@code ingame} if not set.
+     * @return The seconds since the epoch depending on the selected locale.
      * @cc.tparam[opt] string The locale to get the seconds for. Defaults to {@code ingame} if not set.
      * @cc.treturn number The seconds since the epoch depending on the selected locale.
      * @throws LuaException If an invalid locale is passed.
@@ -421,6 +428,9 @@ public class OSAPI implements ILuaAPI
      * Daylight Savings Time is in effect. This table can be converted to a UNIX
      * timestamp (days since 1 January 1970) with {@link #date}.
      *
+     * @param formatA The format of the string to return. This defaults to {@code %c}, which expands to a string similar to "Sat Dec 24 16:58:00 2011".
+     * @param timeA The time to convert to a string. This defaults to the current time.
+     * @return The resulting format string.
      * @cc.tparam[opt] string formatA The format of the string to return. This defaults to {@code %c}, which expands to a string similar to "Sat Dec 24 16:58:00 2011".
      * @cc.tparam[opt] number timeA The time to convert to a string. This defaults to the current time.
      * @cc.treturn string The resulting format string.

--- a/src/main/java/dan200/computercraft/core/apis/OSAPI.java
+++ b/src/main/java/dan200/computercraft/core/apis/OSAPI.java
@@ -159,7 +159,8 @@ public class OSAPI implements ILuaAPI
      *
      * @param name The name of the event to queue.
      * @param args The parameters of the event.
-     * @cc.param [opt] ... The parameters of the event.
+     * @cc.tparam string name The name of the event to queue.
+     * @cc.param ... The parameters of the event.
      * @cc.see os.pullEvent To pull the event queued
      */
     @LuaFunction
@@ -314,7 +315,6 @@ public class OSAPI implements ILuaAPI
      * @param args The locale of the time, or a table filled by {@code os.date("*t")} to decode. Defaults to {@code ingame} locale if not specified.
      * @return The hour of the selected locale, or a UNIX timestamp from the table, depending on the argument passed in.
      * @cc.tparam [opt] string|table locale The locale of the time, or a table filled by {@code os.date("*t")} to decode. Defaults to {@code ingame} locale if not specified.
-     * @cc.treturn number The hour of the selected locale, or a UNIX timestamp from the table, depending on the argument passed in.
      * @see #date To get a date table that can be converted with this function.
      * @throws LuaException If an invalid locale is passed.
      */
@@ -350,8 +350,6 @@ public class OSAPI implements ILuaAPI
      *
      * @param args The locale to get the day for. Defaults to {@code ingame} if not set.
      * @return The day depending on the selected locale.
-     * @cc.tparam [opt] string The locale to get the day for. Defaults to {@code ingame} if not set.
-     * @cc.treturn number The day depending on the selected locale.
      * @throws LuaException If an invalid locale is passed.
      */
     @LuaFunction
@@ -382,8 +380,6 @@ public class OSAPI implements ILuaAPI
      *
      * @param args The locale to get the seconds for. Defaults to {@code ingame} if not set.
      * @return The seconds since the epoch depending on the selected locale.
-     * @cc.tparam [opt] string The locale to get the seconds for. Defaults to {@code ingame} if not set.
-     * @cc.treturn number The seconds since the epoch depending on the selected locale.
      * @throws LuaException If an invalid locale is passed.
      */
     @LuaFunction
@@ -432,9 +428,6 @@ public class OSAPI implements ILuaAPI
      * @param formatA The format of the string to return. This defaults to {@code %c}, which expands to a string similar to "Sat Dec 24 16:58:00 2011".
      * @param timeA The time to convert to a string. This defaults to the current time.
      * @return The resulting format string.
-     * @cc.tparam [opt] string formatA The format of the string to return. This defaults to {@code %c}, which expands to a string similar to "Sat Dec 24 16:58:00 2011".
-     * @cc.tparam [opt] number timeA The time to convert to a string. This defaults to the current time.
-     * @cc.treturn string The resulting format string.
      * @throws LuaException If an invalid format is passed.
      */
     @LuaFunction

--- a/src/main/java/dan200/computercraft/shared/peripheral/diskdrive/DiskDrivePeripheral.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/diskdrive/DiskDrivePeripheral.java
@@ -80,7 +80,7 @@ public class DiskDrivePeripheral implements IPeripheral
      * an error will be thrown.
      *
      * @param labelA The new label of the disk, or {@code nil} to clear.
-     * @cc.tparam[opt] string labelA The new label of the disk, or {@code nil} to clear.
+     * @cc.tparam [opt] string labelA The new label of the disk, or {@code nil} to clear.
      * @throws LuaException If the disk's label can't be changed.
      */
     @LuaFunction( mainThread = true )

--- a/src/main/java/dan200/computercraft/shared/peripheral/diskdrive/DiskDrivePeripheral.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/diskdrive/DiskDrivePeripheral.java
@@ -47,12 +47,22 @@ public class DiskDrivePeripheral implements IPeripheral
         return "drive";
     }
 
+    /**
+     * Returns whether a disk is currently inserted in the drive.
+     *
+     * @return Whether a disk is currently inserted in the drive.
+     */
     @LuaFunction
     public final boolean isDiskPresent()
     {
         return !diskDrive.getDiskStack().isEmpty();
     }
 
+    /**
+     * Returns the label of the disk in the drive if available.
+     *
+     * @return The label of the disk, or {@code nil} if either no disk is inserted or the disk doesn't have a label.
+     */
     @LuaFunction
     public final Object[] getDiskLabel()
     {
@@ -61,6 +71,16 @@ public class DiskDrivePeripheral implements IPeripheral
         return media == null ? null : new Object[] { media.getLabel( stack ) };
     }
 
+    /**
+     * Sets or clears the label for a disk.
+     *
+     * If no label or {@code nil} is passed, the label will be cleared.
+     *
+     * If the inserted disk's label can't be changed (for example, a record),
+     * an error will be thrown.
+     *
+     * @cc.tparam[opt] string labelA The new label of the disk, or {@code nil} to clear.
+     */
     @LuaFunction( mainThread = true )
     public final void setDiskLabel( Optional<String> labelA ) throws LuaException
     {
@@ -76,18 +96,33 @@ public class DiskDrivePeripheral implements IPeripheral
         diskDrive.setDiskStack( stack );
     }
 
+    /**
+     * Returns whether a disk with data is inserted.
+     *
+     * @return Whether a disk with data is inserted.
+     */
     @LuaFunction
     public final boolean hasData( IComputerAccess computer )
     {
         return diskDrive.getDiskMountPath( computer ) != null;
     }
 
+    /**
+     * Returns the mount path for the inserted disk.
+     *
+     * @return The mount path for the disk, or {@code nil} if no data disk is inserted.
+     */
     @LuaFunction
     public final String getMountPath( IComputerAccess computer )
     {
         return diskDrive.getDiskMountPath( computer );
     }
 
+    /**
+     * Returns whether a disk with audio is inserted.
+     *
+     * @return Whether a disk with audio is inserted.
+     */
     @LuaFunction
     public final boolean hasAudio()
     {
@@ -96,6 +131,11 @@ public class DiskDrivePeripheral implements IPeripheral
         return media != null && media.getAudio( stack ) != null;
     }
 
+    /**
+     * Returns the title of the inserted audio disk.
+     *
+     * @return The title of the audio, or {@code nil} if no audio disk is inserted.
+     */
     @LuaFunction
     public final Object getAudioTitle()
     {
@@ -104,24 +144,40 @@ public class DiskDrivePeripheral implements IPeripheral
         return media != null ? media.getAudioTitle( stack ) : false;
     }
 
+    /**
+     * Plays the audio in the inserted disk, if available.
+     */
     @LuaFunction
     public final void playAudio()
     {
         diskDrive.playDiskAudio();
     }
 
+    /**
+     * Stops any audio that may be playing.
+     *
+     * @see #playAudio
+     */
     @LuaFunction
     public final void stopAudio()
     {
         diskDrive.stopDiskAudio();
     }
 
+    /**
+     * Ejects any disk that may be in the drive.
+     */
     @LuaFunction
     public final void ejectDisk()
     {
         diskDrive.ejectDisk();
     }
 
+    /**
+     * Returns the ID of the disk inserted in the drive.
+     *
+     * @return The ID of the disk in the drive, or {@code nil} if no disk with an ID is inserted.
+     */
     @LuaFunction
     public final Object[] getDiskID()
     {

--- a/src/main/java/dan200/computercraft/shared/peripheral/diskdrive/DiskDrivePeripheral.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/diskdrive/DiskDrivePeripheral.java
@@ -62,6 +62,7 @@ public class DiskDrivePeripheral implements IPeripheral
      * Returns the label of the disk in the drive if available.
      *
      * @return The label of the disk, or {@code nil} if either no disk is inserted or the disk doesn't have a label.
+     * @cc.treturn string The label of the disk, or {@code nil} if either no disk is inserted or the disk doesn't have a label.
      */
     @LuaFunction
     public final Object[] getDiskLabel()
@@ -181,6 +182,7 @@ public class DiskDrivePeripheral implements IPeripheral
      * Returns the ID of the disk inserted in the drive.
      *
      * @return The ID of the disk in the drive, or {@code nil} if no disk with an ID is inserted.
+     * @cc.treturn number The The ID of the disk in the drive, or {@code nil} if no disk with an ID is inserted.
      */
     @LuaFunction
     public final Object[] getDiskID()

--- a/src/main/java/dan200/computercraft/shared/peripheral/diskdrive/DiskDrivePeripheral.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/diskdrive/DiskDrivePeripheral.java
@@ -80,6 +80,7 @@ public class DiskDrivePeripheral implements IPeripheral
      * an error will be thrown.
      *
      * @cc.tparam[opt] string labelA The new label of the disk, or {@code nil} to clear.
+     * @throws LuaException If the disk's label can't be changed.
      */
     @LuaFunction( mainThread = true )
     public final void setDiskLabel( Optional<String> labelA ) throws LuaException

--- a/src/main/java/dan200/computercraft/shared/peripheral/diskdrive/DiskDrivePeripheral.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/diskdrive/DiskDrivePeripheral.java
@@ -16,6 +16,7 @@ import dan200.computercraft.shared.util.StringUtil;
 import net.minecraft.item.ItemStack;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.Optional;
 
 /**
@@ -81,7 +82,6 @@ public class DiskDrivePeripheral implements IPeripheral
      * an error will be thrown.
      *
      * @param labelA The new label of the disk, or {@code nil} to clear.
-     * @cc.tparam [opt] string labelA The new label of the disk, or {@code nil} to clear.
      * @throws LuaException If the disk's label can't be changed.
      */
     @LuaFunction( mainThread = true )
@@ -118,6 +118,7 @@ public class DiskDrivePeripheral implements IPeripheral
      * @return The mount path for the disk, or {@code nil} if no data disk is inserted.
      */
     @LuaFunction
+    @Nullable
     public final String getMountPath( IComputerAccess computer )
     {
         return diskDrive.getDiskMountPath( computer );
@@ -142,6 +143,7 @@ public class DiskDrivePeripheral implements IPeripheral
      * @return The title of the audio, or {@code nil} if no audio disk is inserted.
      */
     @LuaFunction
+    @Nullable
     public final Object getAudioTitle()
     {
         ItemStack stack = diskDrive.getDiskStack();

--- a/src/main/java/dan200/computercraft/shared/peripheral/diskdrive/DiskDrivePeripheral.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/diskdrive/DiskDrivePeripheral.java
@@ -79,6 +79,7 @@ public class DiskDrivePeripheral implements IPeripheral
      * If the inserted disk's label can't be changed (for example, a record),
      * an error will be thrown.
      *
+     * @param labelA The new label of the disk, or {@code nil} to clear.
      * @cc.tparam[opt] string labelA The new label of the disk, or {@code nil} to clear.
      * @throws LuaException If the disk's label can't be changed.
      */
@@ -100,6 +101,7 @@ public class DiskDrivePeripheral implements IPeripheral
     /**
      * Returns whether a disk with data is inserted.
      *
+     * @param computer The computer object
      * @return Whether a disk with data is inserted.
      */
     @LuaFunction
@@ -111,6 +113,7 @@ public class DiskDrivePeripheral implements IPeripheral
     /**
      * Returns the mount path for the inserted disk.
      *
+     * @param computer The computer object
      * @return The mount path for the disk, or {@code nil} if no data disk is inserted.
      */
     @LuaFunction

--- a/src/main/java/dan200/computercraft/shared/peripheral/printer/PrinterPeripheral.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/printer/PrinterPeripheral.java
@@ -42,6 +42,11 @@ public class PrinterPeripheral implements IPeripheral
     // FIXME: None of our page modification functions actually mark the tile as dirty, so the page may not be
     //  persisted correctly.
 
+    /**
+     * Writes text to the current page.
+     *
+     * @cc.tparam string/number ... The values to write to the page.
+     */
     @LuaFunction
     public final void write( IArguments arguments ) throws LuaException
     {
@@ -51,6 +56,12 @@ public class PrinterPeripheral implements IPeripheral
         page.setCursorPos( page.getCursorX() + text.length(), page.getCursorY() );
     }
 
+    /**
+     * Returns the current position of the cursor on the page.
+     *
+     * @cc.treturn number The X position of the cursor.
+     * @cc.treturn number The Y position of the cursor.
+     */
     @LuaFunction
     public final Object[] getCursorPos() throws LuaException
     {
@@ -60,6 +71,12 @@ public class PrinterPeripheral implements IPeripheral
         return new Object[] { x + 1, y + 1 };
     }
 
+    /**
+     * Sets the position of the cursor on the page.
+     *
+     * @param x The X coordinate to set the cursor at.
+     * @param y The Y coordinate to set the cursor at.
+     */
     @LuaFunction
     public final void setCursorPos( int x, int y ) throws LuaException
     {
@@ -67,6 +84,12 @@ public class PrinterPeripheral implements IPeripheral
         page.setCursorPos( x - 1, y - 1 );
     }
 
+    /**
+     * Returns the size of the current page.
+     *
+     * @cc.treturn number The width of the page.
+     * @cc.treturn number The height of the page.
+     */
     @LuaFunction
     public final Object[] getPageSize() throws LuaException
     {
@@ -76,12 +99,22 @@ public class PrinterPeripheral implements IPeripheral
         return new Object[] { width, height };
     }
 
+    /**
+     * Starts printing a new page.
+     *
+     * @return Whether a new page could be started.
+     */
     @LuaFunction( mainThread = true )
     public final boolean newPage()
     {
         return printer.startNewPage();
     }
 
+    /**
+     * Finalizes printing of the current page and outputs it to the tray.
+     *
+     * @return Whether the page could be successfully finished.
+     */
     @LuaFunction( mainThread = true )
     public final boolean endPage() throws LuaException
     {
@@ -89,6 +122,11 @@ public class PrinterPeripheral implements IPeripheral
         return printer.endCurrentPage();
     }
 
+    /**
+     * Sets the title of the current page.
+     *
+     * @cc.tparam[opt] string title The title to set for the page.
+     */
     @LuaFunction
     public final void setPageTitle( Optional<String> title ) throws LuaException
     {
@@ -96,12 +134,22 @@ public class PrinterPeripheral implements IPeripheral
         printer.setPageTitle( StringUtil.normaliseLabel( title.orElse( "" ) ) );
     }
 
+    /**
+     * Returns the amount of ink left in the printer.
+     *
+     * @return The amount of ink available to print with.
+     */
     @LuaFunction
     public final int getInkLevel()
     {
         return printer.getInkLevel();
     }
 
+    /**
+     * Returns the amount of paper left in the printer.
+     *
+     * @return The amount of paper available to print with.
+     */
     @LuaFunction
     public final int getPaperLevel()
     {

--- a/src/main/java/dan200/computercraft/shared/peripheral/printer/PrinterPeripheral.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/printer/PrinterPeripheral.java
@@ -134,7 +134,6 @@ public class PrinterPeripheral implements IPeripheral
      * Sets the title of the current page.
      *
      * @param title The title to set for the page.
-     * @cc.tparam [opt] string title The title to set for the page.
      * @throws LuaException If a page isn't being printed.
      */
     @LuaFunction

--- a/src/main/java/dan200/computercraft/shared/peripheral/printer/PrinterPeripheral.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/printer/PrinterPeripheral.java
@@ -134,7 +134,7 @@ public class PrinterPeripheral implements IPeripheral
      * Sets the title of the current page.
      *
      * @param title The title to set for the page.
-     * @cc.tparam[opt] string title The title to set for the page.
+     * @cc.tparam [opt] string title The title to set for the page.
      * @throws LuaException If a page isn't being printed.
      */
     @LuaFunction

--- a/src/main/java/dan200/computercraft/shared/peripheral/printer/PrinterPeripheral.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/printer/PrinterPeripheral.java
@@ -45,7 +45,8 @@ public class PrinterPeripheral implements IPeripheral
     /**
      * Writes text to the current page.
      *
-     * @cc.tparam string/number arguments The values to write to the page.
+     * @param arguments The values to write to the page.
+     * @cc.tparam string|number ... The values to write to the page.
      * @throws LuaException If any values couldn't be converted to a string, or if no page is started.
      */
     @LuaFunction
@@ -60,6 +61,7 @@ public class PrinterPeripheral implements IPeripheral
     /**
      * Returns the current position of the cursor on the page.
      *
+     * @return The position of the cursor.
      * @cc.treturn number The X position of the cursor.
      * @cc.treturn number The Y position of the cursor.
      * @throws LuaException If a page isn't being printed.
@@ -90,6 +92,7 @@ public class PrinterPeripheral implements IPeripheral
     /**
      * Returns the size of the current page.
      *
+     * @return The size of the page.
      * @cc.treturn number The width of the page.
      * @cc.treturn number The height of the page.
      * @throws LuaException If a page isn't being printed.
@@ -130,6 +133,7 @@ public class PrinterPeripheral implements IPeripheral
     /**
      * Sets the title of the current page.
      *
+     * @param title The title to set for the page.
      * @cc.tparam[opt] string title The title to set for the page.
      * @throws LuaException If a page isn't being printed.
      */

--- a/src/main/java/dan200/computercraft/shared/peripheral/printer/PrinterPeripheral.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/printer/PrinterPeripheral.java
@@ -45,7 +45,8 @@ public class PrinterPeripheral implements IPeripheral
     /**
      * Writes text to the current page.
      *
-     * @cc.tparam string/number ... The values to write to the page.
+     * @cc.tparam string/number arguments The values to write to the page.
+     * @throws LuaException If any values couldn't be converted to a string, or if no page is started.
      */
     @LuaFunction
     public final void write( IArguments arguments ) throws LuaException
@@ -61,6 +62,7 @@ public class PrinterPeripheral implements IPeripheral
      *
      * @cc.treturn number The X position of the cursor.
      * @cc.treturn number The Y position of the cursor.
+     * @throws LuaException If a page isn't being printed.
      */
     @LuaFunction
     public final Object[] getCursorPos() throws LuaException
@@ -76,6 +78,7 @@ public class PrinterPeripheral implements IPeripheral
      *
      * @param x The X coordinate to set the cursor at.
      * @param y The Y coordinate to set the cursor at.
+     * @throws LuaException If a page isn't being printed.
      */
     @LuaFunction
     public final void setCursorPos( int x, int y ) throws LuaException
@@ -89,6 +92,7 @@ public class PrinterPeripheral implements IPeripheral
      *
      * @cc.treturn number The width of the page.
      * @cc.treturn number The height of the page.
+     * @throws LuaException If a page isn't being printed.
      */
     @LuaFunction
     public final Object[] getPageSize() throws LuaException
@@ -114,6 +118,7 @@ public class PrinterPeripheral implements IPeripheral
      * Finalizes printing of the current page and outputs it to the tray.
      *
      * @return Whether the page could be successfully finished.
+     * @throws LuaException If a page isn't being printed.
      */
     @LuaFunction( mainThread = true )
     public final boolean endPage() throws LuaException
@@ -126,6 +131,7 @@ public class PrinterPeripheral implements IPeripheral
      * Sets the title of the current page.
      *
      * @cc.tparam[opt] string title The title to set for the page.
+     * @throws LuaException If a page isn't being printed.
      */
     @LuaFunction
     public final void setPageTitle( Optional<String> title ) throws LuaException

--- a/src/main/java/dan200/computercraft/shared/peripheral/speaker/SpeakerPeripheral.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/speaker/SpeakerPeripheral.java
@@ -66,9 +66,10 @@ public abstract class SpeakerPeripheral implements IPeripheral
      * with an optional volume and speed multiplier, and plays it through the speaker.
      *
      * @cc.tparam string name The name of the sound to play.
-     * @cc.tparam[opt] number volume The volume to play the sound at, from 0.0 to 3.0. Defaults to 1.0.
-     * @cc.tparam[opt] number speed The speed to play the sound at, from 0.5 to 2.0. Defaults to 1.0.
+     * @cc.tparam[opt] number volumeA The volume to play the sound at, from 0.0 to 3.0. Defaults to 1.0.
+     * @cc.tparam[opt] number pitchA The speed to play the sound at, from 0.5 to 2.0. Defaults to 1.0.
      * @return Whether the sound could be played.
+     * @throws LuaException If the sound name couldn't be decoded.
      */
     @LuaFunction
     public final boolean playSound( ILuaContext context, String name, Optional<Double> volumeA, Optional<Double> pitchA ) throws LuaException
@@ -100,9 +101,10 @@ public abstract class SpeakerPeripheral implements IPeripheral
      * and 6 and 18 map to C.
      *
      * @cc.tparam string name The name of the note to play.
-     * @cc.tparam[opt] number volume The volume to play the note at, from 0.0 to 3.0. Defaults to 1.0.
-     * @cc.tparam[opt] number pitch The pitch to play the note at in semitones, from 0 to 24. Defaults to 12.
+     * @cc.tparam[opt] number volumeA The volume to play the note at, from 0.0 to 3.0. Defaults to 1.0.
+     * @cc.tparam[opt] number pitchA The pitch to play the note at in semitones, from 0 to 24. Defaults to 12.
      * @return Whether the note could be played.
+     * @throws LuaException If the instrument doesn't exist.
      */
     @LuaFunction
     public final synchronized boolean playNote( ILuaContext context, String name, Optional<Double> volumeA, Optional<Double> pitchA ) throws LuaException

--- a/src/main/java/dan200/computercraft/shared/peripheral/speaker/SpeakerPeripheral.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/speaker/SpeakerPeripheral.java
@@ -58,6 +58,18 @@ public abstract class SpeakerPeripheral implements IPeripheral
         return "speaker";
     }
 
+    /**
+     * Plays a sound through the speaker.
+     *
+     * This plays sounds similar to the {@code /playsound} command in Minecraft.
+     * It takes the namespaced path of a sound (e.g. {@code minecraft:block.note_block.harp})
+     * with an optional volume and speed multiplier, and plays it through the speaker.
+     *
+     * @cc.tparam string name The name of the sound to play.
+     * @cc.tparam[opt] number volume The volume to play the sound at, from 0.0 to 3.0. Defaults to 1.0.
+     * @cc.tparam[opt] number speed The speed to play the sound at, from 0.5 to 2.0. Defaults to 1.0.
+     * @return Whether the sound could be played.
+     */
     @LuaFunction
     public final boolean playSound( ILuaContext context, String name, Optional<Double> volumeA, Optional<Double> pitchA ) throws LuaException
     {
@@ -77,6 +89,21 @@ public abstract class SpeakerPeripheral implements IPeripheral
         return playSound( context, identifier, volume, pitch, false );
     }
 
+    /**
+     * Plays a note block note through the speaker.
+     *
+     * This takes the name of a note to play, as well as optionally the volume
+     * and pitch to play the note at.
+     *
+     * The pitch argument uses semitones as the unit. This directly maps to the
+     * number of clicks on a note block. For reference, 0, 12, and 24 map to F#,
+     * and 6 and 18 map to C.
+     *
+     * @cc.tparam string name The name of the note to play.
+     * @cc.tparam[opt] number volume The volume to play the note at, from 0.0 to 3.0. Defaults to 1.0.
+     * @cc.tparam[opt] number pitch The pitch to play the note at in semitones, from 0 to 24. Defaults to 12.
+     * @return Whether the note could be played.
+     */
     @LuaFunction
     public final synchronized boolean playNote( ILuaContext context, String name, Optional<Double> volumeA, Optional<Double> pitchA ) throws LuaException
     {

--- a/src/main/java/dan200/computercraft/shared/peripheral/speaker/SpeakerPeripheral.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/speaker/SpeakerPeripheral.java
@@ -69,9 +69,6 @@ public abstract class SpeakerPeripheral implements IPeripheral
      * @param name The name of the sound to play.
      * @param volumeA The volume to play the sound at, from 0.0 to 3.0. Defaults to 1.0.
      * @param pitchA The speed to play the sound at, from 0.5 to 2.0. Defaults to 1.0.
-     * @cc.tparam string name The name of the sound to play.
-     * @cc.tparam [opt] number volume The volume to play the sound at, from 0.0 to 3.0. Defaults to 1.0.
-     * @cc.tparam [opt] number speed The speed to play the sound at, from 0.5 to 2.0. Defaults to 1.0.
      * @return Whether the sound could be played.
      * @throws LuaException If the sound name couldn't be decoded.
      */
@@ -108,9 +105,6 @@ public abstract class SpeakerPeripheral implements IPeripheral
      * @param name The name of the note to play.
      * @param volumeA The volume to play the note at, from 0.0 to 3.0. Defaults to 1.0.
      * @param pitchA The pitch to play the note at in semitones, from 0 to 24. Defaults to 12.
-     * @cc.tparam string name The name of the note to play.
-     * @cc.tparam [opt] number volume The volume to play the note at, from 0.0 to 3.0. Defaults to 1.0.
-     * @cc.tparam [opt] number pitch The pitch to play the note at in semitones, from 0 to 24. Defaults to 12.
      * @return Whether the note could be played.
      * @throws LuaException If the instrument doesn't exist.
      */

--- a/src/main/java/dan200/computercraft/shared/peripheral/speaker/SpeakerPeripheral.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/speaker/SpeakerPeripheral.java
@@ -70,8 +70,8 @@ public abstract class SpeakerPeripheral implements IPeripheral
      * @param volumeA The volume to play the sound at, from 0.0 to 3.0. Defaults to 1.0.
      * @param pitchA The speed to play the sound at, from 0.5 to 2.0. Defaults to 1.0.
      * @cc.tparam string name The name of the sound to play.
-     * @cc.tparam[opt] number volume The volume to play the sound at, from 0.0 to 3.0. Defaults to 1.0.
-     * @cc.tparam[opt] number speed The speed to play the sound at, from 0.5 to 2.0. Defaults to 1.0.
+     * @cc.tparam [opt] number volume The volume to play the sound at, from 0.0 to 3.0. Defaults to 1.0.
+     * @cc.tparam [opt] number speed The speed to play the sound at, from 0.5 to 2.0. Defaults to 1.0.
      * @return Whether the sound could be played.
      * @throws LuaException If the sound name couldn't be decoded.
      */
@@ -109,8 +109,8 @@ public abstract class SpeakerPeripheral implements IPeripheral
      * @param volumeA The volume to play the note at, from 0.0 to 3.0. Defaults to 1.0.
      * @param pitchA The pitch to play the note at in semitones, from 0 to 24. Defaults to 12.
      * @cc.tparam string name The name of the note to play.
-     * @cc.tparam[opt] number volume The volume to play the note at, from 0.0 to 3.0. Defaults to 1.0.
-     * @cc.tparam[opt] number pitch The pitch to play the note at in semitones, from 0 to 24. Defaults to 12.
+     * @cc.tparam [opt] number volume The volume to play the note at, from 0.0 to 3.0. Defaults to 1.0.
+     * @cc.tparam [opt] number pitch The pitch to play the note at in semitones, from 0 to 24. Defaults to 12.
      * @return Whether the note could be played.
      * @throws LuaException If the instrument doesn't exist.
      */

--- a/src/main/java/dan200/computercraft/shared/peripheral/speaker/SpeakerPeripheral.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/speaker/SpeakerPeripheral.java
@@ -65,9 +65,13 @@ public abstract class SpeakerPeripheral implements IPeripheral
      * It takes the namespaced path of a sound (e.g. {@code minecraft:block.note_block.harp})
      * with an optional volume and speed multiplier, and plays it through the speaker.
      *
+     * @param context The Lua context
+     * @param name The name of the sound to play.
+     * @param volumeA The volume to play the sound at, from 0.0 to 3.0. Defaults to 1.0.
+     * @param pitchA The speed to play the sound at, from 0.5 to 2.0. Defaults to 1.0.
      * @cc.tparam string name The name of the sound to play.
-     * @cc.tparam[opt] number volumeA The volume to play the sound at, from 0.0 to 3.0. Defaults to 1.0.
-     * @cc.tparam[opt] number pitchA The speed to play the sound at, from 0.5 to 2.0. Defaults to 1.0.
+     * @cc.tparam[opt] number volume The volume to play the sound at, from 0.0 to 3.0. Defaults to 1.0.
+     * @cc.tparam[opt] number speed The speed to play the sound at, from 0.5 to 2.0. Defaults to 1.0.
      * @return Whether the sound could be played.
      * @throws LuaException If the sound name couldn't be decoded.
      */
@@ -100,9 +104,13 @@ public abstract class SpeakerPeripheral implements IPeripheral
      * number of clicks on a note block. For reference, 0, 12, and 24 map to F#,
      * and 6 and 18 map to C.
      *
+     * @param context The Lua context
+     * @param name The name of the note to play.
+     * @param volumeA The volume to play the note at, from 0.0 to 3.0. Defaults to 1.0.
+     * @param pitchA The pitch to play the note at in semitones, from 0 to 24. Defaults to 12.
      * @cc.tparam string name The name of the note to play.
-     * @cc.tparam[opt] number volumeA The volume to play the note at, from 0.0 to 3.0. Defaults to 1.0.
-     * @cc.tparam[opt] number pitchA The pitch to play the note at in semitones, from 0 to 24. Defaults to 12.
+     * @cc.tparam[opt] number volume The volume to play the note at, from 0.0 to 3.0. Defaults to 1.0.
+     * @cc.tparam[opt] number pitch The pitch to play the note at in semitones, from 0 to 24. Defaults to 12.
      * @return Whether the note could be played.
      * @throws LuaException If the instrument doesn't exist.
      */


### PR DESCRIPTION
This PR adds some documentation for APIs that did not have docs in the
source yet. This includes:
* the drive peripheral
* the FS API
* the OS PAI
* the printer peripheral
* the speaker peripheral

The term API also needs documenting, but the TermAPI.java file does not
have the actual functions inside it, so they'll need to go elsewhere.
The turtle API also needs some further documentation, but I don't know
much about it. The official CC wiki can fill in the holes eventually.

This will help towards resolving #133, and builds upon 9f8774960fe01f673fc9eae48a2dbfff100fb770 by enhancing the resulting docs.

Note: I mostly used the standard Javadoc `@param` and `@return` tags, while using the `@cc` tags when dealing with optional parameters. I'm not sure what code style is preferred, but I tried to follow the style of other comments as best as possible.