### PR TITLE
epoch not represented in seconds as per the docs

### DIFF
--- a/src/main/java/dan200/computercraft/core/apis/OSAPI.java
+++ b/src/main/java/dan200/computercraft/core/apis/OSAPI.java
@@ -150,7 +150,7 @@ public class OSAPI implements ILuaAPI
 
     private static long getEpochForCalendar( Calendar c )
     {
-        return c.getTime().getTime();
+        return c.getTime().getTime() / 1000;
     }
 
     /**

--- a/src/main/java/dan200/computercraft/core/apis/OSAPI.java
+++ b/src/main/java/dan200/computercraft/core/apis/OSAPI.java
@@ -150,7 +150,7 @@ public class OSAPI implements ILuaAPI
 
     private static long getEpochForCalendar( Calendar c )
     {
-        return c.getTime().getTime() / 1000;
+        return c.getTime().getTime();
     }
 
     /**

--- a/src/main/java/dan200/computercraft/core/apis/OSAPI.java
+++ b/src/main/java/dan200/computercraft/core/apis/OSAPI.java
@@ -380,15 +380,15 @@ public class OSAPI implements ILuaAPI
     /**
      * Returns the number of seconds since an epoch depending on the locale.
      *
-     * * If called with {@code ingame}, returns the number of seconds since the
+     * * If called with {@code ingame}, returns the number of milliseconds since the
      * world was created. This is the default.
-     * * If called with {@code utc}, returns the number of seconds since 1
+     * * If called with {@code utc}, returns the number of milliseconds since 1
      * January 1970 in the UTC timezone.
-     * * If called with {@code local}, returns the number of seconds since 1
+     * * If called with {@code local}, returns the number of milliseconds since 1
      * January 1970 in the server's local timezone.
      *
      * @param args The locale to get the seconds for. Defaults to {@code ingame} if not set.
-     * @return The seconds since the epoch depending on the selected locale.
+     * @return The milliseconds since the epoch depending on the selected locale.
      * @throws LuaException If an invalid locale is passed.
      */
     @LuaFunction

--- a/src/main/java/dan200/computercraft/core/apis/OSAPI.java
+++ b/src/main/java/dan200/computercraft/core/apis/OSAPI.java
@@ -387,7 +387,7 @@ public class OSAPI implements ILuaAPI
      * * If called with {@code local}, returns the number of milliseconds since 1
      * January 1970 in the server's local timezone.
      *
-     * @param args The locale to get the seconds for. Defaults to {@code ingame} if not set.
+     * @param args The locale to get the milliseconds for. Defaults to {@code ingame} if not set.
      * @return The milliseconds since the epoch depending on the selected locale.
      * @throws LuaException If an invalid locale is passed.
      */

--- a/src/main/java/dan200/computercraft/core/apis/OSAPI.java
+++ b/src/main/java/dan200/computercraft/core/apis/OSAPI.java
@@ -378,7 +378,7 @@ public class OSAPI implements ILuaAPI
     }
 
     /**
-     * Returns the number of seconds since an epoch depending on the locale.
+     * Returns the number of milliseconds since an epoch depending on the locale.
      *
      * * If called with {@code ingame}, returns the number of milliseconds since the
      * world was created. This is the default.


### PR DESCRIPTION
Not sure if you want to update the docs to reflect milliseconds or update the code to reflect seconds. Regardless, here is a PR changing the milliseconds to seconds.

**Issue**
https://github.com/SquidDev-CC/CC-Tweaked/issues/579
