### PR TITLE
Add date-specific MOTDs (like Minecraft)

### DIFF
--- a/src/main/resources/data/computercraft/lua/rom/programs/motd.lua
+++ b/src/main/resources/data/computercraft/lua/rom/programs/motd.lua
@@ -1,15 +1,24 @@
-local tMotd = {}
+local date = os.date("*t")
+if date.month == 1 and date.day == 1 then
+    print("Happy new year!")
+elseif date.month == 12 and date.day == 24 then
+    print("Merry X-mas!")
+elseif date.month == 10 and date.day == 31 then
+    print("OOoooOOOoooo! Spooky!")
+else
+    local tMotd = {}
 
-for sPath in string.gmatch(settings.get("motd.path"), "[^:]+") do
-    if fs.exists(sPath) then
-        for sLine in io.lines(sPath) do
-            table.insert(tMotd, sLine)
+    for sPath in string.gmatch(settings.get("motd.path"), "[^:]+") do
+        if fs.exists(sPath) then
+            for sLine in io.lines(sPath) do
+                table.insert(tMotd, sLine)
+            end
         end
     end
-end
 
-if #tMotd == 0 then
-    print("missingno")
-else
-    print(tMotd[math.random(1, #tMotd)])
+    if #tMotd == 0 then
+        print("missingno")
+    else
+        print(tMotd[math.random(1, #tMotd)])
+    end
 end

--- a/src/test/resources/test-rom/spec/programs/motd_spec.lua
+++ b/src/test/resources/test-rom/spec/programs/motd_spec.lua
@@ -1,14 +1,33 @@
 local capture = require "test_helpers".capture_program
 
 describe("The motd program", function()
+        
+    local function setup_date(month, day)
+        stub(_G, "os", { date = function() return { month = month, day = day } end })
+    end
 
-    it("displays MODT", function()
-        local file = fs.open("/modt_check.txt", "w")
+    it("displays MOTD", function()
+        setup_date(0, 0)
+        local file = fs.open("/motd_check.txt", "w")
         file.write("Hello World!")
         file.close()
-        settings.set("motd.path", "/modt_check.txt")
+        settings.set("motd.path", "/motd_check.txt")
 
         expect(capture(stub, "motd"))
             :matches { ok = true, output = "Hello World!\n", error = "" }
+    end)
+        
+    it("displays date-specific MOTD", function()
+        setup_date(1, 1)
+        expect(capture(stub, "motd"))
+            :matches { ok = true, output = "Happy new year!\n", error = "" }
+                
+        setup_date(10, 31)
+        expect(capture(stub, "motd"))
+            :matches { ok = true, output = "OOoooOOOoooo! Spooky!\n", error = "" }
+        
+        setup_date(12, 24)
+        expect(capture(stub, "motd"))
+            :matches { ok = true, output = "Merry X-mas!\n", error = "" }
     end)
 end)

--- a/src/test/resources/test-rom/spec/programs/motd_spec.lua
+++ b/src/test/resources/test-rom/spec/programs/motd_spec.lua
@@ -2,13 +2,7 @@ local capture = require "test_helpers".capture_program
 
 describe("The motd program", function()
     local function setup_date(month, day)
-        stub(_G, "os", {
-            date = function() return { month = month, day = day } end,
-            run = os.run,
-            queueEvent = os.queueEvent,
-            pullEvent = os.pullEvent,
-            startTimer = os.startTimer,
-        })
+        stub(os, "date", function() return { month = month, day = day } end)
     end
 
     it("displays MOTD", function()

--- a/src/test/resources/test-rom/spec/programs/motd_spec.lua
+++ b/src/test/resources/test-rom/spec/programs/motd_spec.lua
@@ -1,7 +1,6 @@
 local capture = require "test_helpers".capture_program
 
 describe("The motd program", function()
-        
     local function setup_date(month, day)
         stub(_G, "os", {
             date = function() return { month = month, day = day } end,
@@ -22,19 +21,19 @@ describe("The motd program", function()
         expect(capture(stub, "motd"))
             :matches { ok = true, output = "Hello World!\n", error = "" }
     end)
-        
+
     it("displays date-specific MOTD (1/1)", function()
         setup_date(1, 1)
         expect(capture(stub, "motd"))
             :matches { ok = true, output = "Happy new year!\n", error = "" }
     end)
-        
+
     it("displays date-specific MOTD (10/31)", function()
         setup_date(10, 31)
         expect(capture(stub, "motd"))
             :matches { ok = true, output = "OOoooOOOoooo! Spooky!\n", error = "" }
     end)
-        
+
     it("displays date-specific MOTD (12/24)", function()
         setup_date(12, 24)
         expect(capture(stub, "motd"))

--- a/src/test/resources/test-rom/spec/programs/motd_spec.lua
+++ b/src/test/resources/test-rom/spec/programs/motd_spec.lua
@@ -3,7 +3,7 @@ local capture = require "test_helpers".capture_program
 describe("The motd program", function()
         
     local function setup_date(month, day)
-        stub(_G, "os", { date = function() return { month = month, day = day } end })
+        os.date = function() return { month = month, day = day } end
     end
 
     it("displays MOTD", function()

--- a/src/test/resources/test-rom/spec/programs/motd_spec.lua
+++ b/src/test/resources/test-rom/spec/programs/motd_spec.lua
@@ -17,15 +17,19 @@ describe("The motd program", function()
             :matches { ok = true, output = "Hello World!\n", error = "" }
     end)
         
-    it("displays date-specific MOTD", function()
+    it("displays date-specific MOTD (1/1)", function()
         setup_date(1, 1)
         expect(capture(stub, "motd"))
             :matches { ok = true, output = "Happy new year!\n", error = "" }
-                
+    end)
+        
+    it("displays date-specific MOTD (10/31)", function()
         setup_date(10, 31)
         expect(capture(stub, "motd"))
             :matches { ok = true, output = "OOoooOOOoooo! Spooky!\n", error = "" }
+    end)
         
+    it("displays date-specific MOTD (12/24)", function()
         setup_date(12, 24)
         expect(capture(stub, "motd"))
             :matches { ok = true, output = "Merry X-mas!\n", error = "" }

--- a/src/test/resources/test-rom/spec/programs/motd_spec.lua
+++ b/src/test/resources/test-rom/spec/programs/motd_spec.lua
@@ -8,7 +8,7 @@ describe("The motd program", function()
             run = os.run,
             queueEvent = os.queueEvent,
             pullEvent = os.pullEvent,
-            startTimer = os.startTimer
+            startTimer = os.startTimer,
         })
     end
 

--- a/src/test/resources/test-rom/spec/programs/motd_spec.lua
+++ b/src/test/resources/test-rom/spec/programs/motd_spec.lua
@@ -3,7 +3,13 @@ local capture = require "test_helpers".capture_program
 describe("The motd program", function()
         
     local function setup_date(month, day)
-        os.date = function() return { month = month, day = day } end
+        stub(_G, "os", {
+            date = function() return { month = month, day = day } end,
+            run = os.run,
+            queueEvent = os.queueEvent,
+            pullEvent = os.pullEvent,
+            startTimer = os.startTimer
+        })
     end
 
     it("displays MOTD", function()


### PR DESCRIPTION
This PR adds a few MOTDs from Minecraft that will only be displayed on specific dates. Like Minecraft, they will also be the only MOTDs displayed for that date. The list includes: 
* "Happy new year!" - January 1
* "Merry X-mas!" - December 24
* "OOoooOOOoooo! Spooky!" - October 31

These may be tuned as necessary, since they come from splash text which is shorter than the MOTDs usually are.