### PR TITLE
Don't propagate adjacent redstone signals for computers

### DIFF
--- a/src/main/java/dan200/computercraft/shared/computer/blocks/BlockComputerBase.java
+++ b/src/main/java/dan200/computercraft/shared/computer/blocks/BlockComputerBase.java
@@ -24,6 +24,7 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.world.IBlockReader;
+import net.minecraft.world.IWorldReader;
 import net.minecraft.world.World;
 import net.minecraft.world.server.ServerWorld;
 import net.minecraft.world.storage.loot.LootContext;
@@ -179,5 +180,11 @@ public abstract class BlockComputerBase<T extends TileComputerBase> extends Bloc
             String label = item.getLabel( stack );
             if( label != null ) computer.setLabel( label );
         }
+    }
+
+    @Override
+    public boolean shouldCheckWeakPower( BlockState state, IWorldReader world, BlockPos pos, Direction side )
+    {
+        return false;
     }
 }


### PR DESCRIPTION
Minecraft propagates "strong" redstone signals (those from comparators and repeaters) through solid blocks, allowing them to be picked up on the other side. For example:

![image](https://user-images.githubusercontent.com/4346137/94998730-f7cebe00-05ab-11eb-86fb-b11722396f2e.png)

This also happens with computers, which may not always be desired (see #548). It definitely makes working with redstone a little more awkward. This PR changes computers to not propagate redstone - in the above screenshot the two wires would no longer be lit.

This is _technically_ a breaking change<sup>1</sup>, and does mean computers no longer behave consistently with vanilla redstone components. I think it's worth it, so would appreciate people's thoughts.

<sup>1</sup>: In the sense that redstone mechanics change. Not that Mojang don't do that every few Minecraft versions anyway.