### PR TITLE
Fix typo in turtle.craft documentation

### DIFF
--- a/doc/stub/turtle.lua
+++ b/doc/stub/turtle.lua
@@ -1,7 +1,7 @@
 --[[- Craft a recipe based on the turtle's inventory.
 
 The turtle's inventory should set up like a crafting grid. For instance, to
-craft sticks, slots 1 and 5 should contain sticks. _All_ other slots should be
+craft sticks, slots 1 and 5 should contain planks. _All_ other slots should be
 empty, including those outside the crafting "grid".
 
 @tparam[opt=64] number limit The maximum number of crafting steps to run.


### PR DESCRIPTION
Description wrote "to craft sticks, slots should contain sticks", whereas it should say "planks" in the second part.

## A quick checklist
 - If there's a existing issue, please link to it. If not, provide fill out the same information you would in a normal issue - reproduction steps for bugs, rationale for use-case.
 - If you're working on CraftOS, try to write a few test cases so we can ensure everything continues to work in the future. Tests live in `src/test/resources/test-rom/spec` and can be run with `./gradlew check`.
