### PR TITLE
Allow command computers to drop as loot.

### DIFF
--- a/src/generated/resources/assets/computercraft/models/block/computer_advanced_blinking.json
+++ b/src/generated/resources/assets/computercraft/models/block/computer_advanced_blinking.json
@@ -1,5 +1,5 @@
 {
-  "parent": "block/orientable",
+  "parent": "minecraft:block/orientable",
   "textures": {
     "top": "computercraft:block/computer_advanced_top",
     "side": "computercraft:block/computer_advanced_side",

--- a/src/generated/resources/assets/computercraft/models/block/computer_advanced_off.json
+++ b/src/generated/resources/assets/computercraft/models/block/computer_advanced_off.json
@@ -1,5 +1,5 @@
 {
-  "parent": "block/orientable",
+  "parent": "minecraft:block/orientable",
   "textures": {
     "top": "computercraft:block/computer_advanced_top",
     "side": "computercraft:block/computer_advanced_side",

--- a/src/generated/resources/assets/computercraft/models/block/computer_advanced_on.json
+++ b/src/generated/resources/assets/computercraft/models/block/computer_advanced_on.json
@@ -1,5 +1,5 @@
 {
-  "parent": "block/orientable",
+  "parent": "minecraft:block/orientable",
   "textures": {
     "top": "computercraft:block/computer_advanced_top",
     "side": "computercraft:block/computer_advanced_side",

--- a/src/generated/resources/assets/computercraft/models/block/computer_command_blinking.json
+++ b/src/generated/resources/assets/computercraft/models/block/computer_command_blinking.json
@@ -1,5 +1,5 @@
 {
-  "parent": "block/orientable",
+  "parent": "minecraft:block/orientable",
   "textures": {
     "top": "computercraft:block/computer_command_top",
     "side": "computercraft:block/computer_command_side",

--- a/src/generated/resources/assets/computercraft/models/block/computer_command_off.json
+++ b/src/generated/resources/assets/computercraft/models/block/computer_command_off.json
@@ -1,5 +1,5 @@
 {
-  "parent": "block/orientable",
+  "parent": "minecraft:block/orientable",
   "textures": {
     "top": "computercraft:block/computer_command_top",
     "side": "computercraft:block/computer_command_side",

--- a/src/generated/resources/assets/computercraft/models/block/computer_command_on.json
+++ b/src/generated/resources/assets/computercraft/models/block/computer_command_on.json
@@ -1,5 +1,5 @@
 {
-  "parent": "block/orientable",
+  "parent": "minecraft:block/orientable",
   "textures": {
     "top": "computercraft:block/computer_command_top",
     "side": "computercraft:block/computer_command_side",

--- a/src/generated/resources/assets/computercraft/models/block/computer_normal_blinking.json
+++ b/src/generated/resources/assets/computercraft/models/block/computer_normal_blinking.json
@@ -1,5 +1,5 @@
 {
-  "parent": "block/orientable",
+  "parent": "minecraft:block/orientable",
   "textures": {
     "top": "computercraft:block/computer_normal_top",
     "side": "computercraft:block/computer_normal_side",

--- a/src/generated/resources/assets/computercraft/models/block/computer_normal_off.json
+++ b/src/generated/resources/assets/computercraft/models/block/computer_normal_off.json
@@ -1,5 +1,5 @@
 {
-  "parent": "block/orientable",
+  "parent": "minecraft:block/orientable",
   "textures": {
     "top": "computercraft:block/computer_normal_top",
     "side": "computercraft:block/computer_normal_side",

--- a/src/generated/resources/assets/computercraft/models/block/computer_normal_on.json
+++ b/src/generated/resources/assets/computercraft/models/block/computer_normal_on.json
@@ -1,5 +1,5 @@
 {
-  "parent": "block/orientable",
+  "parent": "minecraft:block/orientable",
   "textures": {
     "top": "computercraft:block/computer_normal_top",
     "side": "computercraft:block/computer_normal_side",

--- a/src/generated/resources/data/computercraft/loot_tables/blocks/computer_command.json
+++ b/src/generated/resources/data/computercraft/loot_tables/blocks/computer_command.json
@@ -1,0 +1,34 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "name": "main",
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:dynamic",
+          "name": "computercraft:computer"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:alternative",
+          "terms": [
+            {
+              "condition": "computercraft:block_named"
+            },
+            {
+              "condition": "computercraft:has_id"
+            },
+            {
+              "condition": "minecraft:inverted",
+              "term": {
+                "condition": "computercraft:player_creative"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/java/dan200/computercraft/data/LootTables.java
+++ b/src/main/java/dan200/computercraft/data/LootTables.java
@@ -43,6 +43,7 @@ public class LootTables extends LootTableProvider
 
         computerDrop( add, Registry.ModBlocks.COMPUTER_NORMAL );
         computerDrop( add, Registry.ModBlocks.COMPUTER_ADVANCED );
+        computerDrop( add, Registry.ModBlocks.COMPUTER_COMMAND );
         computerDrop( add, Registry.ModBlocks.TURTLE_NORMAL );
         computerDrop( add, Registry.ModBlocks.TURTLE_ADVANCED );
 


### PR DESCRIPTION
Fixes #641 

Also a few stray changes triggered by regenerating the data.  They seem correct.  I could split them into separate commits if you prefer.