### PR TITLE
Pretty sure FileSystemWrapperMount.isDirectory() should call Filesystem.isDir(), not Filesystem.exists()

### DIFF
--- a/src/main/java/dan200/computercraft/core/filesystem/FileSystemWrapperMount.java
+++ b/src/main/java/dan200/computercraft/core/filesystem/FileSystemWrapperMount.java
@@ -124,7 +124,7 @@ public class FileSystemWrapperMount implements IFileSystem
     {
         try
         {
-            return m_filesystem.exists( path );
+            return m_filesystem.isDir( path );
         }
         catch( FileSystemException e )
         {


### PR DESCRIPTION
Pretty sure FileSystemWrapperMount.isDirectory() should call Filesystem.isDir(), not Filesystem.exists(), otherwise it's just doing the same as FileSystemWrapperMount.exists()