### PR TITLE
Add the ability to call `cc.expect` directly

### DIFF
--- a/src/main/resources/data/computercraft/lua/rom/modules/main/cc/expect.lua
+++ b/src/main/resources/data/computercraft/lua/rom/modules/main/cc/expect.lua
@@ -114,8 +114,8 @@ local function range(num, min, max)
   return num
 end
 
-return {
+return setmetatable({
     expect = expect,
     field = field,
     range = range,
-}
+}, { __call = function(_, ...) return expect(...) end })


### PR DESCRIPTION
This PR is a tiny syntax adjustment to the `cc.expect` module to allow calling the result directly, rather than having to use `expect.expect`. It accomplishes this through setting the `__call` metamethod to a simple wrapper that calls `expect.expect`, discarding `self` in the process. This makes usage a bit simpler for basic `expect` calls:
```lua
local expect = require "cc.expect"

local function myFunction(tab, str)
    expect(1, tab, "table")
    expect(2, str, "string", "nil")
    expect.field(tab, "name", "string")
    expect.field(tab, "type", "number")
    expect.range(tab.type, 1, 4)
    -- ...
end
```
