### PR TITLE
term.redirect: redirect colo(u)r variants to the other one by default

### DIFF
--- a/src/main/resources/data/computercraft/lua/rom/apis/term.lua
+++ b/src/main/resources/data/computercraft/lua/rom/apis/term.lua
@@ -42,8 +42,22 @@ term.redirect = function(target)
     for k, v in pairs(native) do
         if type(k) == "string" and type(v) == "function" then
             if type(target[k]) ~= "function" then
-                target[k] = function()
-                    error("Redirect object is missing method " .. k .. ".", 2)
+                if k:sub(-6, -1) == 'Colour' then
+                    local delegate = target[k:sub(1, -7) .. 'Color']
+
+                    target[k] = function(...)
+                        target[delegate](...)
+                    end
+                elseif k:sub(-5, -1) == 'Color' then
+                    local delegate = target[k:sub(1, -6) .. 'Colour']
+
+                    target[k] = function(...)
+                        target[delegate](...)
+                    end
+                else
+                    target[k] = function()
+                        error("Redirect object is missing method " .. k .. ".", 2)
+                    end
                 end
             end
         end

--- a/src/main/resources/data/computercraft/lua/rom/apis/term.lua
+++ b/src/main/resources/data/computercraft/lua/rom/apis/term.lua
@@ -46,13 +46,13 @@ term.redirect = function(target)
                     local delegate = target[k:sub(1, -7) .. 'Color']
 
                     target[k] = function(...)
-                        target[delegate](...)
+                        return target[delegate](...)
                     end
                 elseif k:sub(-5, -1) == 'Color' then
                     local delegate = target[k:sub(1, -6) .. 'Colour']
 
                     target[k] = function(...)
-                        target[delegate](...)
+                        return target[delegate](...)
                     end
                 else
                     target[k] = function()

--- a/src/main/resources/data/computercraft/lua/rom/apis/term.lua
+++ b/src/main/resources/data/computercraft/lua/rom/apis/term.lua
@@ -57,7 +57,7 @@ term.redirect = function(target)
                     target[k] = function()
                         error("Redirect object is missing method " .. k .. ".", 2)
                     end
-                    
+
                     -- prevent the delegate from redirecting back to this one and providing a mismatching error message
                     if delegate then
                         target[delegate] = function()

--- a/src/main/resources/data/computercraft/lua/rom/apis/term.lua
+++ b/src/main/resources/data/computercraft/lua/rom/apis/term.lua
@@ -51,9 +51,7 @@ term.redirect = function(target)
                 end
 
                 if delegate and type(target[delegate]) == 'function' then
-                    target[k] = function(...)
-                        return target[delegate](...)
-                    end
+                    target[k] = target[delegate]
                 else
                     -- can happen if both colour and color variants are missing
                     target[k] = function()

--- a/src/main/resources/data/computercraft/lua/rom/apis/term.lua
+++ b/src/main/resources/data/computercraft/lua/rom/apis/term.lua
@@ -43,7 +43,7 @@ term.redirect = function(target)
         if type(k) == "string" and type(v) == "function" then
             if type(target[k]) ~= "function" then
                 local delegate
-                
+
                 if k:sub(-6, -1) == 'Colour' then
                     delegate = target[k:sub(1, -7) .. 'Color']
                 elseif k:sub(-5, -1) == 'Color' then


### PR DESCRIPTION
This allows redirect objects to provide their preferred spelling only, whether it's `colour` or `color`. This also improves compatibility with redirect objects which already do that (where one spelling will work and the other one will error). See https://github.com/MCJack123/craftos2-rom/pull/8

Since the delegate key is calculated once and stored as an upvalue, this offers only a very minimal performance hit at runtime (only the overhead of a single field access and function call when calling redirected functions, plus the one-time hit when `term.redirect` is first called)