### PR TITLE
Fix typo in paintutils documentation

### DIFF
--- a/src/main/resources/data/computercraft/lua/rom/apis/paintutils.lua
+++ b/src/main/resources/data/computercraft/lua/rom/apis/paintutils.lua
@@ -276,7 +276,7 @@ end
 --
 -- @tparam table image The parsed image data.
 -- @tparam number xPos The x position to start drawing at.
--- @tparam number xPos The y position to start drawing at.
+-- @tparam number yPos The y position to start drawing at.
 function drawImage(image, xPos, yPos)
     expect(1, image, "table")
     expect(2, xPos, "number")


### PR DESCRIPTION
The documentation says the y position argument for `drawImage` is called `xPos`, but it should say `yPos`.

## A quick checklist
 - If there's a existing issue, please link to it. If not, provide fill out the same information you would in a normal issue - reproduction steps for bugs, rationale for use-case.
 - If you're working on CraftOS, try to write a few test cases so we can ensure everything continues to work in the future. Tests live in `src/test/resources/test-rom/spec` and can be run with `./gradlew check`.