### PR TITLE
Added Numpad Enter Support - bios.lua

### DIFF
--- a/src/main/resources/data/computercraft/lua/bios.lua
+++ b/src/main/resources/data/computercraft/lua/bios.lua
@@ -338,8 +338,8 @@ function read(_sReplaceChar, _tHistory, _fnComplete, _sDefault)
             redraw()
 
         elseif sEvent == "key" then
-            if param == keys.enter then
-                -- Enter
+            if param == keys.enter or param == keys.numPadEnter then
+                -- Enter/Numpad Enter
                 if nCompletion then
                     clear()
                     uncomplete()


### PR DESCRIPTION
Add the ability to use Numpad Enter and have it act just like normal Enter.
(Just like the web-based emulator on the Tweaked.cc wiki)
