### PR TITLE
Fixed length check on function name in `expect`

### DIFF
--- a/src/main/resources/data/computercraft/lua/rom/modules/main/cc/expect.lua
+++ b/src/main/resources/data/computercraft/lua/rom/modules/main/cc/expect.lua
@@ -53,7 +53,7 @@ local function expect(index, value, ...)
     local name
     if native_type(debug) == "table" and native_type(debug.getinfo) == "function" then
         local ok, info = pcall(debug.getinfo, 3, "nS")
-        if ok and info.name and #info.name ~= "" and info.what ~= "C" then name = info.name end
+        if ok and info.name and info.name ~= "" and info.what ~= "C" then name = info.name end
     end
 
     local type_names = get_type_names(...)


### PR DESCRIPTION
This PR fixes a tiny typo in `expect.expect` when getting the calling function's name. The current code tries to compare the length of the name to an empty string, which fails. This removes the length operator to compare the name itself with an empty string.
