### PR TITLE
Turn a nil to a string

### DIFF
--- a/src/main/resources/data/computercraft/lua/rom/apis/settings.lua
+++ b/src/main/resources/data/computercraft/lua/rom/apis/settings.lua
@@ -42,7 +42,7 @@ for _, v in ipairs(valid_types) do valid_types[v] = true end
 --    will error.
 function define(name, options)
     expect(1, name, "string")
-    expect(2, options, "table", nil)
+    expect(2, options, "table", "nil")
 
     if options then
         options = {


### PR DESCRIPTION
Makes a `nil` a string inside of an expect in `define`, allowing `nil` to be passed.

## A quick checklist
 - If there's a existing issue, please link to it. If not, provide fill out the same information you would in a normal issue - reproduction steps for bugs, rationale for use-case.
 Reproduction steps:
1. call `settings.define("some.setting")`
2. expect will error with "bad argument #2 (expected table, got nil)"
The way the expect is written it seems like it should accept `nil`, just someone forgot to make it a string, and the define code handles it being `nil`.
 - If you're working on CraftOS, try to write a few test cases so we can ensure everything continues to work in the future. Tests live in `src/test/resources/test-rom/spec` and can be run with `./gradlew check`.
