### PR TITLE
Use blit to draw boxes, add colors.toBlit

### DIFF
--- a/src/main/resources/data/computercraft/lua/rom/apis/colors.lua
+++ b/src/main/resources/data/computercraft/lua/rom/apis/colors.lua
@@ -332,3 +332,14 @@ function rgb8(r, g, b)
         return packRGB(r, g, b)
     end
 end
+
+--- Converts the given color to a paint/blit hex character (0-9a-f).
+--
+-- This is equivalent to converting floor(log_2(color)) to hexadecimal.
+--
+-- @tparam number color The color to convert.
+-- @treturn string The blit hex code of the color.
+function toBlit(color)
+    expect(1, color, "number")
+    return string.format("%x", math.floor(math.log(color) / math.log(2)))
+end

--- a/src/main/resources/data/computercraft/lua/rom/apis/colors.lua
+++ b/src/main/resources/data/computercraft/lua/rom/apis/colors.lua
@@ -333,6 +333,12 @@ function rgb8(r, g, b)
     end
 end
 
+-- Colour to hex lookup table for toBlit
+local color_hex_lookup = {}
+for i = 0, 15 do
+    color_hex_lookup[2 ^ i] = string.format("%x", i)
+end
+
 --- Converts the given color to a paint/blit hex character (0-9a-f).
 --
 -- This is equivalent to converting floor(log_2(color)) to hexadecimal.
@@ -341,5 +347,6 @@ end
 -- @treturn string The blit hex code of the color.
 function toBlit(color)
     expect(1, color, "number")
-    return string.format("%x", math.floor(math.log(color) / math.log(2)))
+    return color_hex_lookup[color] or
+        string.format("%x", math.floor(math.log(color) / math.log(2)))
 end

--- a/src/test/resources/test-rom/spec/apis/colors_spec.lua
+++ b/src/test/resources/test-rom/spec/apis/colors_spec.lua
@@ -80,27 +80,8 @@ describe("The colors library", function()
         end)
 
         it("converts all colors", function()
-            local colorsHex = {
-                [colors.white] = "0",
-                [colors.orange] = "1",
-                [colors.magenta] = "2",
-                [colors.lightBlue] = "3",
-                [colors.yellow] = "4",
-                [colors.lime] = "5",
-                [colors.pink] = "6",
-                [colors.gray] = "7",
-                [colors.lightGray] = "8",
-                [colors.cyan] = "9",
-                [colors.purple] = "a",
-                [colors.blue] = "b",
-                [colors.brown] = "c",
-                [colors.green] = "d",
-                [colors.red] = "e",
-                [colors.black] = "f",
-            }
-
-            for color, hex in pairs(colorsHex) do
-                expect(colors.toBlit(color)):eq(hex)
+            for i = 0, 15 do
+                expect(colors.toBlit(2 ^ i)):eq(string.format("%x", i))
             end
         end)
 

--- a/src/test/resources/test-rom/spec/apis/colors_spec.lua
+++ b/src/test/resources/test-rom/spec/apis/colors_spec.lua
@@ -73,4 +73,39 @@ describe("The colors library", function()
         expect(colors.rgb8(0.3, 0.5, 0.6)):equals(0x4c7f99)
         expect({ colors.rgb8(0x4c7f99) }):same { 0x4c / 0xFF, 0x7f / 0xFF, 0.6 }
     end)
+
+    describe("colors.toBlit", function()
+        it("validates arguments", function()
+            expect.error(colors.toBlit, nil):eq("bad argument #1 (expected number, got nil)")
+        end)
+
+        it("converts all colors", function()
+            local colorsHex = {
+                [colors.white] = "0",
+                [colors.orange] = "1",
+                [colors.magenta] = "2",
+                [colors.lightBlue] = "3",
+                [colors.yellow] = "4",
+                [colors.lime] = "5",
+                [colors.pink] = "6",
+                [colors.gray] = "7",
+                [colors.lightGray] = "8",
+                [colors.cyan] = "9",
+                [colors.purple] = "a",
+                [colors.blue] = "b",
+                [colors.brown] = "c",
+                [colors.green] = "d",
+                [colors.red] = "e",
+                [colors.black] = "f",
+            }
+
+            for color, hex in pairs(colorsHex) do
+                expect(colors.toBlit(color)):eq(hex)
+            end
+        end)
+
+        it("floors colors", function()
+            expect(colors.toBlit(16385)):eq("e")
+        end)
+    end)
 end)

--- a/src/test/resources/test-rom/spec/apis/paintutils_spec.lua
+++ b/src/test/resources/test-rom/spec/apis/paintutils_spec.lua
@@ -1,4 +1,19 @@
+local with_window = require "test_helpers".with_window
+
 describe("The paintutils library", function()
+    -- Verifies that a window's lines are equal to the given table of blit
+    -- strings ({{"text", "fg", "bg"}, {"text", "fg", "bg"}...})
+    local function window_eq(w, state)
+        -- Verification of the size isn't really important in the tests, but
+        -- better safe than sorry.
+        local _, height = w.getSize()
+        expect(#state):eq(height)
+
+        for line = 1, height do
+            expect({ w.getLine(line) }):same(state[line])
+        end
+    end
+
     describe("paintutils.parseImage", function()
         it("validates arguments", function()
             paintutils.parseImage("")
@@ -28,6 +43,30 @@ describe("The paintutils library", function()
             expect.error(paintutils.drawLine, 1, 1, 1, nil):eq("bad argument #4 (expected number, got nil)")
             expect.error(paintutils.drawLine, 1, 1, 1, 1, false):eq("bad argument #5 (expected number, got boolean)")
         end)
+
+        it("draws a line going across with custom colour", function()
+            local w = with_window(3, 2, function()
+                paintutils.drawLine(1, 1, 3, 1, colours.red)
+            end)
+
+            window_eq(w, {
+                { "   ", "000", "eee" },
+                { "   ", "000", "fff" },
+            })
+        end)
+
+        it("draws a line going diagonally with term colour", function()
+            local w = with_window(3, 3, function()
+                term.setBackgroundColour(colours.red)
+                paintutils.drawLine(1, 1, 3, 3)
+            end)
+
+            window_eq(w, {
+                { "   ", "000", "eff" },
+                { "   ", "000", "fef" },
+                { "   ", "000", "ffe" },
+            })
+        end)
     end)
 
     describe("paintutils.drawBox", function()
@@ -38,6 +77,45 @@ describe("The paintutils library", function()
             expect.error(paintutils.drawBox, 1, 1, 1, nil):eq("bad argument #4 (expected number, got nil)")
             expect.error(paintutils.drawBox, 1, 1, 1, 1, false):eq("bad argument #5 (expected number, got boolean)")
         end)
+
+        it("draws a box with term colour", function()
+            local w = with_window(3, 3, function()
+                term.setBackgroundColour(colours.red)
+                paintutils.drawBox(1, 1, 3, 3)
+            end)
+
+            window_eq(w, {
+                { "   ", "eee", "eee" },
+                { "   ", "e0e", "efe" },
+                { "   ", "eee", "eee" },
+            })
+        end)
+
+        it("draws a box with custom colour", function()
+            local w = with_window(3, 3, function()
+                paintutils.drawBox(1, 1, 3, 3, colours.red)
+            end)
+
+            window_eq(w, {
+                { "   ", "eee", "eee" },
+                { "   ", "e0e", "efe" },
+                { "   ", "eee", "eee" },
+            })
+        end)
+
+        it("draws a box without overwriting existing content", function()
+            local w = with_window(3, 3, function()
+                term.setCursorPos(2, 2)
+                term.write("a")
+                paintutils.drawBox(1, 1, 3, 3, colours.red)
+            end)
+
+            window_eq(w, {
+                { "   ", "eee", "eee" },
+                { " a ", "e0e", "efe" },
+                { "   ", "eee", "eee" },
+            })
+        end)
     end)
 
     describe("paintutils.drawFilledBox", function()
@@ -47,6 +125,31 @@ describe("The paintutils library", function()
             expect.error(paintutils.drawFilledBox, 1, 1, nil):eq("bad argument #3 (expected number, got nil)")
             expect.error(paintutils.drawFilledBox, 1, 1, 1, nil):eq("bad argument #4 (expected number, got nil)")
             expect.error(paintutils.drawFilledBox, 1, 1, 1, 1, false):eq("bad argument #5 (expected number, got boolean)")
+        end)
+
+        it("draws a filled box with term colour", function()
+            local w = with_window(3, 3, function()
+                term.setBackgroundColour(colours.red)
+                paintutils.drawFilledBox(1, 1, 3, 3)
+            end)
+
+            window_eq(w, {
+                { "   ", "eee", "eee" },
+                { "   ", "eee", "eee" },
+                { "   ", "eee", "eee" },
+            })
+        end)
+
+        it("draws a filled box with custom colour", function()
+            local w = with_window(3, 3, function()
+                paintutils.drawFilledBox(1, 1, 3, 3, colours.red)
+            end)
+
+            window_eq(w, {
+                { "   ", "eee", "eee" },
+                { "   ", "eee", "eee" },
+                { "   ", "eee", "eee" },
+            })
         end)
     end)
 


### PR DESCRIPTION
This PR adds tests to some of the paintutils functions and switches to using term.blit() in drawBox and drawFilledBox (closes #561). I haven't benchmarked the performance of the blit version yet.

The updated paintutils function make use of a new function in `colors`, `colors.toBlit`. This converts the given colour to a paint/blit hex code. It does this with math, so it's definitely not as fast as a lookup table, but it will work more gracefully with invalid, non-po2 colours. It could probably be changed to use a lookup table instead if that's preferred, but the window API already has one in there with its own blit conversion stuff (which looks micro-optimised).