### PR TITLE
Finish the rest of the event documentation

### DIFF
--- a/doc/events/alarm.md
+++ b/doc/events/alarm.md
@@ -1,0 +1,17 @@
+---
+module: [kind=event] alarm
+see: os.setAlarm To start an alarm.
+---
+
+The @{timer} event is fired when an alarm started with @{os.setAlarm} completes.
+
+## Return Values
+1. @{number}: The ID of the alarm that finished.
+
+## Example
+Starts a timer and then prints its ID:
+```lua
+os.setAlarm(os.time() + 0.05)
+local event, id = os.pullEvent("alarm")
+print("Alarm with ID " .. id .. " was fired")
+```

--- a/doc/events/alarm.md
+++ b/doc/events/alarm.md
@@ -6,12 +6,16 @@ see: os.setAlarm To start an alarm.
 The @{timer} event is fired when an alarm started with @{os.setAlarm} completes.
 
 ## Return Values
-1. @{number}: The ID of the alarm that finished.
+1. @{string}: The event name.
+2. @{number}: The ID of the alarm that finished.
 
 ## Example
 Starts a timer and then prints its ID:
 ```lua
-os.setAlarm(os.time() + 0.05)
-local event, id = os.pullEvent("alarm")
+local alarmID = os.setAlarm(os.time() + 0.05)
+local event, id
+repeat
+    event, id = os.pullEvent("alarm")
+until id == alarmID
 print("Alarm with ID " .. id .. " was fired")
 ```

--- a/doc/events/computer_command.md
+++ b/doc/events/computer_command.md
@@ -2,7 +2,7 @@
 module: [kind=event] computer_command
 ---
 
-The @{computer_command} event is fired when the @{/computer} command is run for the current computer.
+The @{computer_command} event is fired when the `/computer}` command is run for the current computer.
 
 ## Return Values
 ... @{string}: The arguments passed to the command.

--- a/doc/events/computer_command.md
+++ b/doc/events/computer_command.md
@@ -1,0 +1,17 @@
+---
+module: [kind=event] computer_command
+---
+
+The @{computer_command} event is fired when the @{/computer} command is run for the current computer.
+
+## Return Values
+... @{string}: The arguments passed to the command.
+
+## Example
+Prints the contents of messages sent:
+```lua
+while true do
+  local event = {os.pullEvent("computer_command")}
+  print("Received message:", table.unpack(event, 2))
+end
+```

--- a/doc/events/computer_command.md
+++ b/doc/events/computer_command.md
@@ -2,7 +2,7 @@
 module: [kind=event] computer_command
 ---
 
-The @{computer_command} event is fired when the `/computer` command is run for the current computer.
+The @{computer_command} event is fired when the `/computercraft queue` command is run for the current computer.
 
 ## Return Values
 ... @{string}: The arguments passed to the command.

--- a/doc/events/computer_command.md
+++ b/doc/events/computer_command.md
@@ -5,6 +5,7 @@ module: [kind=event] computer_command
 The @{computer_command} event is fired when the `/computercraft queue` command is run for the current computer.
 
 ## Return Values
+1. @{string}: The event name.
 ... @{string}: The arguments passed to the command.
 
 ## Example

--- a/doc/events/computer_command.md
+++ b/doc/events/computer_command.md
@@ -2,7 +2,7 @@
 module: [kind=event] computer_command
 ---
 
-The @{computer_command} event is fired when the `/computer}` command is run for the current computer.
+The @{computer_command} event is fired when the `/computer` command is run for the current computer.
 
 ## Return Values
 ... @{string}: The arguments passed to the command.

--- a/doc/events/disk.md
+++ b/doc/events/disk.md
@@ -3,7 +3,7 @@ module: [kind=event] disk
 see: disk_eject For the event sent when a disk is removed.
 ---
 
-The @{disk} event is fired when a disk is inserted into an adjacent disk drive.
+The @{disk} event is fired when a disk is inserted into an adjacent or networked disk drive.
 
 ## Return Values
 1. @{string}: The side of the disk drive that had a disk inserted.

--- a/doc/events/disk.md
+++ b/doc/events/disk.md
@@ -6,7 +6,8 @@ see: disk_eject For the event sent when a disk is removed.
 The @{disk} event is fired when a disk is inserted into an adjacent or networked disk drive.
 
 ## Return Values
-1. @{string}: The side of the disk drive that had a disk inserted.
+1. @{string}: The event name.
+2. @{string}: The side of the disk drive that had a disk inserted.
 
 ## Example
 Prints a message when a disk is inserted:

--- a/doc/events/disk.md
+++ b/doc/events/disk.md
@@ -1,0 +1,18 @@
+---
+module: [kind=event] disk
+see: disk_eject For the event sent when a disk is removed.
+---
+
+The @{disk} event is fired when a disk is inserted into an adjacent disk drive.
+
+## Return Values
+1. @{string}: The side of the disk drive that had a disk inserted.
+
+## Example
+Prints a message when a disk is inserted:
+```lua
+while true do
+  local event, side = os.pullEvent("disk")
+  print("Inserted a disk on side " .. side)
+end
+```

--- a/doc/events/disk_eject.md
+++ b/doc/events/disk_eject.md
@@ -1,0 +1,18 @@
+---
+module: [kind=event] disk_eject
+see: disk For the event sent when a disk is inserted.
+---
+
+The @{disk_eject} event is fired when a disk is removed from an adjacent disk drive.
+
+## Return Values
+1. @{string}: The side of the disk drive that had a disk removed.
+
+## Example
+Prints a message when a disk is removed:
+```lua
+while true do
+  local event, side = os.pullEvent("disk_eject")
+  print("Removed a disk on side " .. side)
+end
+```

--- a/doc/events/disk_eject.md
+++ b/doc/events/disk_eject.md
@@ -3,7 +3,7 @@ module: [kind=event] disk_eject
 see: disk For the event sent when a disk is inserted.
 ---
 
-The @{disk_eject} event is fired when a disk is removed from an adjacent disk drive.
+The @{disk_eject} event is fired when a disk is removed from an adjacent or networked disk drive.
 
 ## Return Values
 1. @{string}: The side of the disk drive that had a disk removed.

--- a/doc/events/disk_eject.md
+++ b/doc/events/disk_eject.md
@@ -6,7 +6,8 @@ see: disk For the event sent when a disk is inserted.
 The @{disk_eject} event is fired when a disk is removed from an adjacent or networked disk drive.
 
 ## Return Values
-1. @{string}: The side of the disk drive that had a disk removed.
+1. @{string}: The event name.
+2. @{string}: The side of the disk drive that had a disk removed.
 
 ## Example
 Prints a message when a disk is removed:

--- a/doc/events/http_check.md
+++ b/doc/events/http_check.md
@@ -8,21 +8,7 @@ The @{http_check} event is fired when a URL check finishes.
 This event is normally handled inside @{http.checkURL}, but it can still be seen when using @{http.checkURLAsync}.
 
 ## Return Values
-1. @{string}: The URL requested to be checked.
-2. @{boolean}: Whether the check succeeded.
-3. @{string|nil}: If the check failed, a reason explaining why the check failed.
-
-## Example
-Checks a valid URL:
-```lua
-http.checkURLAsync("http://www.example.com")
-local event, url, success, err = os.pullEvent("http_check")
-print("The check on " .. url .. " " .. (success and "succeeded." or "failed: " .. err))
-```
-
-Checks an invalid URL:
-```lua
-http.checkURLAsync("ht:/")
-local event, url, success, err = os.pullEvent("http_check")
-print("The check on " .. url .. " " .. (success and "succeeded." or "failed: " .. err))
-```
+1. @{string}: The event name.
+2. @{string}: The URL requested to be checked.
+3. @{boolean}: Whether the check succeeded.
+4. @{string|nil}: If the check failed, a reason explaining why the check failed.

--- a/doc/events/http_check.md
+++ b/doc/events/http_check.md
@@ -1,0 +1,28 @@
+---
+module: [kind=event] http_check
+see: http.checkURLAsync To check a URL asynchronously.
+---
+
+The @{http_check} event is fired when a URL check finishes.
+
+This event is normally handled inside @{http.checkURL}, but it can still be seen when using @{http.checkURLAsync}.
+
+## Return Values
+1. @{string}: The URL requested to be checked.
+2. @{boolean}: Whether the check succeeded.
+3. @{string|nil}: If the check failed, a reason explaining why the check failed.
+
+## Example
+Checks a valid URL:
+```lua
+http.checkURLAsync("http://www.example.com")
+local event, url, success, err = os.pullEvent("http_check")
+print("The check on " .. url .. " " .. (success and "succeeded." or "failed: " .. err))
+```
+
+Checks an invalid URL:
+```lua
+http.checkURLAsync("ht:/")
+local event, url, success, err = os.pullEvent("http_check")
+print("The check on " .. url .. " " .. (success and "succeeded." or "failed: " .. err))
+```

--- a/doc/events/http_failure.md
+++ b/doc/events/http_failure.md
@@ -1,0 +1,30 @@
+---
+module: [kind=event] http_failure
+see: http.request To send an HTTP request.
+---
+
+The @{http_failure} event is fired when an HTTP request fails.
+
+This event is normally handled inside @{http.get} and @{http.post}, but it can still be seen when using @{http.request}.
+
+## Return Values
+1. @{string}: The URL of the site requested.
+2. @{string}: An error describing the failure.
+3. @{Response|nil}: A response handle if the connection succeeded, but the server's response indicated failure.
+
+## Example
+Prints an error why the website cannot be contacted:
+```lua
+http.request("http://this.website.does.not.exist")
+local event, url, err = os.pullEvent("http_failure")
+print("The URL " .. url .. " could not be reached: " .. err)
+```
+
+Prints the contents of a webpage that does not exist:
+```lua
+http.request("http://httpbin.org/status/404")
+local event, url, err, handle = os.pullEvent("http_failure")
+print("The URL " .. url .. " could not be reached: " .. err)
+print(handle.getResponseCode())
+handle.close()
+```

--- a/doc/events/http_failure.md
+++ b/doc/events/http_failure.md
@@ -10,7 +10,7 @@ This event is normally handled inside @{http.get} and @{http.post}, but it can s
 ## Return Values
 1. @{string}: The URL of the site requested.
 2. @{string}: An error describing the failure.
-3. @{Response|nil}: A response handle if the connection succeeded, but the server's response indicated failure.
+3. @{http.Response|nil}: A response handle if the connection succeeded, but the server's response indicated failure.
 
 ## Example
 Prints an error why the website cannot be contacted:

--- a/doc/events/http_failure.md
+++ b/doc/events/http_failure.md
@@ -8,22 +8,31 @@ The @{http_failure} event is fired when an HTTP request fails.
 This event is normally handled inside @{http.get} and @{http.post}, but it can still be seen when using @{http.request}.
 
 ## Return Values
-1. @{string}: The URL of the site requested.
-2. @{string}: An error describing the failure.
-3. @{http.Response|nil}: A response handle if the connection succeeded, but the server's response indicated failure.
+1. @{string}: The event name.
+2. @{string}: The URL of the site requested.
+3. @{string}: An error describing the failure.
+4. @{http.Response|nil}: A response handle if the connection succeeded, but the server's response indicated failure.
 
 ## Example
 Prints an error why the website cannot be contacted:
 ```lua
-http.request("http://this.website.does.not.exist")
-local event, url, err = os.pullEvent("http_failure")
+local myURL = "http://this.website.does.not.exist"
+http.request(myURL)
+local event, url, err
+repeat
+    event, url, err = os.pullEvent("http_failure")
+until url == myURL
 print("The URL " .. url .. " could not be reached: " .. err)
 ```
 
 Prints the contents of a webpage that does not exist:
 ```lua
-http.request("http://httpbin.org/status/404")
-local event, url, err, handle = os.pullEvent("http_failure")
+local myURL = "https://tweaked.cc/this/does/not/exist"
+http.request(myURL)
+local event, url, err, handle
+repeat
+    event, url, err, handle = os.pullEvent("http_failure")
+until url == myURL
 print("The URL " .. url .. " could not be reached: " .. err)
 print(handle.getResponseCode())
 handle.close()

--- a/doc/events/http_success.md
+++ b/doc/events/http_success.md
@@ -9,7 +9,7 @@ This event is normally handled inside @{http.get} and @{http.post}, but it can s
 
 ## Return Values
 1. @{string}: The URL of the site requested.
-2. @{Response}: The handle for the response text.
+2. @{http.Response}: The handle for the response text.
 
 ## Example
 Prints the content of a website (this may fail if the request fails):

--- a/doc/events/http_success.md
+++ b/doc/events/http_success.md
@@ -8,14 +8,19 @@ The @{http_success} event is fired when an HTTP request returns successfully.
 This event is normally handled inside @{http.get} and @{http.post}, but it can still be seen when using @{http.request}.
 
 ## Return Values
-1. @{string}: The URL of the site requested.
-2. @{http.Response}: The handle for the response text.
+1. @{string}: The event name.
+2. @{string}: The URL of the site requested.
+3. @{http.Response}: The handle for the response text.
 
 ## Example
 Prints the content of a website (this may fail if the request fails):
 ```lua
-http.request("http://www.example.com")
-local event, url, handle = os.pullEvent("http_success")
+local myURL = "https://tweaked.cc/"
+http.request(myURL)
+local event, url, handle
+repeat
+    event, url, handle = os.pullEvent("http_success")
+until url == myURL
 print("Contents of " .. url .. ":")
 print(handle.readAll())
 handle.close()

--- a/doc/events/http_success.md
+++ b/doc/events/http_success.md
@@ -1,0 +1,22 @@
+---
+module: [kind=event] http_success
+see: http.request To make an HTTP request.
+---
+
+The @{http_success} event is fired when an HTTP request returns successfully.
+
+This event is normally handled inside @{http.get} and @{http.post}, but it can still be seen when using @{http.request}.
+
+## Return Values
+1. @{string}: The URL of the site requested.
+2. @{Response}: The handle for the response text.
+
+## Example
+Prints the content of a website (this may fail if the request fails):
+```lua
+http.request("http://www.example.com")
+local event, url, handle = os.pullEvent("http_success")
+print("Contents of " .. url .. ":")
+print(handle.readAll())
+handle.close()
+```

--- a/doc/events/key.md
+++ b/doc/events/key.md
@@ -11,9 +11,9 @@ If the button pressed represented a printable character, then the @{key} event w
 event. If you are consuming text input, use a @{char} event instead!
 
 ## Return values
-1. [`string`]: The event name.
-2. [`number`]: The numerical key value of the key pressed.
-3. [`boolean`]: Whether the key event was generated while holding the key (@{true}), rather than pressing it the first time (@{false}).
+1. @{string}: The event name.
+2. @{number}: The numerical key value of the key pressed.
+3. @{boolean}: Whether the key event was generated while holding the key (@{true}), rather than pressing it the first time (@{false}).
 
 ## Example
 Prints each key when the user presses it, and if the key is being held.

--- a/doc/events/modem_message.md
+++ b/doc/events/modem_message.md
@@ -5,17 +5,18 @@ module: [kind=event] modem_message
 The @{modem_message} event is fired when a message is received on an open channel on any modem.
 
 ## Return Values
-1. @{string}: The side of the modem that received the message.
-2. @{number}: The channel that the message was sent on.
-3. @{number}: The reply channel set by the sender.
-4. @{any}: The message as sent by the sender.
-5. @{number}: The distance between the sender and the receiver, in blocks (decimal).
+1. @{string}: The event name.
+2. @{string}: The side of the modem that received the message.
+3. @{number}: The channel that the message was sent on.
+4. @{number}: The reply channel set by the sender.
+5. @{any}: The message as sent by the sender.
+6. @{number}: The distance between the sender and the receiver, in blocks (decimal).
 
 ## Example
 Prints a message when one is sent:
 ```lua
 while true do
   local event, side, channel, replyChannel, message, distance = os.pullEvent("modem_message")
-  print("Message received on side " .. side .. " on channel " .. channel .. " (reply to " .. replyChannel .. ") from " .. distance .. " blocks away with message " .. tostring(message))
+  print(("Message received on side %s on channel %d (reply to %d) from %f blocks away with message %s"):format(side, channel, replyChannel, distance, tostring(message)))
 end
 ```

--- a/doc/events/modem_message.md
+++ b/doc/events/modem_message.md
@@ -1,0 +1,21 @@
+---
+module: [kind=event] modem_message
+---
+
+The @{modem_message} event is fired when a message is received on an open channel on any modem.
+
+## Return Values
+1. @{string}: The side of the modem that received the message.
+2. @{number}: The channel that the message was sent on.
+3. @{number}: The reply channel set by the sender.
+4. @{any}: The message as sent by the sender.
+5. @{number}: The distance between the sender and the receiver, in blocks (decimal).
+
+## Example
+Prints a message when one is sent:
+```lua
+while true do
+  local event, side, channel, replyChannel, message, distance = os.pullEvent("modem_message")
+  print("Message received on side " .. side .. " on channel " .. channel .. " (reply to " .. replyChannel .. ") from " .. distance .. " blocks away with message " .. tostring(message))
+end
+```

--- a/doc/events/monitor_resize.md
+++ b/doc/events/monitor_resize.md
@@ -1,0 +1,17 @@
+---
+module: [kind=event] monitor_resize
+---
+
+The @{monitor_resize} event is fired when an adjacent or networked monitor's size is changed.
+
+## Return Values
+1. @{string}: The side or network ID of the monitor that resized.
+
+## Example
+Prints a message when a monitor is resized:
+```lua
+while true do
+  local event, side = os.pullEvent("monitor_resize")
+  print("The monitor on side " .. side .. " was resized.")
+end
+```

--- a/doc/events/monitor_resize.md
+++ b/doc/events/monitor_resize.md
@@ -5,7 +5,8 @@ module: [kind=event] monitor_resize
 The @{monitor_resize} event is fired when an adjacent or networked monitor's size is changed.
 
 ## Return Values
-1. @{string}: The side or network ID of the monitor that resized.
+1. @{string}: The event name.
+2. @{string}: The side or network ID of the monitor that resized.
 
 ## Example
 Prints a message when a monitor is resized:

--- a/doc/events/monitor_touch.md
+++ b/doc/events/monitor_touch.md
@@ -1,0 +1,19 @@
+---
+module: [kind=event] monitor_touch
+---
+
+The @{monitor_touch} event is fired when an adjacent or networked Advanced Monitor is right-clicked.
+
+## Return Values
+1. @{string}: The side or network ID of the monitor that was touched.
+2. @{number}: The X coordinate of the touch, in characters.
+3. @{number}: The Y coordinate of the touch, in characters.
+
+## Example
+Prints a message when a monitor is touched:
+```lua
+while true do
+  local event, side, x, y = os.pullEvent("monitor_touch")
+  print("The monitor on side " .. side .. " was touched at (" .. x .. ", " .. y .. ")")
+end
+```

--- a/doc/events/monitor_touch.md
+++ b/doc/events/monitor_touch.md
@@ -5,9 +5,10 @@ module: [kind=event] monitor_touch
 The @{monitor_touch} event is fired when an adjacent or networked Advanced Monitor is right-clicked.
 
 ## Return Values
-1. @{string}: The side or network ID of the monitor that was touched.
-2. @{number}: The X coordinate of the touch, in characters.
-3. @{number}: The Y coordinate of the touch, in characters.
+1. @{string}: The event name.
+2. @{string}: The side or network ID of the monitor that was touched.
+3. @{number}: The X coordinate of the touch, in characters.
+4. @{number}: The Y coordinate of the touch, in characters.
 
 ## Example
 Prints a message when a monitor is touched:

--- a/doc/events/mouse_drag.md
+++ b/doc/events/mouse_drag.md
@@ -20,5 +20,3 @@ while true do
   print(("The mouse button %s was dragged at %d, %d"):format(button, x, y))
 end
 ```
-
-

--- a/doc/events/mouse_up.md
+++ b/doc/events/mouse_up.md
@@ -19,6 +19,3 @@ while true do
   print(("The mouse button %s was released at %d, %d"):format(button, x, y))
 end
 ```
-
-[`string`]: string
-[`number`]: number

--- a/doc/events/paste.md
+++ b/doc/events/paste.md
@@ -5,7 +5,8 @@ module: [kind=event] paste
 The @{paste} event is fired when text is pasted into the computer through Ctrl-V (or ⌘V on Mac).
 
 ## Return values
-1. @{string} The text that was pasted.
+1. @{string}: The event name.
+2. @{string} The text that was pasted.
 
 ## Example
 Prints pasted text:

--- a/doc/events/paste.md
+++ b/doc/events/paste.md
@@ -1,0 +1,17 @@
+---
+module: [kind=event] paste
+---
+
+The @{paste} event is fired when text is pasted into the computer through Ctrl-V (or ⌘V on Mac).
+
+## Return values
+1. @{string} The text that was pasted.
+
+## Example
+Prints pasted text:
+```lua
+while true do
+  local event, text = os.pullEvent("paste")
+  print('"' .. text .. '" was pasted')
+end
+```

--- a/doc/events/peripheral.md
+++ b/doc/events/peripheral.md
@@ -6,7 +6,8 @@ see: peripheral_detach For the event fired when a peripheral is detached.
 The @{peripheral} event is fired when a peripheral is attached on a side or to a modem.
 
 ## Return Values
-1. @{string}: The side the peripheral was attached to.
+1. @{string}: The event name.
+2. @{string}: The side the peripheral was attached to.
 
 ## Example
 Prints a message when a peripheral is attached:

--- a/doc/events/peripheral.md
+++ b/doc/events/peripheral.md
@@ -3,7 +3,7 @@ module: [kind=event] peripheral
 see: peripheral_detach For the event fired when a peripheral is detached.
 ---
 
-The @{peripheral} event is fired when a peripheral is attached on a side.
+The @{peripheral} event is fired when a peripheral is attached on a side or to a modem.
 
 ## Return Values
 1. @{string}: The side the peripheral was attached to.

--- a/doc/events/peripheral.md
+++ b/doc/events/peripheral.md
@@ -1,0 +1,18 @@
+---
+module: [kind=event] peripheral
+see: peripheral_detach For the event fired when a peripheral is detached.
+---
+
+The @{peripheral} event is fired when a peripheral is attached on a side.
+
+## Return Values
+1. @{string}: The side the peripheral was attached to.
+
+## Example
+Prints a message when a peripheral is attached:
+```lua
+while true do
+  local event, side = os.pullEvent("peripheral")
+  print("A peripheral was attached on side " .. side)
+end
+```

--- a/doc/events/peripheral_detach.md
+++ b/doc/events/peripheral_detach.md
@@ -3,7 +3,7 @@ module: [kind=event] peripheral_detach
 see: peripheral For the event fired when a peripheral is attached.
 ---
 
-The @{peripheral_detach} event is fired when a peripheral is detached from a side.
+The @{peripheral_detach} event is fired when a peripheral is detached from a side or from a modem.
 
 ## Return Values
 1. @{string}: The side the peripheral was detached from.

--- a/doc/events/peripheral_detach.md
+++ b/doc/events/peripheral_detach.md
@@ -6,7 +6,8 @@ see: peripheral For the event fired when a peripheral is attached.
 The @{peripheral_detach} event is fired when a peripheral is detached from a side or from a modem.
 
 ## Return Values
-1. @{string}: The side the peripheral was detached from.
+1. @{string}: The event name.
+2. @{string}: The side the peripheral was detached from.
 
 ## Example
 Prints a message when a peripheral is detached:

--- a/doc/events/peripheral_detach.md
+++ b/doc/events/peripheral_detach.md
@@ -1,0 +1,18 @@
+---
+module: [kind=event] peripheral_detach
+see: peripheral For the event fired when a peripheral is attached.
+---
+
+The @{peripheral_detach} event is fired when a peripheral is detached from a side.
+
+## Return Values
+1. @{string}: The side the peripheral was detached from.
+
+## Example
+Prints a message when a peripheral is detached:
+```lua
+while true do
+  local event, side = os.pullEvent("peripheral_detach")
+  print("A peripheral was detached on side " .. side)
+end
+```

--- a/doc/events/rednet_message.md
+++ b/doc/events/rednet_message.md
@@ -1,0 +1,27 @@
+---
+module: [kind=event] rednet_message
+see: modem_message For raw modem messages sent outside of Rednet.
+see: rednet.receive To wait for a Rednet message with an optional timeout and protocol filter.
+---
+
+The @{rednet_message} event is fired when a message is sent over Rednet.
+
+This event is usually handled by @{rednet.receive}, but it can also be pulled manually.
+
+## Return Values
+1. @{number}: The ID of the sending computer.
+2. @{any}: The message sent.
+3. @{string|nil}: The protocol of the message, if provided.
+
+## Example
+Prints a message when one is sent:
+```lua
+while true do
+  local event, sender, message, protocol = os.pullEvent("rednet_message")
+  if protocol ~= nil then
+    print("Received message from " .. sender .. " with protocol " .. protocol .. " and message " .. tostring(message))
+  else
+    print("Received message from " .. sender .. " with message " .. tostring(message))
+  end
+end
+```

--- a/doc/events/rednet_message.md
+++ b/doc/events/rednet_message.md
@@ -8,6 +8,8 @@ The @{rednet_message} event is fired when a message is sent over Rednet.
 
 This event is usually handled by @{rednet.receive}, but it can also be pulled manually.
 
+@{rednet_message} events are sent by @{rednet.run} in the top-level coroutine in response to @{modem_message} events. A @{rednet_message} event is always preceded by a @{modem_message} event. They are generated inside CraftOS rather than being sent by the ComputerCraft machine.
+
 ## Return Values
 1. @{number}: The ID of the sending computer.
 2. @{any}: The message sent.

--- a/doc/events/rednet_message.md
+++ b/doc/events/rednet_message.md
@@ -11,9 +11,10 @@ This event is usually handled by @{rednet.receive}, but it can also be pulled ma
 @{rednet_message} events are sent by @{rednet.run} in the top-level coroutine in response to @{modem_message} events. A @{rednet_message} event is always preceded by a @{modem_message} event. They are generated inside CraftOS rather than being sent by the ComputerCraft machine.
 
 ## Return Values
-1. @{number}: The ID of the sending computer.
-2. @{any}: The message sent.
-3. @{string|nil}: The protocol of the message, if provided.
+1. @{string}: The event name.
+2. @{number}: The ID of the sending computer.
+3. @{any}: The message sent.
+4. @{string|nil}: The protocol of the message, if provided.
 
 ## Example
 Prints a message when one is sent:

--- a/doc/events/redstone.md
+++ b/doc/events/redstone.md
@@ -1,0 +1,14 @@
+---
+module: [kind=event] redstone
+---
+
+The @{redstone} event is fired whenever any redstone inputs on the computer change.
+
+## Example
+Prints a message when a redstone input changes:
+```lua
+while true do
+  os.pullEvent("redstone")
+  print("A redstone input has changed!")
+end
+```

--- a/doc/events/task_complete.md
+++ b/doc/events/task_complete.md
@@ -3,21 +3,23 @@ module: [kind=event] task_complete
 see: commands.execAsync To run a command which fires a task_complete event.
 ---
 
-The @{task_complete} event is fired when a command run with @{commands.execAsync} or any function in @{commands.async} finishes.
-
-This event is normally only available on Command Computers.
+The @{task_complete} event is fired when an asynchronous task completes. This is usually handled inside the function call that queued the task; however, functions such as @{commands.execAsync} return immediately so the user can wait for completion.
 
 ## Return Values
-1. @{number}: The ID of the task as returned by @{commands.execAsync}.
-2. @{boolean}: Whether the command succeeded.
-3. @{string}: If the command failed, an error message explaining the failure. (This is not present if the command succeeded.)
+1. @{string}: The event name.
+2. @{number}: The ID of the task that completed.
+3. @{boolean}: Whether the command succeeded.
+4. @{string}: If the command failed, an error message explaining the failure. (This is not present if the command succeeded.)
 ...: Any parameters returned from the command.
 
 ## Example
 Prints the results of an asynchronous command:
 ```lua
-commands.execAsync("say Hello")
-local event = {os.pullEvent("task_complete")}
+local taskID = commands.execAsync("say Hello")
+local event
+repeat
+    event = {os.pullEvent("task_complete")}
+until event[2] == taskID
 if event[3] == true then
   print("Task " .. event[2] .. " succeeded:", table.unpack(event, 4))
 else

--- a/doc/events/task_complete.md
+++ b/doc/events/task_complete.md
@@ -1,0 +1,26 @@
+---
+module: [kind=event] task_complete
+see: commands.execAsync To run a command which fires a task_complete event.
+---
+
+The @{task_complete} event is fired when a command run with @{commands.execAsync} or any function in @{commands.async} finishes.
+
+This event is normally only available on Command Computers.
+
+## Return Values
+1. @{number}: The ID of the task as returned by @{commands.execAsync}.
+2. @{boolean}: Whether the command succeeded.
+3. @{string}: If the command failed, an error message explaining the failure. (This is not present if the command succeeded.)
+...: Any parameters returned from the command.
+
+## Example
+Prints the results of an asynchronous command:
+```lua
+commands.execAsync("say Hello")
+local event = {os.pullEvent("task_complete")}
+if event[3] == true then
+  print("Task " .. event[2] .. " succeeded:", table.unpack(event, 4))
+else
+  print("Task " .. event[2] .. " failed: " .. event[4])
+end
+```

--- a/doc/events/term_resize.md
+++ b/doc/events/term_resize.md
@@ -1,0 +1,15 @@
+---
+module: [kind=event] term_resize
+---
+
+The @{term_resize} event is fired when the main terminal is resized, mainly when a new tab is opened or closed in @{multishell}.
+
+## Example
+Prints :
+```lua
+while true do
+  os.pullEvent("term_resize")
+  local w, h = term.getSize()
+  print("The term was resized to (" .. w .. ", " .. h .. ")")
+end
+```

--- a/doc/events/terminate.md
+++ b/doc/events/terminate.md
@@ -2,7 +2,7 @@
 module: [kind=event] terminate
 ---
 
-The @{terminate} event is fired when Ctrl-T is held down.
+The @{terminate} event is fired when <kbd>Ctrl-T</kbd> is held down.
 
 This event is normally handled by @{os.pullEvent}, and will not be returned. However, @{os.pullEventRaw} will return this event when fired.
 

--- a/doc/events/terminate.md
+++ b/doc/events/terminate.md
@@ -1,0 +1,25 @@
+---
+module: [kind=event] terminate
+---
+
+The @{terminate} event is fired when Ctrl-T is held down.
+
+This event is normally handled by @{os.pullEvent}, and will not be returned. However, @{os.pullEventRaw} will return this event when fired.
+
+@{terminate} will be sent even when a filter is provided to @{os.pullEventRaw}. When using @{os.pullEventRaw} with a filter, make sure to check that the event is not @{terminate}.
+
+## Example
+Prints a message when Ctrl-T is held:
+```lua
+while true do
+  local event = os.pullEventRaw("terminate")
+  if event == "terminate" then print("Terminate requested!") end
+end
+```
+
+Exits when Ctrl-T is held:
+```lua
+while true do
+  os.pullEvent()
+end
+```

--- a/doc/events/timer.md
+++ b/doc/events/timer.md
@@ -6,12 +6,16 @@ see: os.startTimer To start a timer.
 The @{timer} event is fired when a timer started with @{os.startTimer} completes.
 
 ## Return Values
-1. @{number}: The ID of the timer that finished.
+1. @{string}: The event name.
+2. @{number}: The ID of the timer that finished.
 
 ## Example
 Starts a timer and then prints its ID:
 ```lua
-os.startTimer(2)
-local event, id = os.pullEvent("timer")
+local timerID = os.startTimer(2)
+local event, id
+repeat
+    event, id = os.pullEvent("timer")
+until id == timerID
 print("Timer with ID " .. id .. " was fired")
 ```

--- a/doc/events/timer.md
+++ b/doc/events/timer.md
@@ -1,0 +1,17 @@
+---
+module: [kind=event] timer
+see: os.startTimer To start a timer.
+---
+
+The @{timer} event is fired when a timer started with @{os.startTimer} completes.
+
+## Return Values
+1. @{number}: The ID of the timer that finished.
+
+## Example
+Starts a timer and then prints its ID:
+```lua
+os.startTimer(2)
+local event, id = os.pullEvent("timer")
+print("Timer with ID " .. id .. " was fired")
+```

--- a/doc/events/turtle_inventory.md
+++ b/doc/events/turtle_inventory.md
@@ -1,0 +1,14 @@
+---
+module: [kind=event] turtle_inventory
+---
+
+The @{turtle_inventory} event is fired when a Turtle's inventory is changed.
+
+## Example
+Prints a message when the inventory is changed:
+```lua
+while true do
+  os.pullEvent("turtle_inventory")
+  print("The inventory was changed.")
+end
+```

--- a/doc/events/turtle_inventory.md
+++ b/doc/events/turtle_inventory.md
@@ -2,7 +2,7 @@
 module: [kind=event] turtle_inventory
 ---
 
-The @{turtle_inventory} event is fired when a Turtle's inventory is changed.
+The @{turtle_inventory} event is fired when a turtle's inventory is changed.
 
 ## Example
 Prints a message when the inventory is changed:

--- a/doc/events/websocket_closed.md
+++ b/doc/events/websocket_closed.md
@@ -5,12 +5,17 @@ module: [kind=event] websocket_closed
 The @{websocket_closed} event is fired when an open WebSocket connection is closed.
 
 ## Return Values
-1. @{string}: The URL of the WebSocket that was closed.
+1. @{string}: The event name.
+2. @{string}: The URL of the WebSocket that was closed.
 
 ## Example
 Prints a message when a WebSocket is closed (this may take a minute):
 ```lua
-local ws = http.websocket("ws://echo.websocket.org")
-local event, url = os.pullEvent("websocket_closed")
+local myURL = "ws://echo.websocket.org"
+local ws = http.websocket(myURL)
+local event, url
+repeat
+    event, url = os.pullEvent("websocket_closed")
+until url == myURL
 print("The WebSocket at " .. url .. " was closed.")
 ```

--- a/doc/events/websocket_closed.md
+++ b/doc/events/websocket_closed.md
@@ -1,0 +1,16 @@
+---
+module: [kind=event] websocket_closed
+---
+
+The @{websocket_closed} event is fired when an open WebSocket connection is closed.
+
+## Return Values
+1. @{string}: The URL of the WebSocket that was closed.
+
+## Example
+Prints a message when a WebSocket is closed (this may take a minute):
+```lua
+local ws = http.websocket("ws://echo.websocket.org")
+local event, url = os.pullEvent("websocket_closed")
+print("The WebSocket at " .. url .. " was closed.")
+```

--- a/doc/events/websocket_failure.md
+++ b/doc/events/websocket_failure.md
@@ -8,13 +8,18 @@ The @{websocket_failure} event is fired when a WebSocket connection request fail
 This event is normally handled inside @{http.websocket}, but it can still be seen when using @{http.websocketAsync}.
 
 ## Return Values
-1. @{string}: The URL of the site requested.
-2. @{string}: An error describing the failure.
+1. @{string}: The event name.
+2. @{string}: The URL of the site requested.
+3. @{string}: An error describing the failure.
 
 ## Example
 Prints an error why the website cannot be contacted:
 ```lua
-http.websocketAsync("ws://this.website.does.not.exist")
-local event, url, err = os.pullEvent("websocket_failure")
+local myURL = "ws://this.website.does.not.exist"
+http.websocketAsync(myURL)
+local event, url, err
+repeat
+    event, url, err = os.pullEvent("websocket_failure")
+until url == myURL
 print("The URL " .. url .. " could not be reached: " .. err)
 ```

--- a/doc/events/websocket_failure.md
+++ b/doc/events/websocket_failure.md
@@ -1,0 +1,20 @@
+---
+module: [kind=event] websocket_failure
+see: http.websocketAsync To send an HTTP request.
+---
+
+The @{websocket_failure} event is fired when a WebSocket connection request fails.
+
+This event is normally handled inside @{http.websocket}, but it can still be seen when using @{http.websocketAsync}.
+
+## Return Values
+1. @{string}: The URL of the site requested.
+2. @{string}: An error describing the failure.
+
+## Example
+Prints an error why the website cannot be contacted:
+```lua
+http.websocketAsync("ws://this.website.does.not.exist")
+local event, url, err = os.pullEvent("websocket_failure")
+print("The URL " .. url .. " could not be reached: " .. err)
+```

--- a/doc/events/websocket_message.md
+++ b/doc/events/websocket_message.md
@@ -1,0 +1,21 @@
+---
+module: [kind=event] websocket_message
+---
+
+The @{websocket_message} event is fired when a message is received on an open WebSocket connection.
+
+This event is normally handled by @{Websocket.receive}, but it can also be pulled manually.
+
+## Return Values
+1. @{string}: The URL of the WebSocket.
+2. @{string}: The contents of the message.
+
+## Example
+Prints a message sent by a WebSocket:
+```lua
+local ws = http.websocket("ws://echo.websocket.org")
+ws.send("Hello!")
+local event, url, message = os.pullEvent("websocket_message")
+print("Received message from " .. url .. " with contents " .. message)
+ws.close()
+```

--- a/doc/events/websocket_message.md
+++ b/doc/events/websocket_message.md
@@ -7,15 +7,20 @@ The @{websocket_message} event is fired when a message is received on an open We
 This event is normally handled by @{http.Websocket.receive}, but it can also be pulled manually.
 
 ## Return Values
-1. @{string}: The URL of the WebSocket.
-2. @{string}: The contents of the message.
+1. @{string}: The event name.
+2. @{string}: The URL of the WebSocket.
+3. @{string}: The contents of the message.
 
 ## Example
 Prints a message sent by a WebSocket:
 ```lua
-local ws = http.websocket("ws://echo.websocket.org")
+local myURL = "ws://echo.websocket.org"
+local ws = http.websocket(myURL)
 ws.send("Hello!")
-local event, url, message = os.pullEvent("websocket_message")
+local event, url, message
+repeat
+    event, url, message = os.pullEvent("websocket_message")
+until url == myURL
 print("Received message from " .. url .. " with contents " .. message)
 ws.close()
 ```

--- a/doc/events/websocket_message.md
+++ b/doc/events/websocket_message.md
@@ -4,7 +4,7 @@ module: [kind=event] websocket_message
 
 The @{websocket_message} event is fired when a message is received on an open WebSocket connection.
 
-This event is normally handled by @{Websocket.receive}, but it can also be pulled manually.
+This event is normally handled by @{http.Websocket.receive}, but it can also be pulled manually.
 
 ## Return Values
 1. @{string}: The URL of the WebSocket.

--- a/doc/events/websocket_success.md
+++ b/doc/events/websocket_success.md
@@ -8,14 +8,19 @@ The @{websocket_success} event is fired when a WebSocket connection request retu
 This event is normally handled inside @{http.websocket}, but it can still be seen when using @{http.websocketAsync}.
 
 ## Return Values
-1. @{string}: The URL of the site.
-2. @{http.Websocket}: The handle for the WebSocket.
+1. @{string}: The event name.
+2. @{string}: The URL of the site.
+3. @{http.Websocket}: The handle for the WebSocket.
 
 ## Example
 Prints the content of a website (this may fail if the request fails):
 ```lua
-http.websocketAsync("ws://echo.websocket.org")
-local event, url, handle = os.pullEvent("websocket_success")
+local myURL = "ws://echo.websocket.org"
+http.websocketAsync(myURL)
+local event, url, handle
+repeat
+    event, url, handle = os.pullEvent("websocket_success")
+until url == myURL
 print("Connected to " .. url)
 handle.send("Hello!")
 print(handle.receive())

--- a/doc/events/websocket_success.md
+++ b/doc/events/websocket_success.md
@@ -14,7 +14,7 @@ This event is normally handled inside @{http.websocket}, but it can still be see
 ## Example
 Prints the content of a website (this may fail if the request fails):
 ```lua
-http.websocketAsync("http://echo.websocket.org")
+http.websocketAsync("ws://echo.websocket.org")
 local event, url, handle = os.pullEvent("websocket_success")
 print("Connected to " .. url)
 handle.send("Hello!")

--- a/doc/events/websocket_success.md
+++ b/doc/events/websocket_success.md
@@ -1,0 +1,23 @@
+---
+module: [kind=event] websocket_success
+see: http.websocketAsync To open a WebSocket asynchronously.
+---
+
+The @{websocket_success} event is fired when a WebSocket connection request returns successfully.
+
+This event is normally handled inside @{http.websocket}, but it can still be seen when using @{http.websocketAsync}.
+
+## Return Values
+1. @{string}: The URL of the site.
+2. @{Websocket}: The handle for the WebSocket.
+
+## Example
+Prints the content of a website (this may fail if the request fails):
+```lua
+http.websocketAsync("http://echo.websocket.org")
+local event, url, handle = os.pullEvent("websocket_success")
+print("Connected to " .. url)
+handle.send("Hello!")
+print(handle.receive())
+handle.close()
+```

--- a/doc/events/websocket_success.md
+++ b/doc/events/websocket_success.md
@@ -9,7 +9,7 @@ This event is normally handled inside @{http.websocket}, but it can still be see
 
 ## Return Values
 1. @{string}: The URL of the site.
-2. @{Websocket}: The handle for the WebSocket.
+2. @{http.Websocket}: The handle for the WebSocket.
 
 ## Example
 Prints the content of a website (this may fail if the request fails):


### PR DESCRIPTION
This PR adds the rest of the events to the docs. The data was fetched mostly from the old wiki, with new changes added from the new wiki, as well as some things I've remembered over time.

Sorry for the large amount of commits; I was too lazy to clone it myself, and just did everything in the GitHub web interface. Just squash it (you usually do that anyway).

Closes: #681, closes #640