### PR TITLE
Added improved help viewer

### DIFF
--- a/src/main/resources/data/computercraft/lua/rom/programs/help.lua
+++ b/src/main/resources/data/computercraft/lua/rom/programs/help.lua
@@ -21,7 +21,7 @@ if file then
 
     local w, h = term.getSize()
     local oldterm = term.redirect(window.create(term.current(), 1, 1, w, h, false))
-    local len = print(sContents:gsub("[-*]", "\7"))
+    local len = print(sContents:gsub("(\n *)[-*]( +)", "%1\7%2"))
     term.redirect(oldterm)
     local win = window.create(term.current(), 1, 1, w, len)
     term.clear()

--- a/src/main/resources/data/computercraft/lua/rom/programs/help.lua
+++ b/src/main/resources/data/computercraft/lua/rom/programs/help.lua
@@ -21,39 +21,43 @@ if file then
 
     local w, h = term.getSize()
     local oldterm = term.redirect(window.create(term.current(), 1, 1, w, h, false))
-    local len = print(sContents)
+    local len = print(sContents:gsub("[-*]", "\7"))
     term.redirect(oldterm)
     local win = window.create(term.current(), 1, 1, w, len)
+    term.clear()
     oldterm = term.redirect(win)
     write(sContents)
     local yPos = 1
     while true do
         local ev = { os.pullEvent() }
         if ev[1] == "key" then
-           if ev[2] == keys.up and yPos < 1 then
-               yPos = yPos + 1
-               win.reposition(1, yPos)
-           elseif ev[2] == keys.down and yPos > -len + h + 1 then
-               yPos = yPos - 1
-               win.reposition(1, yPos)
-            elseif ev[2] == keys.pageUp and yPos < 1 then
-                yPos = math.min(yPos + h, 1)
-                win.reposition(1, yPos)
-            elseif ev[2] == keys.pageDown and yPos > -len + h + 1 then
-                yPos = math.max(yPos - h, -len + h + 1)
-               win.reposition(1, yPos)
-           elseif ev[2] == keys.home then
-                yPos = 1
-               win.reposition(1, yPos)
-            elseif ev[2] == keys["end"] then
-                yPos = -len + h + 1
-                win.reposition(1, yPos)
-           elseif ev[2] == keys.q then break end
-       elseif ev[1] == "mouse_scroll" then
-           if ev[2] == -1 and yPos < 1 then
+            if len > h then
+                if ev[2] == keys.up and yPos < 1 then
+                    yPos = yPos + 1
+                    win.reposition(1, yPos)
+                elseif ev[2] == keys.down and yPos > -len + h + 1 then
+                    yPos = yPos - 1
+                    win.reposition(1, yPos)
+                elseif ev[2] == keys.pageUp and yPos < 1 then
+                    yPos = math.min(yPos + h, 1)
+                    win.reposition(1, yPos)
+                elseif ev[2] == keys.pageDown and yPos > -len + h + 1 then
+                    yPos = math.max(yPos - h, -len + h + 1)
+                    win.reposition(1, yPos)
+                elseif ev[2] == keys.home then
+                    yPos = 1
+                    win.reposition(1, yPos)
+                elseif ev[2] == keys["end"] then
+                    yPos = -len + h + 1
+                    win.reposition(1, yPos)
+                end
+            end
+            if ev[2] == keys.q then break end
+       elseif ev[1] == "mouse_scroll" and len > h then
+            if ev[2] == -1 and yPos < 1 then
                 yPos = yPos + 1
                 win.reposition(1, yPos)
-           elseif ev[2] == 1 and yPos > -len + h + 1 then
+            elseif ev[2] == 1 and yPos > -len + h + 1 then
                 yPos = yPos - 1
                 win.reposition(1, yPos)
             end

--- a/src/main/resources/data/computercraft/lua/rom/programs/help.lua
+++ b/src/main/resources/data/computercraft/lua/rom/programs/help.lua
@@ -103,10 +103,10 @@ while true do
         end
     elseif event == "mouse_scroll" then
         if param < 0 and offset > 0 then
-            offset = offset + 1
+            offset = offset - 1
             draw()
         elseif param > 0 and offset < print_height - height then
-            offset = offset - 1
+            offset = offset + 1
             draw()
         end
     elseif event == "term_resize" then

--- a/src/main/resources/data/computercraft/lua/rom/programs/help.lua
+++ b/src/main/resources/data/computercraft/lua/rom/programs/help.lua
@@ -17,6 +17,7 @@ local sFile = help.lookup(sTopic)
 local file = sFile ~= nil and io.open(sFile) or nil
 if not file then
     printError("No help available")
+    return
 end
 
 local contents = file:read("*a"):gsub("(\n *)[-*]( +)", "%1\7%2")

--- a/src/main/resources/data/computercraft/lua/rom/programs/help.lua
+++ b/src/main/resources/data/computercraft/lua/rom/programs/help.lua
@@ -39,7 +39,7 @@ if file then
     while true do
         local ev = { os.pullEvent() }
         if ev[1] == "key" then
-            if len > h then
+            if len > h - 1 then
                 if ev[2] == keys.up and yPos < 1 then
                     yPos = yPos + 1
                     win.reposition(1, yPos)
@@ -67,7 +67,7 @@ if file then
                 end
             end
             if ev[2] == keys.q then break end
-       elseif ev[1] == "mouse_scroll" and len > h then
+       elseif ev[1] == "mouse_scroll" and len > h - 1 then
             if ev[2] == -1 and yPos < 1 then
                 yPos = yPos + 1
                 win.reposition(1, yPos)

--- a/src/main/resources/data/computercraft/lua/rom/programs/help.lua
+++ b/src/main/resources/data/computercraft/lua/rom/programs/help.lua
@@ -15,73 +15,118 @@ end
 
 local sFile = help.lookup(sTopic)
 local file = sFile ~= nil and io.open(sFile) or nil
-if file then
-    local sContents = file:read("*a")
-    file:close()
+if not file then
+    printError("No help available")
+end
 
-    local w, h = term.getSize()
-    local oldterm = term.redirect(window.create(term.current(), 1, 1, w, h, false))
-    local len = print(sContents)
-    term.redirect(oldterm)
-    local win = window.create(term.current(), 1, 1, w, len)
-    local infowin = window.create(term.current(), 1, h, w, 1)
-    if term.isColor() then infowin.setTextColor(colors.yellow)
-    else infowin.setTextColor(colors.lightGray) end
-    infowin.clear()
-    infowin.write("Help: " .. sTopic)
-    infowin.setCursorPos(w - 14, 1)
-    infowin.write("Press Q to exit")
-    term.clear()
-    oldterm = term.redirect(win)
-    write(sContents:gsub("(\n *)[-*]( +)", "%1\7%2"))
-    infowin.redraw()
-    local yPos = 1
-    while true do
-        local ev = { os.pullEvent() }
-        if ev[1] == "key" then
-            if len > h - 1 then
-                if ev[2] == keys.up and yPos < 1 then
-                    yPos = yPos + 1
-                    win.reposition(1, yPos)
-                    infowin.redraw()
-                elseif ev[2] == keys.down and yPos > -len + h then
-                    yPos = yPos - 1
-                    win.reposition(1, yPos)
-                    infowin.redraw()
-                elseif ev[2] == keys.pageUp and yPos < 1 then
-                    yPos = math.min(yPos + h, 1)
-                    win.reposition(1, yPos)
-                    infowin.redraw()
-                elseif ev[2] == keys.pageDown and yPos > -len + h then
-                    yPos = math.max(yPos - h, -len + h)
-                    win.reposition(1, yPos)
-                    infowin.redraw()
-                elseif ev[2] == keys.home then
-                    yPos = 1
-                    win.reposition(1, yPos)
-                    infowin.redraw()
-                elseif ev[2] == keys["end"] then
-                    yPos = -len + h
-                    win.reposition(1, yPos)
-                    infowin.redraw()
-                end
-            end
-            if ev[2] == keys.q then break end
-       elseif ev[1] == "mouse_scroll" and len > h - 1 then
-            if ev[2] == -1 and yPos < 1 then
-                yPos = yPos + 1
-                win.reposition(1, yPos)
-                infowin.redraw()
-            elseif ev[2] == 1 and yPos > -len + h then
-                yPos = yPos - 1
-                win.reposition(1, yPos)
-                infowin.redraw()
-            end
+local contents = file:read("*a"):gsub("(\n *)[-*]( +)", "%1\7%2")
+file:close()
+
+local width, height = term.getSize()
+local buffer = window.create(term.current(), 1, 1, width, height, false)
+local old_term = term.redirect(buffer)
+
+local print_height = print(contents) + 1
+
+-- If we fit within the screen, just display without pagination.
+if print_height <= height then
+    term.redirect(old_term)
+    print(contents)
+    return
+end
+
+local function draw_buffer(width)
+    buffer.reposition(1, 1, width, print_height)
+    buffer.clear()
+    buffer.setCursorPos(1, 1)
+    print(contents)
+    term.redirect(old_term)
+end
+
+local offset = 0
+
+local function draw()
+    for y = 1, height - 1 do
+        term.setCursorPos(1, y)
+        if y + offset > print_height then
+             -- Should only happen if we resize the terminal to a larger one
+             -- than actually needed for the current text.
+            term.clearLine()
+        else
+            term.blit(buffer.getLine(y + offset))
         end
     end
-    term.redirect(oldterm)
-    term.setCursorPos(1, 1)
-    term.clear()
-else
-    print("No help available")
 end
+
+local function draw_menu()
+    term.setTextColor(colors.yellow)
+    term.setCursorPos(1, height)
+    term.clearLine()
+
+    local tag = "Help: " .. sTopic
+    term.write("Help: " .. sTopic)
+
+    if width >= #tag + 15 then
+        term.setCursorPos(width - 14, height)
+        term.write("Press Q to exit")
+    end
+end
+
+draw_buffer(width)
+draw()
+draw_menu()
+
+while true do
+    local event, param = os.pullEvent()
+    if event == "key" then
+        if param == keys.up and offset > 0 then
+            offset = offset - 1
+            draw()
+        elseif param == keys.down and offset < print_height - height then
+            offset = offset + 1
+            draw()
+        elseif param == keys.pageUp and offset > 0 then
+            offset = math.min(offset + height, 0)
+            draw()
+        elseif param == keys.pageDown and offset < print_height - height then
+            offset = math.max(offset - height, print_height - height)
+            draw()
+        elseif param == keys.home then
+            offset = 0
+            draw()
+        elseif param == keys["end"] then
+            offset = print_height - height
+            draw()
+        elseif param == keys.q then
+            sleep(0) -- Super janky, but consumes stray "char" events.
+            break
+        end
+    elseif event == "mouse_scroll" then
+        if param < 0 and offset > 0 then
+            offset = offset + 1
+            draw()
+        elseif param > 0 and offset < print_height - height then
+            offset = offset - 1
+            draw()
+        end
+    elseif event == "term_resize" then
+        local new_width, new_height = term.getSize()
+
+        if new_width ~= width then
+            buffer.setCursorPos(1, 1)
+            buffer.reposition(1, 1, new_width, print_height)
+            term.redirect(buffer)
+            print_height = print(contents) + 1
+            draw_buffer(new_width)
+        end
+
+        width, height = new_width, new_height
+        offset = math.max(math.min(offset, print_height - height), 0)
+        draw()
+        draw_menu()
+    end
+end
+
+term.redirect(old_term)
+term.setCursorPos(1, 1)
+term.clear()

--- a/src/main/resources/data/computercraft/lua/rom/programs/help.lua
+++ b/src/main/resources/data/computercraft/lua/rom/programs/help.lua
@@ -67,7 +67,7 @@ local function draw_menu()
     local tag = "Help: " .. sTopic
     term.write("Help: " .. sTopic)
 
-    if width >= #tag + 15 then
+    if width >= #tag + 16 then
         term.setCursorPos(width - 14, height)
         term.write("Press Q to exit")
     end

--- a/src/main/resources/data/computercraft/lua/rom/programs/help.lua
+++ b/src/main/resources/data/computercraft/lua/rom/programs/help.lua
@@ -19,8 +19,49 @@ if file then
     local sContents = file:read("*a")
     file:close()
 
-    local _, nHeight = term.getSize()
-    textutils.pagedPrint(sContents, nHeight - 3)
+    local w, h = term.getSize()
+    local oldterm = term.redirect(window.create(term.current(), 1, 1, w, h, false))
+    local len = print(sContents)
+    term.redirect(oldterm)
+    local win = window.create(term.current(), 1, 1, w, len)
+    oldterm = term.redirect(win)
+    write(sContents)
+    local yPos = 1
+    while true do
+        local ev = { os.pullEvent() }
+        if ev[1] == "key" then
+           if ev[2] == keys.up and yPos < 1 then
+               yPos = yPos + 1
+               win.reposition(1, yPos)
+           elseif ev[2] == keys.down and yPos > -len + h + 1 then
+               yPos = yPos - 1
+               win.reposition(1, yPos)
+            elseif ev[2] == keys.pageUp and yPos < 1 then
+                yPos = math.min(yPos + h, 1)
+                win.reposition(1, yPos)
+            elseif ev[2] == keys.pageDown and yPos > -len + h + 1 then
+                yPos = math.max(yPos - h, -len + h + 1)
+               win.reposition(1, yPos)
+           elseif ev[2] == keys.home then
+                yPos = 1
+               win.reposition(1, yPos)
+            elseif ev[2] == keys["end"] then
+                yPos = -len + h + 1
+                win.reposition(1, yPos)
+           elseif ev[2] == keys.q then break end
+       elseif ev[1] == "mouse_scroll" then
+           if ev[2] == -1 and yPos < 1 then
+                yPos = yPos + 1
+                win.reposition(1, yPos)
+           elseif ev[2] == 1 and yPos > -len + h + 1 then
+                yPos = yPos - 1
+                win.reposition(1, yPos)
+            end
+        end
+    end
+    term.redirect(oldterm)
+    term.setCursorPos(1, 1)
+    term.clear()
 else
     print("No help available")
 end

--- a/src/main/resources/data/computercraft/lua/rom/programs/help.lua
+++ b/src/main/resources/data/computercraft/lua/rom/programs/help.lua
@@ -34,7 +34,7 @@ if file then
     term.clear()
     oldterm = term.redirect(win)
     write(sContents:gsub("(\n *)[-*]( +)", "%1\7%2"))
-    oldterm.redraw()
+    infowin.redraw()
     local yPos = 1
     while true do
         local ev = { os.pullEvent() }
@@ -43,27 +43,27 @@ if file then
                 if ev[2] == keys.up and yPos < 1 then
                     yPos = yPos + 1
                     win.reposition(1, yPos)
-                    oldterm.redraw()
+                    infowin.redraw()
                 elseif ev[2] == keys.down and yPos > -len + h then
                     yPos = yPos - 1
                     win.reposition(1, yPos)
-                    oldterm.redraw()
+                    infowin.redraw()
                 elseif ev[2] == keys.pageUp and yPos < 1 then
                     yPos = math.min(yPos + h, 1)
                     win.reposition(1, yPos)
-                    oldterm.redraw()
+                    infowin.redraw()
                 elseif ev[2] == keys.pageDown and yPos > -len + h then
                     yPos = math.max(yPos - h, -len + h)
                     win.reposition(1, yPos)
-                    oldterm.redraw()
+                    infowin.redraw()
                 elseif ev[2] == keys.home then
                     yPos = 1
                     win.reposition(1, yPos)
-                    oldterm.redraw()
+                    infowin.redraw()
                 elseif ev[2] == keys["end"] then
                     yPos = -len + h
                     win.reposition(1, yPos)
-                    oldterm.redraw()
+                    infowin.redraw()
                 end
             end
             if ev[2] == keys.q then break end
@@ -71,11 +71,11 @@ if file then
             if ev[2] == -1 and yPos < 1 then
                 yPos = yPos + 1
                 win.reposition(1, yPos)
-                oldterm.redraw()
+                infowin.redraw()
             elseif ev[2] == 1 and yPos > -len + h then
                 yPos = yPos - 1
                 win.reposition(1, yPos)
-                oldterm.redraw()
+                infowin.redraw()
             end
         end
     end

--- a/src/main/resources/data/computercraft/lua/rom/programs/help.lua
+++ b/src/main/resources/data/computercraft/lua/rom/programs/help.lua
@@ -86,10 +86,10 @@ while true do
             offset = offset + 1
             draw()
         elseif param == keys.pageUp and offset > 0 then
-            offset = math.min(offset + height, 0)
+            offset = math.max(offset - height + 2, 0)
             draw()
         elseif param == keys.pageDown and offset < print_height - height then
-            offset = math.max(offset - height, print_height - height)
+            offset = math.min(offset + height - 2, print_height - height)
             draw()
         elseif param == keys.home then
             offset = 0

--- a/src/main/resources/data/computercraft/lua/rom/programs/help.lua
+++ b/src/main/resources/data/computercraft/lua/rom/programs/help.lua
@@ -21,12 +21,20 @@ if file then
 
     local w, h = term.getSize()
     local oldterm = term.redirect(window.create(term.current(), 1, 1, w, h, false))
-    local len = print(sContents:gsub("(\n *)[-*]( +)", "%1\7%2"))
+    local len = print(sContents)
     term.redirect(oldterm)
     local win = window.create(term.current(), 1, 1, w, len)
+    local infowin = window.create(term.current(), 1, h, w, 1)
+    if term.isColor() then infowin.setTextColor(colors.yellow)
+    else infowin.setTextColor(colors.lightGray) end
+    infowin.clear()
+    infowin.write("Help: " .. sTopic)
+    infowin.setCursorPos(w - 14, 1)
+    infowin.write("Press Q to exit")
     term.clear()
     oldterm = term.redirect(win)
-    write(sContents)
+    write(sContents:gsub("(\n *)[-*]( +)", "%1\7%2"))
+    oldterm.redraw()
     local yPos = 1
     while true do
         local ev = { os.pullEvent() }
@@ -35,21 +43,27 @@ if file then
                 if ev[2] == keys.up and yPos < 1 then
                     yPos = yPos + 1
                     win.reposition(1, yPos)
-                elseif ev[2] == keys.down and yPos > -len + h + 1 then
+                    oldterm.redraw()
+                elseif ev[2] == keys.down and yPos > -len + h then
                     yPos = yPos - 1
                     win.reposition(1, yPos)
+                    oldterm.redraw()
                 elseif ev[2] == keys.pageUp and yPos < 1 then
                     yPos = math.min(yPos + h, 1)
                     win.reposition(1, yPos)
-                elseif ev[2] == keys.pageDown and yPos > -len + h + 1 then
-                    yPos = math.max(yPos - h, -len + h + 1)
+                    oldterm.redraw()
+                elseif ev[2] == keys.pageDown and yPos > -len + h then
+                    yPos = math.max(yPos - h, -len + h)
                     win.reposition(1, yPos)
+                    oldterm.redraw()
                 elseif ev[2] == keys.home then
                     yPos = 1
                     win.reposition(1, yPos)
+                    oldterm.redraw()
                 elseif ev[2] == keys["end"] then
-                    yPos = -len + h + 1
+                    yPos = -len + h
                     win.reposition(1, yPos)
+                    oldterm.redraw()
                 end
             end
             if ev[2] == keys.q then break end
@@ -57,9 +71,11 @@ if file then
             if ev[2] == -1 and yPos < 1 then
                 yPos = yPos + 1
                 win.reposition(1, yPos)
-            elseif ev[2] == 1 and yPos > -len + h + 1 then
+                oldterm.redraw()
+            elseif ev[2] == 1 and yPos > -len + h then
                 yPos = yPos - 1
                 win.reposition(1, yPos)
+                oldterm.redraw()
             end
         end
     end

--- a/src/test/resources/test-rom/spec/programs/help_spec.lua
+++ b/src/test/resources/test-rom/spec/programs/help_spec.lua
@@ -3,6 +3,6 @@ local capture = require "test_helpers".capture_program
 describe("The help program", function()
     it("errors when there is no such help file", function()
         expect(capture(stub, "help nothing"))
-            :matches { ok = true, output = "No help available\n", error = "" }
+            :matches { ok = true, error = "No help available\n", output = "" }
     end)
 end)


### PR DESCRIPTION
I made this file viewer for a release notes viewer in CraftOS-PC. It renders the text into a window that is sized to fit the text, and then moves the window up to scroll down. This viewer can be used as a replacement for help's text viewer (#569) - at least for now. Since it uses `print`/`write` to write the entire text, color is not possible yet, but this could probably be changed over time to add that (possibly with `cc.pretty`?).

This will likely need a bit of work until it's ready for production.

Controls:
* Up/scroll up: Scroll up one line
* Down/scroll down: Scroll down one line
* Page Up: Scroll up one screen
* Page Down: Scroll down one screen
* Home: Scroll to the start
* End: Scroll to the end
* Q: exit