### PR TITLE
Add port to Host http header if necessary

### DIFF
--- a/src/main/java/dan200/computercraft/core/apis/http/request/HttpRequestHandler.java
+++ b/src/main/java/dan200/computercraft/core/apis/http/request/HttpRequestHandler.java
@@ -86,7 +86,7 @@ public final class HttpRequestHandler extends SimpleChannelInboundHandler<HttpOb
         {
             request.headers().set( HttpHeaderNames.USER_AGENT, this.request.environment().getComputerEnvironment().getUserAgent() );
         }
-        request.headers().set( HttpHeaderNames.HOST, uri.getHost() );
+        request.headers().set( HttpHeaderNames.HOST, uri.getPort() < 0 ? uri.getHost() : uri.getHost() + ":" + uri.getPort() );
         request.headers().set( HttpHeaderNames.CONNECTION, HttpHeaderValues.CLOSE );
 
         ctx.channel().writeAndFlush( request );


### PR DESCRIPTION
Host header must contain port if it is not default port for the protocol.
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host