### PR TITLE
Fix missing `term.setCursorBlink(true)` in edit.lua

### DIFF
--- a/src/main/resources/data/computercraft/lua/rom/programs/edit.lua
+++ b/src/main/resources/data/computercraft/lua/rom/programs/edit.lua
@@ -801,6 +801,7 @@ while bRunning do
                 end
             else
                 bMenu = false
+                term.setCursorBlink(true)
                 redrawMenu()
             end
         end


### PR DESCRIPTION
I noticed that it was not restoring cursor blink when mouse click canceled menu.
Turns out it was missing one line.
