### PR TITLE
Fixed error handling in scale subcommand

### DIFF
--- a/src/main/resources/data/computercraft/lua/rom/programs/monitor.lua
+++ b/src/main/resources/data/computercraft/lua/rom/programs/monitor.lua
@@ -7,7 +7,7 @@ local function printUsage()
 end
 
 local tArgs = { ... }
-if #tArgs < 2 or (tArgs[1] == "scale" and #tArgs < 3) then
+if #tArgs < 2 or tArgs[1] == "scale" and #tArgs < 3 then
     printUsage()
     return
 end

--- a/src/main/resources/data/computercraft/lua/rom/programs/monitor.lua
+++ b/src/main/resources/data/computercraft/lua/rom/programs/monitor.lua
@@ -7,7 +7,7 @@ local function printUsage()
 end
 
 local tArgs = { ... }
-if #tArgs < 2 then
+if #tArgs < 2 or (tArgs[1] == "scale" and #tArgs < 3) then
     printUsage()
     return
 end
@@ -21,7 +21,7 @@ if tArgs[1] == "scale" then
 
     local nRes = tonumber(tArgs[3])
     if nRes == nil or nRes < 0.5 or nRes > 5 then
-        print("Invalid scale: " .. nRes)
+        print("Invalid scale: " .. tArgs[3])
         return
     end
 

--- a/src/test/resources/test-rom/spec/programs/monitor_spec.lua
+++ b/src/test/resources/test-rom/spec/programs/monitor_spec.lua
@@ -21,7 +21,7 @@ describe("The monitor program", function()
             :matches { ok = true, output = "", error = "" }
         expect(r):equals(0.5)
     end)
-        
+
     it("displays correct error messages", function()
         local r = 1
         stub(peripheral, "call", function(s, f, t) r = t end)

--- a/src/test/resources/test-rom/spec/programs/monitor_spec.lua
+++ b/src/test/resources/test-rom/spec/programs/monitor_spec.lua
@@ -21,4 +21,24 @@ describe("The monitor program", function()
             :matches { ok = true, output = "", error = "" }
         expect(r):equals(0.5)
     end)
+        
+    it("displays correct error messages", function()
+        local r = 1
+        stub(peripheral, "call", function(s, f, t) r = t end)
+        stub(peripheral, "getType", function(side) return side == "left" and "monitor" or nil end)
+        expect(capture(stub, "monitor", "scale", "left"))
+            :matches {
+                ok = true,
+                output =
+                    "Usage:\n" ..
+                    "  monitor <name> <program> <arguments>\n" ..
+                    "  monitor scale <name> <scale>\n",
+                error = "",
+            }
+        expect(capture(stub, "monitor", "scale", "top", "0.5"))
+            :matches { ok = true, output = "No monitor named top", error = "" }
+        expect(capture(stub, "monitor", "scale", "left", "aaa"))
+            :matches { ok = true, output = "Invalid scale: aaa", error = "" }
+        expect(r):equals(1)
+    end)
 end)

--- a/src/test/resources/test-rom/spec/programs/monitor_spec.lua
+++ b/src/test/resources/test-rom/spec/programs/monitor_spec.lua
@@ -36,9 +36,9 @@ describe("The monitor program", function()
                 error = "",
             }
         expect(capture(stub, "monitor", "scale", "top", "0.5"))
-            :matches { ok = true, output = "No monitor named top", error = "" }
+            :matches { ok = true, output = "No monitor named top\n", error = "" }
         expect(capture(stub, "monitor", "scale", "left", "aaa"))
-            :matches { ok = true, output = "Invalid scale: aaa", error = "" }
+            :matches { ok = true, output = "Invalid scale: aaa\n", error = "" }
         expect(r):equals(1)
     end)
 end)


### PR DESCRIPTION
@Wojbie notified me that running `monitor scale` without a scale value (or with an invalid value) will error out due to concatenating `nil`. This PR fixes that.