### PR TITLE
Add cc.shell.completion `programWithArgs` completion.

### DIFF
--- a/src/main/resources/data/computercraft/lua/rom/modules/main/cc/shell/completion.lua
+++ b/src/main/resources/data/computercraft/lua/rom/modules/main/cc/shell/completion.lua
@@ -110,7 +110,7 @@ local function programWithArgs(shell, text, previous, starting)
         if not resolved then return end
         local tCompletion = shell.getCompletionInfo()[resolved]
         if not tCompletion then return end
-        return tCompletion.fnComplete(shell, #previous - starting + 1, text, {program, table.unpack(previous,starting+1,#previous)})
+        return tCompletion.fnComplete(shell, #previous - starting + 1, text, { program, table.unpack(previous, starting + 1, #previous) })
     end
 end
 

--- a/src/main/resources/data/computercraft/lua/rom/modules/main/cc/shell/completion.lua
+++ b/src/main/resources/data/computercraft/lua/rom/modules/main/cc/shell/completion.lua
@@ -29,8 +29,9 @@ local completion = require "cc.completion"
 
 --- Complete the name of a file relative to the current working directory.
 --
--- @tparam table shell The shell we're completing in
--- @tparam { string... } choices The list of choices to complete from.
+-- @tparam table shell The shell we're completing in.
+-- @tparam string text Current text to complete.
+-- @tparam { string... } previous The shell arguments before this one.
 -- @treturn { string... } A list of suffixes of matching files.
 local function file(shell, text)
     return fs.complete(text, shell.dir(), true, false)
@@ -38,8 +39,9 @@ end
 
 --- Complete the name of a directory relative to the current working directory.
 --
--- @tparam table shell The shell we're completing in
--- @tparam { string... } choices The list of choices to complete from.
+-- @tparam table shell The shell we're completing in.
+-- @tparam string text Current text to complete.
+-- @tparam { string... } previous The shell arguments before this one.
 -- @treturn { string... } A list of suffixes of matching directories.
 local function dir(shell, text)
     return fs.complete(text, shell.dir(), false, true)
@@ -48,8 +50,8 @@ end
 --- Complete the name of a file or directory relative to the current working
 -- directory.
 --
--- @tparam table shell The shell we're completing in
--- @tparam { string... } choices The list of choices to complete from.
+-- @tparam table shell The shell we're completing in.
+-- @tparam string text Current text to complete.
 -- @tparam { string... } previous The shell arguments before this one.
 -- @tparam[opt] boolean add_space Whether to add a space after the completed item.
 -- @treturn { string... } A list of suffixes of matching files and directories.
@@ -74,12 +76,41 @@ end
 
 --- Complete the name of a program.
 --
--- @tparam table shell The shell we're completing in
--- @tparam { string... } choices The list of choices to complete from.
+-- @tparam table shell The shell we're completing in.
+-- @tparam string text Current text to complete.
+-- @tparam { string... } previous The shell arguments before this one.
+-- @tparam[opt] boolean completion_space Whether to add a space after the completed item if there is completion for this program.
 -- @treturn { string... } A list of suffixes of matching programs.
 -- @see shell.completeProgram
-local function program(shell, text)
-    return shell.completeProgram(text)
+local function program(shell, text, previous, completion_space)
+    local results = shell.completeProgram(text)
+    if completion_space then
+        local tCompletionInfo = shell.getCompletionInfo()
+        for n = 1, #results do
+            local sResult = results[n]
+            if sResult:sub(-1) ~= "/" and tCompletionInfo[shell.resolveProgram(text .. sResult)] then
+                results[n] = sResult .. " "
+            end
+        end
+    end
+    return results
+end
+
+--- Complete arguments of a program.
+--
+-- @tparam table shell The shell we're completing in.
+-- @tparam string text Current text to complete.
+-- @tparam { string... } previous The shell arguments before this one.
+-- @tparam string|number program Path of program to complete args for, or a number of argument index which specified program.
+-- @tparam number starting Which argument index this program args started at.
+-- @treturn { string... } A list of suffixes of matching programs.
+-- @see shell.completeProgram
+local function programArgs(shell, text, previous, program, starting)
+    local resolved = type(program) == "string" and program or shell.resolveProgram(previous[program])
+    if not resolved then return end
+    local tCompletionInfo = shell.getCompletionInfo()
+    if not tCompletionInfo[resolved] then return end
+    return tCompletionInfo[resolved].fnComplete(shell, #previous - starting + 2, text, {resolved, table.unpack(previous,starting,#previous)})
 end
 
 --[[- A helper function for building shell completion arguments.
@@ -144,6 +175,7 @@ return {
     dir = dir,
     dirOrFile = dirOrFile,
     program = program,
+    programArgs = programArgs,
 
     -- Re-export various other functions
     help = wrap(help.completeTopic), --- Wraps @{help.completeTopic} as a @{build} compatible function.

--- a/src/main/resources/data/computercraft/lua/rom/startup.lua
+++ b/src/main/resources/data/computercraft/lua/rom/startup.lua
@@ -90,7 +90,7 @@ shell.setCompletionFunction("rom/programs/monitor.lua", completion.build(
                 return completion.programWithArgs(shell, text, previous, 3)
             end
         end,
-        many = true
+        many = true,
     }
 ))
 
@@ -106,11 +106,10 @@ shell.setCompletionFunction("rom/programs/rename.lua", completion.build(
     { completion.dirOrFile, true },
     completion.dirOrFile
 ))
-shell.setCompletionFunction("rom/programs/shell.lua", completion.build({ completion.programWithArgs, 2, many = true}))
 shell.setCompletionFunction("rom/programs/type.lua", completion.build(completion.dirOrFile))
 shell.setCompletionFunction("rom/programs/set.lua", completion.build({ completion.setting, true }))
-shell.setCompletionFunction("rom/programs/advanced/bg.lua", completion.build({ completion.programWithArgs, 2, many = true}))
-shell.setCompletionFunction("rom/programs/advanced/fg.lua", completion.build({ completion.programWithArgs, 2, many = true}))
+shell.setCompletionFunction("rom/programs/advanced/bg.lua", completion.build({ completion.programWithArgs, 2, many = true }))
+shell.setCompletionFunction("rom/programs/advanced/fg.lua", completion.build({ completion.programWithArgs, 2, many = true }))
 shell.setCompletionFunction("rom/programs/fun/dj.lua", completion.build(
     { completion.choice, { "play", "play ", "stop " } },
     completion.peripheral

--- a/src/main/resources/data/computercraft/lua/rom/startup.lua
+++ b/src/main/resources/data/computercraft/lua/rom/startup.lua
@@ -81,9 +81,17 @@ shell.setCompletionFunction("rom/programs/monitor.lua", completion.build(
         if previous[2] == "scale" then
             return completion.peripheral(shell, text, previous, true)
         else
-            return completion.program(shell, text, previous)
+            return completion.program(shell, text, previous, true)
         end
-    end
+    end,
+    {
+        function(shell, text, previous)
+            if previous[2] ~= "scale" then
+                return completion.programArgs(shell, text, previous, 3, 4)
+            end
+        end,
+        many = true
+    }
 ))
 
 shell.setCompletionFunction("rom/programs/move.lua", completion.build(
@@ -98,11 +106,20 @@ shell.setCompletionFunction("rom/programs/rename.lua", completion.build(
     { completion.dirOrFile, true },
     completion.dirOrFile
 ))
-shell.setCompletionFunction("rom/programs/shell.lua", completion.build(completion.program))
+shell.setCompletionFunction("rom/programs/shell.lua", completion.build(
+    { completion.program, true},
+    { completion.programArgs, 2, 3, many = true}
+))
 shell.setCompletionFunction("rom/programs/type.lua", completion.build(completion.dirOrFile))
 shell.setCompletionFunction("rom/programs/set.lua", completion.build({ completion.setting, true }))
-shell.setCompletionFunction("rom/programs/advanced/bg.lua", completion.build(completion.program))
-shell.setCompletionFunction("rom/programs/advanced/fg.lua", completion.build(completion.program))
+shell.setCompletionFunction("rom/programs/advanced/bg.lua", completion.build(
+    { completion.program, true},
+    { completion.programArgs, 2, 3, many = true}
+))
+shell.setCompletionFunction("rom/programs/advanced/fg.lua", completion.build(
+    { completion.program, true},
+    { completion.programArgs, 2, 3, many = true}
+))
 shell.setCompletionFunction("rom/programs/fun/dj.lua", completion.build(
     { completion.choice, { "play", "play ", "stop " } },
     completion.peripheral

--- a/src/main/resources/data/computercraft/lua/rom/startup.lua
+++ b/src/main/resources/data/computercraft/lua/rom/startup.lua
@@ -106,6 +106,7 @@ shell.setCompletionFunction("rom/programs/rename.lua", completion.build(
     { completion.dirOrFile, true },
     completion.dirOrFile
 ))
+shell.setCompletionFunction("rom/programs/shell.lua", completion.build({ completion.programWithArgs, 2, many = true }))
 shell.setCompletionFunction("rom/programs/type.lua", completion.build(completion.dirOrFile))
 shell.setCompletionFunction("rom/programs/set.lua", completion.build({ completion.setting, true }))
 shell.setCompletionFunction("rom/programs/advanced/bg.lua", completion.build({ completion.programWithArgs, 2, many = true }))

--- a/src/main/resources/data/computercraft/lua/rom/startup.lua
+++ b/src/main/resources/data/computercraft/lua/rom/startup.lua
@@ -81,13 +81,13 @@ shell.setCompletionFunction("rom/programs/monitor.lua", completion.build(
         if previous[2] == "scale" then
             return completion.peripheral(shell, text, previous, true)
         else
-            return completion.program(shell, text, previous, true)
+            return completion.programWithArgs(shell, text, previous, 3)
         end
     end,
     {
         function(shell, text, previous)
             if previous[2] ~= "scale" then
-                return completion.programArgs(shell, text, previous, 3, 4)
+                return completion.programWithArgs(shell, text, previous, 3)
             end
         end,
         many = true
@@ -106,20 +106,11 @@ shell.setCompletionFunction("rom/programs/rename.lua", completion.build(
     { completion.dirOrFile, true },
     completion.dirOrFile
 ))
-shell.setCompletionFunction("rom/programs/shell.lua", completion.build(
-    { completion.program, true},
-    { completion.programArgs, 2, 3, many = true}
-))
+shell.setCompletionFunction("rom/programs/shell.lua", completion.build({ completion.programWithArgs, 2, many = true}))
 shell.setCompletionFunction("rom/programs/type.lua", completion.build(completion.dirOrFile))
 shell.setCompletionFunction("rom/programs/set.lua", completion.build({ completion.setting, true }))
-shell.setCompletionFunction("rom/programs/advanced/bg.lua", completion.build(
-    { completion.program, true},
-    { completion.programArgs, 2, 3, many = true}
-))
-shell.setCompletionFunction("rom/programs/advanced/fg.lua", completion.build(
-    { completion.program, true},
-    { completion.programArgs, 2, 3, many = true}
-))
+shell.setCompletionFunction("rom/programs/advanced/bg.lua", completion.build({ completion.programWithArgs, 2, many = true}))
+shell.setCompletionFunction("rom/programs/advanced/fg.lua", completion.build({ completion.programWithArgs, 2, many = true}))
 shell.setCompletionFunction("rom/programs/fun/dj.lua", completion.build(
     { completion.choice, { "play", "play ", "stop " } },
     completion.peripheral

--- a/src/test/resources/test-rom/spec/modules/cc/shell/completion_spec.lua
+++ b/src/test/resources/test-rom/spec/modules/cc/shell/completion_spec.lua
@@ -23,24 +23,18 @@ describe("cc.shell.completion", function()
                 "apis/", "autorun/", "help/", "modules/", "motd.txt", "programs/", "startup.lua",
             }
         end)
+    end)
 
-        it("adds a space", function()
+    describe("programWithArgs", function()
+        it("completes program name", function()
             shell.setCompletionFunction("rom/motd.txt",function() end)
-            expect(c.program(shell, "rom/", nil, true)):same {
+            expect(c.programWithArgs(shell, "rom/", {"rom/programs/shell.lua"}, 2)):same {
                 "apis/", "autorun/", "help/", "modules/", "motd.txt ", "programs/", "startup.lua",
             }
         end)
-    end)
 
-    describe("programArgs", function()
-        it("completes program from arguments", function()
-            expect(c.programArgs(shell, "", {"rom/programs/shell.lua", "pastebin"}, 2, 3)):same {
-                "put ", "get ", "run ",
-            }
-        end)
-
-        it("completes program from parameter", function()
-            expect(c.programArgs(shell, "", {"rom/programs/shell.lua"}, "rom/programs/http/pastebin.lua", 2)):same {
+        it("completes program arguments", function()
+            expect(c.programWithArgs(shell, "", {"rom/programs/shell.lua","pastebin"}, 2)):same {
                 "put ", "get ", "run ",
             }
         end)

--- a/src/test/resources/test-rom/spec/modules/cc/shell/completion_spec.lua
+++ b/src/test/resources/test-rom/spec/modules/cc/shell/completion_spec.lua
@@ -17,6 +17,36 @@ describe("cc.shell.completion", function()
         end)
     end)
 
+    describe("program", function()
+        it("completes programs", function()
+            expect(c.program(shell, "rom/")):same {
+                "apis/", "autorun/", "help/", "modules/", "motd.txt", "programs/", "startup.lua",
+            }
+        end)
+
+        it("adds a space", function()
+            shell.setCompletionFunction("rom/motd.txt",function() end)
+            expect(c.program(shell, "rom/", nil, true)):same {
+                "apis/", "autorun/", "help/", "modules/", "motd.txt ", "programs/", "startup.lua",
+            }
+        end)
+    end)
+
+    describe("programArgs", function()
+        it("completes program from arguments", function()
+            expect(c.programArgs(shell, "", {"rom/programs/shell.lua", "pastebin"}, 2, 3)):same {
+                "put ", "get ", "run ",
+            }
+        end)
+
+        it("completes program from parameter", function()
+            expect(c.programArgs(shell, "", {"rom/programs/shell.lua"}, "rom/programs/http/pastebin.lua", 2)):same {
+                "put ", "get ", "run ",
+            }
+        end)
+
+    end)
+
     describe("build", function()
         it("completes multiple arguments", function()
             local spec = c.build(

--- a/src/test/resources/test-rom/spec/modules/cc/shell/completion_spec.lua
+++ b/src/test/resources/test-rom/spec/modules/cc/shell/completion_spec.lua
@@ -27,14 +27,14 @@ describe("cc.shell.completion", function()
 
     describe("programWithArgs", function()
         it("completes program name", function()
-            shell.setCompletionFunction("rom/motd.txt",function() end)
-            expect(c.programWithArgs(shell, "rom/", {"rom/programs/shell.lua"}, 2)):same {
+            shell.setCompletionFunction("rom/motd.txt", function() end)
+            expect(c.programWithArgs(shell, "rom/", { "rom/programs/shell.lua" }, 2)):same {
                 "apis/", "autorun/", "help/", "modules/", "motd.txt ", "programs/", "startup.lua",
             }
         end)
 
         it("completes program arguments", function()
-            expect(c.programWithArgs(shell, "", {"rom/programs/shell.lua","pastebin"}, 2)):same {
+            expect(c.programWithArgs(shell, "", { "rom/programs/shell.lua", "pastebin" }, 2)):same {
                 "put ", "get ", "run ",
             }
         end)


### PR DESCRIPTION
Gives ability to define a way to complete arguments of another program specified via parameter or arguments itself. This should make using `monitor` program simpler as well as simplify adding auto completion to similar programs.
![obraz](https://user-images.githubusercontent.com/5893536/121058005-2dbde500-c7c0-11eb-95be-d19cc9d4d18e.png)

Also fixes wrong argument definitions in cc.shell.completion file.