### PR TITLE
Modify edit.lua run code to display errors/results of execution and handle require.

### DIFF
--- a/src/main/resources/data/computercraft/lua/rom/programs/edit.lua
+++ b/src/main/resources/data/computercraft/lua/rom/programs/edit.lua
@@ -63,7 +63,7 @@ end
 if ok and y >= h then
     term.scroll(1)
 end
-term.setCursorPos(1,h)
+term.setCursorPos(1, h)
 if ok then
     write("Program finished. ")
 end

--- a/src/main/resources/data/computercraft/lua/rom/programs/edit.lua
+++ b/src/main/resources/data/computercraft/lua/rom/programs/edit.lua
@@ -57,13 +57,14 @@ term.setBackgroundColor(%i)
 term.setCursorBlink(false)
 local _,y = term.getCursorPos()
 local _,h = term.getSize()
-if y >= h then
-    term.scroll(1)
-    term.setCursorPos(1,h)
-end
 if err then
     printError(err)
-else
+end
+if not err and y >= h then
+    term.scroll(1)
+end
+term.setCursorPos(1,h)
+if not err then
     write("Execution finished. ")
 end
 write("Press any key to continue")

--- a/src/main/resources/data/computercraft/lua/rom/programs/edit.lua
+++ b/src/main/resources/data/computercraft/lua/rom/programs/edit.lua
@@ -422,7 +422,7 @@ local tMenuFuncs = {
         if sTitle:sub(-4) == ".lua" then
             sTitle = sTitle:sub(1, -5)
         end
-        local sTempPath = bReadOnly and "/.temp." .. sTitle or fs.combine(fs.getDir(sPath), "/.temp." .. sTitle)
+        local sTempPath = bReadOnly and ".temp." .. sTitle or fs.combine(fs.getDir(sPath), ".temp." .. sTitle)
         if fs.exists(sTempPath) then
             sStatus = "Error saving to " .. sTempPath
             return

--- a/src/main/resources/data/computercraft/lua/rom/programs/edit.lua
+++ b/src/main/resources/data/computercraft/lua/rom/programs/edit.lua
@@ -422,7 +422,7 @@ local tMenuFuncs = {
         if sTitle:sub(-4) == ".lua" then
             sTitle = sTitle:sub(1, -5)
         end
-        local sTempPath = bReadOnly and sTitle .. ".temp" or fs.combine(fs.getDir(sPath), sTitle .. ".temp")
+        local sTempPath = bReadOnly and "/.temp." .. sTitle or fs.combine(fs.getDir(sPath), "/.temp." .. sTitle)
         if fs.exists(sTempPath) then
             sStatus = "Error saving to " .. sTempPath
             return


### PR DESCRIPTION
This change in `edit.lua` program code makes it so that if its possible edit will create `.temp` file in directory currently edited file is. This will make require work consistently with how it will work in edited file. If file is in read only location it will be created in root same as it is currently.

Additionally it adds a handler code to code that is run that will display errors and hold tab open until any key is pressed to indicate user seen the results/errors generated by run action.

Touches #552 
Resolves #674 

Note1: I didn't include code to reset palette because it could have distorted results if someone is messing with palette. If they are unable to read error message it is expected they will realize their pallette changes made reading it impossible.
Note2: `]] .. [[` breaking up that literal string at lines 51 and 52 is there to ensure edit is capable to run edit. It is side effect of run handler code that any code that itself contains a level 33 long bracket literal string will not be run properly. But this should be fairly unlikely situation. If anyone got idea for reasonable code that would deal with this issue it would be helpful.

Example:

![obraz](https://user-images.githubusercontent.com/5893536/108777268-d3c44700-7563-11eb-9435-4e8684ea5a40.png)
![obraz](https://user-images.githubusercontent.com/5893536/108777218-c3ac6780-7563-11eb-8c6b-afb247af0c2f.png)
