### PR TITLE
Fix `redstone.getBundledInput(side)` returning the output of said side.

### DIFF
--- a/src/main/java/dan200/computercraft/core/apis/RedstoneAPI.java
+++ b/src/main/java/dan200/computercraft/core/apis/RedstoneAPI.java
@@ -191,7 +191,7 @@ public class RedstoneAPI implements ILuaAPI
     @LuaFunction
     public final int getBundledInput( ComputerSide side )
     {
-        return environment.getBundledOutput( side );
+        return environment.getBundledInput( side );
     }
 
     /**


### PR DESCRIPTION
A simple one line fix to stop `redstone.getBundledInput(side)` being an alternative to `redstone.getBundledOutput(side)`.
fix #708 