### PR TITLE
Make rightAlt only close menu, never open it.

### DIFF
--- a/src/main/resources/data/computercraft/lua/rom/programs/edit.lua
+++ b/src/main/resources/data/computercraft/lua/rom/programs/edit.lua
@@ -687,7 +687,7 @@ while bRunning do
 
             end
 
-        elseif param == keys.leftCtrl or param == keys.rightCtrl or param == keys.rightAlt then
+        elseif param == keys.leftCtrl or param == keys.rightCtrl then
             -- Menu toggle
             bMenu = not bMenu
             if bMenu then
@@ -696,7 +696,12 @@ while bRunning do
                 term.setCursorBlink(true)
             end
             redrawMenu()
-
+        elseif param == keys.rightAlt then
+            if bMenu then
+                bMenu = false
+                term.setCursorBlink(true)
+                redrawMenu()
+            end
         end
 
     elseif sEvent == "char" then


### PR DESCRIPTION
Fixes #669

In Edit rightAlt was added to handle fact that on some keyboard layout right alt sends both leftCtrl and rightAlt key codes.
![obraz](https://user-images.githubusercontent.com/5893536/104231090-b96c5900-544e-11eb-8fd9-9ceee1fdf8db.png)
So leftCtrl was opening the menu and rightAlt closed it.
Sadly on keyboards layouts that only send rightAlt this causes it to open the menu instead when user presses it to write special symbol.
![obraz](https://user-images.githubusercontent.com/5893536/104231111-c12bfd80-544e-11eb-8e91-ad3e7330f879.png)
This changes the code to rightAlt acts like paste event and only closes menu when received.
This preserves old functionality while removing unwanted action.