### PR TITLE
Allowed changing how many spaces a tab is in edit.lua

### DIFF
--- a/src/main/resources/data/computercraft/lua/bios.lua
+++ b/src/main/resources/data/computercraft/lua/bios.lua
@@ -969,6 +969,11 @@ settings.define("bios.strict_globals", {
     description = "Prevents assigning variables into a program's environment. Make sure you use the local keyword or assign to _G explicitly.",
     type = "boolean",
 })
+settings.define("edit.indent", {
+    default = 2,    
+    description = "Changes how many spaces will be created when you hit tab in edit.lua."
+    type = "number"
+}
 
 if term.isColour() then
     settings.define("bios.use_multishell", {

--- a/src/main/resources/data/computercraft/lua/bios.lua
+++ b/src/main/resources/data/computercraft/lua/bios.lua
@@ -971,7 +971,7 @@ settings.define("bios.strict_globals", {
 })
 settings.define("edit.indent", {
     default = 2,    
-    description = "Changes how many spaces will be created when you hit tab in edit.lua."
+    description = "Changes how many spaces will be created when you hit tab in edit.lua.",
     type = "number"
 })
 

--- a/src/main/resources/data/computercraft/lua/bios.lua
+++ b/src/main/resources/data/computercraft/lua/bios.lua
@@ -970,9 +970,9 @@ settings.define("bios.strict_globals", {
     type = "boolean",
 })
 settings.define("edit.indent", {
-    default = 2,    
+    default = 4,    
     description = "Changes how many spaces will be created when you hit tab in edit.lua.",
-    type = "number"
+    type = "number",
 })
 
 if term.isColour() then

--- a/src/main/resources/data/computercraft/lua/bios.lua
+++ b/src/main/resources/data/computercraft/lua/bios.lua
@@ -970,7 +970,7 @@ settings.define("bios.strict_globals", {
     type = "boolean",
 })
 settings.define("edit.indent", {
-    default = 4,    
+    default = 4, 
     description = "Changes how many spaces will be created when you hit tab in edit.lua.",
     type = "number",
 })

--- a/src/main/resources/data/computercraft/lua/bios.lua
+++ b/src/main/resources/data/computercraft/lua/bios.lua
@@ -973,7 +973,7 @@ settings.define("edit.indent", {
     default = 2,    
     description = "Changes how many spaces will be created when you hit tab in edit.lua."
     type = "number"
-}
+})
 
 if term.isColour() then
     settings.define("bios.use_multishell", {

--- a/src/main/resources/data/computercraft/lua/bios.lua
+++ b/src/main/resources/data/computercraft/lua/bios.lua
@@ -969,7 +969,7 @@ settings.define("bios.strict_globals", {
     description = "Prevents assigning variables into a program's environment. Make sure you use the local keyword or assign to _G explicitly.",
     type = "boolean",
 })
-settings.define("edit.indent", {
+settings.define("edit.indentWidth", {
     default = 4,
     description = "Changes how many spaces will be created when you hit tab in edit.lua.",
     type = "number",

--- a/src/main/resources/data/computercraft/lua/bios.lua
+++ b/src/main/resources/data/computercraft/lua/bios.lua
@@ -970,7 +970,7 @@ settings.define("bios.strict_globals", {
     type = "boolean",
 })
 settings.define("edit.indent", {
-    default = 4, 
+    default = 4,
     description = "Changes how many spaces will be created when you hit tab in edit.lua.",
     type = "number",
 })

--- a/src/main/resources/data/computercraft/lua/rom/programs/edit.lua
+++ b/src/main/resources/data/computercraft/lua/rom/programs/edit.lua
@@ -532,7 +532,7 @@ while bRunning do
                 else
                     -- Indent line
                     local sLine = tLines[y]
-                    local indent = settings.get("edit.indent")
+                    local indent = settings.get("edit.indentWidth")
                     tLines[y] = string.sub(sLine, 1, x - 1) .. (" "):rep(indent) .. string.sub(sLine, x)
                     setCursor(x + indent, y)
                 end

--- a/src/main/resources/data/computercraft/lua/rom/programs/edit.lua
+++ b/src/main/resources/data/computercraft/lua/rom/programs/edit.lua
@@ -532,8 +532,9 @@ while bRunning do
                 else
                     -- Indent line
                     local sLine = tLines[y]
-                    tLines[y] = string.sub(sLine, 1, x - 1) .. (" "):rep(settings.get("edit.indent")) .. string.sub(sLine, x)
-                    setCursor(x + 4, y)
+                    local indent = settings.get("edit.indent")
+                    tLines[y] = string.sub(sLine, 1, x - 1) .. (" "):rep(indent) .. string.sub(sLine, x)
+                    setCursor(x + indent, y)
                 end
             end
 

--- a/src/main/resources/data/computercraft/lua/rom/programs/edit.lua
+++ b/src/main/resources/data/computercraft/lua/rom/programs/edit.lua
@@ -532,7 +532,7 @@ while bRunning do
                 else
                     -- Indent line
                     local sLine = tLines[y]
-                    tLines[y] = string.sub(sLine, 1, x - 1) .. (" "):rep(settings.get("edit.indent") or 2) .. string.sub(sLine, x)
+                    tLines[y] = string.sub(sLine, 1, x - 1) .. (" "):rep(settings.get("edit.indent")) .. string.sub(sLine, x)
                     setCursor(x + 4, y)
                 end
             end

--- a/src/main/resources/data/computercraft/lua/rom/programs/edit.lua
+++ b/src/main/resources/data/computercraft/lua/rom/programs/edit.lua
@@ -532,7 +532,7 @@ while bRunning do
                 else
                     -- Indent line
                     local sLine = tLines[y]
-                    tLines[y] = string.sub(sLine, 1, x - 1) .. "    " .. string.sub(sLine, x)
+                    tLines[y] = string.sub(sLine, 1, x - 1) .. (" "):rep(settings.get("edit.indent") or 2) .. string.sub(sLine, x)
                     setCursor(x + 4, y)
                 end
             end

--- a/src/main/resources/data/computercraft/lua/rom/programs/edit.lua
+++ b/src/main/resources/data/computercraft/lua/rom/programs/edit.lua
@@ -651,9 +651,10 @@ while bRunning do
                 if x > 1 then
                     -- Remove character
                     local sLine = tLines[y]
-                    if x > 4 and string.sub(sLine, x - 4, x - 1) == "    " and not string.sub(sLine, 1, x - 1):find("%S") then
-                        tLines[y] = string.sub(sLine, 1, x - 5) .. string.sub(sLine, x)
-                        setCursor(x - 4, y)
+                    local indent = settings.get("edit.indentWidth")
+                    if x > indent and string.sub(sLine, x - indent, x - 1) == "    " and not string.sub(sLine, 1, x - 1):find("%S") then
+                        tLines[y] = string.sub(sLine, 1, x - (indent + 1)) .. string.sub(sLine, x)
+                        setCursor(x - indent, y)
                     else
                         tLines[y] = string.sub(sLine, 1, x - 2) .. string.sub(sLine, x)
                         setCursor(x - 1, y)


### PR DESCRIPTION
Added a setting to change how many spaces will be created when you hit tab in the edit program. Default is 2 spaces, as per the Lua style guide.