### PR TITLE
Fix/Update id.lua

### DIFF
--- a/src/main/resources/data/computercraft/lua/rom/programs/id.lua
+++ b/src/main/resources/data/computercraft/lua/rom/programs/id.lua
@@ -32,7 +32,7 @@ else
 
     local id = disk.getID(sDrive)
     if id then
-        print("The disk is #" .. disk.getID(sDrive))
+        print("The disk is #" .. id)
     else
         print("Non-disk data medium")
     end

--- a/src/main/resources/data/computercraft/lua/rom/programs/id.lua
+++ b/src/main/resources/data/computercraft/lua/rom/programs/id.lua
@@ -13,19 +13,17 @@ if sDrive == nil then
     end
 
 else
-    local bAudio = disk.hasAudio(sDrive)
-    if bAudio then
-        print("Audio medium")
-
+    if disk.hasAudio(sDrive) then
         local title = disk.getAudioTitle(sDrive)
         if title then
-            print("Audio is titled \"" .. title .. "\"")
+            print("Has audio track \"" .. title .. "\"")
+        else
+            print("Has untitled audio")
         end
         return
     end
 
-    local bData = disk.hasData(sDrive)
-    if not bData then
+    if not disk.hasData(sDrive) then
         print("No disk in drive " .. sDrive)
         return
     end
@@ -34,7 +32,7 @@ else
     if id then
         print("The disk is #" .. id)
     else
-        print("Non-disk data medium")
+        print("Non-disk data source")
     end
 
     local label = disk.getLabel(sDrive)

--- a/src/main/resources/data/computercraft/lua/rom/programs/id.lua
+++ b/src/main/resources/data/computercraft/lua/rom/programs/id.lua
@@ -13,16 +13,32 @@ if sDrive == nil then
     end
 
 else
+    local bAudio = disk.hasAudio(sDrive)
+    if bAudio then
+        print("Audio medium")
+
+        local title = disk.getAudioTitle(sDrive)
+        if title then
+            print("Audio is titled \"" .. title .. "\"")
+        end
+        return
+    end
+
     local bData = disk.hasData(sDrive)
     if not bData then
         print("No disk in drive " .. sDrive)
         return
     end
 
-    print("The disk is #" .. disk.getID(sDrive))
+    local id = disk.getID(sDrive)
+    if id then
+        print("The disk is #" .. disk.getID(sDrive))
+    else
+        print("Non-disk data medium")
+    end
 
     local label = disk.getLabel(sDrive)
     if label then
-        print("The disk is labelled \"" .. label .. "\"")
+        print("Labelled \"" .. label .. "\"")
     end
 end


### PR DESCRIPTION
Resolves concatenate nil error with disk.getID(sDrive) returning nil for non-disk medium. Adds identification for audio and non-disk medium.

Putting it up as draft cause i am unable to capture proper wording for "non-disk medium" and other messages. They feel off to me. Would appreciate someone with better handle on english chipping in.

I tried to keep file in same style as old one despite the fact it could/should be written more cleanly.
Also no tests cause no simple way to simulate peripherals in tests.
