### PR TITLE
Computers no longer keep IDs 

### DIFF
--- a/src/main/java/dan200/computercraft/shared/computer/items/ComputerItemFactory.java
+++ b/src/main/java/dan200/computercraft/shared/computer/items/ComputerItemFactory.java
@@ -19,7 +19,9 @@ public final class ComputerItemFactory
     @Nonnull
     public static ItemStack create( TileComputer tile )
     {
-        return create( tile.getComputerID(), tile.getLabel(), tile.getFamily() );
+        String label = tile.getLabel();
+        int id = label != null ? tile.getComputerID() : -1;
+        return create( id, label, tile.getFamily() );
     }
 
     @Nonnull

--- a/src/main/java/dan200/computercraft/shared/turtle/items/TurtleItemFactory.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/items/TurtleItemFactory.java
@@ -25,8 +25,11 @@ public final class TurtleItemFactory
     {
         ITurtleAccess access = turtle.getAccess();
 
+        String label = turtle.getLabel();
+        int id = label != null ? turtle.getComputerID() : -1;
+
         return create(
-            turtle.getComputerID(), turtle.getLabel(), turtle.getColour(), turtle.getFamily(),
+            id, turtle.getLabel(), turtle.getColour(), turtle.getFamily(),
             access.getUpgrade( TurtleSide.LEFT ), access.getUpgrade( TurtleSide.RIGHT ),
             access.getFuelLevel(), turtle.getOverlay()
         );

--- a/src/main/resources/data/computercraft/lua/rom/help/label.txt
+++ b/src/main/resources/data/computercraft/lua/rom/help/label.txt
@@ -1,4 +1,5 @@
 label gets or sets the label of the Computer, or of Floppy Disks in attached disk drives.
+Unlabeled Computers will lose their files when broken.
 
 ex:
 "label get" prints the label of the computer.

--- a/src/main/resources/data/computercraft/lua/rom/programs/edit.lua
+++ b/src/main/resources/data/computercraft/lua/rom/programs/edit.lua
@@ -797,3 +797,8 @@ end
 term.clear()
 term.setCursorBlink(false)
 term.setCursorPos(1, 1)
+
+-- Print warning if unlabeled
+if not os.getComputerLabel() then
+    print("Warning! This computer is unlabeled. You will lose your files if you break the block. Type 'help label' for more info.")
+end

--- a/src/main/resources/data/computercraft/lua/rom/programs/http/pastebin.lua
+++ b/src/main/resources/data/computercraft/lua/rom/programs/http/pastebin.lua
@@ -138,6 +138,11 @@ elseif sCommand == "get" then
         file.close()
 
         print("Downloaded as " .. sFile)
+        -- Print warning if unlabeled
+        if not os.getComputerLabel() then
+            print("Warning! This computer is unlabeled. You will lose your files if you break the block. Type 'help label' for more info.")
+        end
+
     end
 elseif sCommand == "run" then
     local sCode = tArgs[2]

--- a/src/main/resources/data/computercraft/lua/rom/programs/http/wget.lua
+++ b/src/main/resources/data/computercraft/lua/rom/programs/http/wget.lua
@@ -84,4 +84,9 @@ else
     file.close()
 
     print("Downloaded as " .. sFile)
+    -- Print warning if unlabeled
+    if not os.getComputerLabel() then
+        print("Warning! This computer is unlabeled. You will lose your files if you break the block. Type 'help label' for more info.")
+    end
+
 end


### PR DESCRIPTION
See #504 for discussion and justification. Happy to continue the discussion in that issue if you aren't convinced.

1. Unlabeled computers and turtles no longer keep their IDs when broken, reverting the behavior introduced in #437.
2. CraftOS programs `edit`, `wget` and `pastebin get` now print a warning to the user after completion, if they are ran on an unlabeled computer.
3. Added a line to the label help doc explaining that unlabeled computers will lose their files.

My warning message is pretty wordy, so I'm happy to hear any other suggestions to slim it down.

Note that the code that displays computer IDs in inventory tooltips is still present, but as far as I'm aware, is now unused. I'm afraid I'm not familiar enough with this project to find and delete that code.