### PR TITLE
Defer peripheral invalidations to next tick to avoid grabbing stale TEs

### DIFF
--- a/src/main/java/dan200/computercraft/shared/computer/blocks/TileComputerBase.java
+++ b/src/main/java/dan200/computercraft/shared/computer/blocks/TileComputerBase.java
@@ -60,7 +60,7 @@ public abstract class TileComputerBase extends TileGeneric implements IComputerT
     boolean startOn = false;
     private boolean fresh = false;
     private final NonNullConsumer<LazyOptional<IPeripheral>>[] invalidate;
-    private final EnumSet<Direction> deferredInvalidations = EnumSet.allOf(Direction.class);
+    private final EnumSet<Direction> deferredInvalidations = EnumSet.allOf( Direction.class );
 
     private final ComputerFamily family;
 
@@ -75,7 +75,7 @@ public abstract class TileComputerBase extends TileGeneric implements IComputerT
         for( Direction direction : Direction.values() )
         {
             // Defer invalidations to next tick to avoid grabbing stale TEs, fixes #696
-            invalidate[direction.ordinal()] = o -> deferredInvalidations.add(direction);
+            invalidate[direction.ordinal()] = o -> deferredInvalidations.add( direction );
         }
     }
 

--- a/src/main/java/dan200/computercraft/shared/computer/blocks/TileComputerBase.java
+++ b/src/main/java/dan200/computercraft/shared/computer/blocks/TileComputerBase.java
@@ -75,7 +75,8 @@ public abstract class TileComputerBase extends TileGeneric implements IComputerT
         {
             // Defer invalidations to next tick to avoid grabbing stale TEs, fixes #696
             invalidate[direction.ordinal()] = o -> {
-                if (deferredInvalidations == null) {
+                if ( deferredInvalidations == null )
+                {
                     deferredInvalidations = new Direction[6];
                 }
 
@@ -164,10 +165,12 @@ public abstract class TileComputerBase extends TileGeneric implements IComputerT
     @Override
     public void tick()
     {
-        if (deferredInvalidations != null) {
-            for (Direction direction : deferredInvalidations) {
-                if (direction == null) continue;
-                updateInput(direction);
+        if ( deferredInvalidations != null )
+        {
+            for ( Direction direction : deferredInvalidations )
+            {
+                if ( direction == null ) continue;
+                updateInput( direction );
             }
 
             deferredInvalidations = null;


### PR DESCRIPTION
Potentially fixes #696.

I tested this with a turtle running a constant script printing the chest size, seemed to work even when there weren't any new block updates.

Issue was caused by the invalidation grabbing the old `ChestTileEntity` because it hasn't updated in the world yet.