### PR TITLE
Add examples to `os` and `window`.

### DIFF
--- a/src/main/java/dan200/computercraft/core/apis/OSAPI.java
+++ b/src/main/java/dan200/computercraft/core/apis/OSAPI.java
@@ -321,6 +321,10 @@ public class OSAPI implements ILuaAPI
      * which will convert the date fields into a UNIX timestamp (number of
      * seconds since 1 January 1970).
      *
+     * @usage Print the current (in world) time.
+     *    local time = os.time()
+     *    print(textutils.formatTime(time,true))
+     *
      * @param args The locale of the time, or a table filled by {@code os.date("*t")} to decode. Defaults to {@code ingame} locale if not specified.
      * @return The hour of the selected locale, or a UNIX timestamp from the table, depending on the argument passed in.
      * @throws LuaException If an invalid locale is passed.
@@ -357,6 +361,14 @@ public class OSAPI implements ILuaAPI
      * * If called with {@code local}, returns the number of days since 1
      * January 1970 in the server's local timezone.
      *
+     * @usage Print the number of days, weeks, months, and years since 1 January 1970 (UTC).
+     *
+     *    local days = os.day("utc")
+     *    print("Days:",days)
+     *    print("Weeks:",math.floor(days/7))
+     *    print("Months:",math.floor(days/30)) -- Yes, some months have 31 days, but 30 is "good enough".
+     *    print("Years:",math.floor(days/365))
+     *
      * @param args The locale to get the day for. Defaults to {@code ingame} if not set.
      * @return The day depending on the selected locale.
      * @throws LuaException If an invalid locale is passed.
@@ -386,6 +398,14 @@ public class OSAPI implements ILuaAPI
      * January 1970 in the UTC timezone.
      * * If called with {@code local}, returns the number of milliseconds since 1
      * January 1970 in the server's local timezone.
+     *
+     * @usage Print milliseconds, seconds, minutes, and hours since 1 January 1970 (UTC).
+     *
+     *    local millis = os.epoch("utc")
+     *    print("Milliseconds:",millis)
+     *    print("Seconds:",math.floor(millis/1000))
+     *    print("Minutes:",math.floor(millis/60000))
+     *    print("Hours:",math.floor(millis/3600000))
      *
      * @param args The locale to get the milliseconds for. Defaults to {@code ingame} if not set.
      * @return The milliseconds since the epoch depending on the selected locale.
@@ -433,6 +453,10 @@ public class OSAPI implements ILuaAPI
      * day, hour, minute, second, day of the week, day of the year, and whether
      * Daylight Savings Time is in effect. This table can be converted to a UNIX
      * timestamp (days since 1 January 1970) with {@link #date}.
+     *
+     * @usage Print the current time and date in UTC.
+     *
+     *    print(os.date("!%Y/%m/%d %H:%M:%S"))
      *
      * @param formatA The format of the string to return. This defaults to {@code %c}, which expands to a string similar to "Sat Dec 24 16:58:00 2011".
      * @param timeA   The time to convert to a string. This defaults to the current time.

--- a/src/main/resources/data/computercraft/lua/rom/apis/window.lua
+++ b/src/main/resources/data/computercraft/lua/rom/apis/window.lua
@@ -62,6 +62,19 @@ local string_sub = string.sub
 -- suitable, though windows may even have other windows assigned as their
 -- parents.
 --
+-- @usage Split the terminal into 2 windows and draw in them.
+--
+--    local width,height = term.getSize() -- Get the width and height of the terminal.
+--    local half = math.floor(width/2+0.5) -- Get the middle boundary of the terminal.
+--    local winOne = window.create(term.current(),1,1,half,height) -- Create the first window, this is the left half of the total terminal.
+--    local winTwo = window.create(term.current(),half+1,1,half-1,height) -- Create the second window, this is the right half of the total terminal.
+--    winTwo.setBackgroundColour(colours.lightGrey) -- This differentiates the windows.
+--    winTwo.clear() -- Apply the background colour
+--    winOne.setCursorPos(1,1) -- Move the cursor pos to 1,1 relative to the window.
+--    winOne.blit("0123456789abcdef","0123456789abcdef","fffffffffffffff0") -- Draw every colour in order.
+--    winTwo.setCursorPos(1,1) -- This just ensures the cursor pos is 1,1 relative to the window.
+--    winTwo.blit("fedcba9876543210","fedcba9876543210","8888888788888888") -- Draw the same thing, but backwards.
+--
 -- @tparam term.Redirect parent The parent terminal redirect to draw to.
 -- @tparam number nX The x coordinate this window is drawn at in the parent terminal
 -- @tparam number nY The y coordinate this window is drawn at in the parent terminal


### PR DESCRIPTION
This just adds examples to the `os` time functions, and `window.create`.