### PR TITLE
Added disk.getType (SquidDev-CC/CC-Tweaked#634)

### DIFF
--- a/src/main/java/dan200/computercraft/shared/peripheral/diskdrive/DiskDrivePeripheral.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/diskdrive/DiskDrivePeripheral.java
@@ -11,7 +11,11 @@ import dan200.computercraft.api.media.IMedia;
 import dan200.computercraft.api.peripheral.IComputerAccess;
 import dan200.computercraft.api.peripheral.IPeripheral;
 import dan200.computercraft.shared.MediaProviders;
+import dan200.computercraft.shared.computer.items.ItemComputer;
+import dan200.computercraft.shared.computer.items.ItemComputerBase;
 import dan200.computercraft.shared.media.items.ItemDisk;
+import dan200.computercraft.shared.pocket.items.ItemPocketComputer;
+import dan200.computercraft.shared.turtle.items.ItemTurtle;
 import dan200.computercraft.shared.util.StringUtil;
 import net.minecraft.item.ItemStack;
 
@@ -192,6 +196,25 @@ public class DiskDrivePeripheral implements IPeripheral
     {
         ItemStack disk = diskDrive.getDiskStack();
         return disk.getItem() instanceof ItemDisk ? new Object[] { ItemDisk.getDiskID( disk ) } : null;
+    }
+
+    /**
+     * Returns the type of media currently in the disk drive.
+     *
+     * @return The type of media currently in the disk drive.
+     * @cc.treturn string|nil The type of media currently in the disk drive, or {@code nil} if the type could not be determined.
+     */
+    @LuaFunction
+    public final String getDiskType()
+    {
+        ItemStack stack = diskDrive.getDiskStack();
+        if (stack.isEmpty()) return "empty";
+        else if (stack.getItem() instanceof ItemDisk) return "disk";
+        else if (stack.getItem() instanceof ItemComputerBase) return "computer";
+        else if (stack.getItem() instanceof ItemTurtle) return "turtle";
+        else if (stack.getItem() instanceof ItemPocketComputer) return "pocket";
+        else if (MediaProviders.get(stack) != null && MediaProviders.get(stack).getAudio(stack) != null) return "record";
+        else return null;
     }
 
     @Override

--- a/src/main/java/dan200/computercraft/shared/peripheral/diskdrive/DiskDrivePeripheral.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/diskdrive/DiskDrivePeripheral.java
@@ -208,13 +208,34 @@ public class DiskDrivePeripheral implements IPeripheral
     public final String getDiskType()
     {
         ItemStack stack = diskDrive.getDiskStack();
-        if (stack.isEmpty()) return "empty";
-        else if (stack.getItem() instanceof ItemDisk) return "disk";
-        else if (stack.getItem() instanceof ItemComputerBase) return "computer";
-        else if (stack.getItem() instanceof ItemTurtle) return "turtle";
-        else if (stack.getItem() instanceof ItemPocketComputer) return "pocket";
-        else if (MediaProviders.get(stack) != null && MediaProviders.get(stack).getAudio(stack) != null) return "record";
-        else return null;
+        if ( stack.isEmpty() )
+        {
+            return "empty";
+        }
+        else if ( stack.getItem() instanceof ItemDisk )
+        {
+            return "disk";
+        }
+        else if ( stack.getItem() instanceof ItemComputerBase )
+        {
+            return "computer";
+        }
+        else if ( stack.getItem() instanceof ItemTurtle )
+        {
+            return "turtle";
+        }
+        else if ( stack.getItem() instanceof ItemPocketComputer )
+        {
+            return "pocket";
+        }
+        else if ( MediaProviders.get( stack ) != null && MediaProviders.get( stack ).getAudio( stack ) != null )
+        {
+            return "record";
+        }
+        else
+        {
+            return null;
+        }
     }
 
     @Override

--- a/src/main/java/dan200/computercraft/shared/peripheral/diskdrive/DiskDrivePeripheral.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/diskdrive/DiskDrivePeripheral.java
@@ -11,7 +11,6 @@ import dan200.computercraft.api.media.IMedia;
 import dan200.computercraft.api.peripheral.IComputerAccess;
 import dan200.computercraft.api.peripheral.IPeripheral;
 import dan200.computercraft.shared.MediaProviders;
-import dan200.computercraft.shared.computer.items.ItemComputer;
 import dan200.computercraft.shared.computer.items.ItemComputerBase;
 import dan200.computercraft.shared.media.items.ItemDisk;
 import dan200.computercraft.shared.pocket.items.ItemPocketComputer;

--- a/src/main/resources/data/computercraft/lua/rom/apis/disk.lua
+++ b/src/main/resources/data/computercraft/lua/rom/apis/disk.lua
@@ -169,3 +169,17 @@ function getID(name)
     end
     return nil
 end
+
+--- Returns a string describing the contents of the drive.
+--
+-- This string can be any of "empty", "disk", "record", "computer", "turtle", or "pocket".
+-- It may also be `nil` if the type cannot be detected; however, this should not normally happen.
+--
+-- @tparam string name The name of the disk drive.
+-- @treturn string|nil The type of media in the drive, or `nil` if the type could not be determined.
+function getType(name)
+    if isDrive(name) then
+        return peripheral.call(name, "getDiskType")
+    end
+    return nil
+end


### PR DESCRIPTION
This PR implements `disk.getType` as described in #634, but with a few changes:
* Music disks are reported as `"record"` to avoid ambiguity
* When the drive is empty, it reports `"empty"`
* If the type is unable to be determined (can't really think of a reason why this may be, but mods may add something?), it returns `nil`
* The drive method is currently named `getDiskType` to avoid a collision with `IPeripheral.getType()` - maybe this could be changed? (I'm not super experienced with Cobalt's APIs.)

![screenshot](https://user-images.githubusercontent.com/6236912/103327162-71e2d780-4a21-11eb-8f8d-4d5ebca8cadc.png)

Not sure how well-done this is, but it works enough for me in testing.