### PR TITLE
Allow player world interaction while pocket pc opened with no terminal

### DIFF
--- a/src/main/java/dan200/computercraft/client/gui/NoTermComputerScreen.java
+++ b/src/main/java/dan200/computercraft/client/gui/NoTermComputerScreen.java
@@ -18,6 +18,7 @@ import net.minecraft.util.IReorderingProcessor;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TranslationTextComponent;
 import org.lwjgl.glfw.GLFW;
+
 import javax.annotation.Nonnull;
 import java.util.List;
 

--- a/src/main/java/dan200/computercraft/client/gui/NoTermComputerScreen.java
+++ b/src/main/java/dan200/computercraft/client/gui/NoTermComputerScreen.java
@@ -43,7 +43,9 @@ public class NoTermComputerScreen<T extends ContainerComputerBase> extends Scree
     protected void init()
     {
         this.passEvents = true; // to allow gui click events pass through mouseHelper protection (see MouseHelper.OnPres:105 code string)
+        minecraft.mouseHandler.grabMouse();
         minecraft.screen = this;
+        
         super.init();
         minecraft.keyboardHandler.setSendRepeatsToGui( true );
 

--- a/src/main/java/dan200/computercraft/client/gui/NoTermComputerScreen.java
+++ b/src/main/java/dan200/computercraft/client/gui/NoTermComputerScreen.java
@@ -46,7 +46,7 @@ public class NoTermComputerScreen<T extends ContainerComputerBase> extends Scree
         this.passEvents = true; // to allow gui click events pass through mouseHelper protection (see MouseHelper.OnPres:105 code string)
         minecraft.mouseHandler.grabMouse();
         minecraft.screen = this;
-        
+
         super.init();
         minecraft.keyboardHandler.setSendRepeatsToGui( true );
 

--- a/src/main/java/dan200/computercraft/client/gui/NoTermComputerScreen.java
+++ b/src/main/java/dan200/computercraft/client/gui/NoTermComputerScreen.java
@@ -10,7 +10,6 @@ import dan200.computercraft.ComputerCraft;
 import dan200.computercraft.client.gui.widgets.WidgetTerminal;
 import dan200.computercraft.shared.computer.core.ClientComputer;
 import dan200.computercraft.shared.computer.inventory.ContainerComputerBase;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.IHasContainer;
 import net.minecraft.client.gui.screen.Screen;
@@ -20,15 +19,10 @@ import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TranslationTextComponent;
 import org.lwjgl.glfw.GLFW;
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import java.lang.reflect.Field;
 import java.util.List;
 
 public class NoTermComputerScreen<T extends ContainerComputerBase> extends Screen implements IHasContainer<T>
 {
-    @Nullable
-    private static final Field mineScreen = TryFindEncodedField(); //try find minecraft.screen field
-
     private final T menu;
     private WidgetTerminal terminal;
 
@@ -49,16 +43,7 @@ public class NoTermComputerScreen<T extends ContainerComputerBase> extends Scree
     protected void init()
     {
         this.passEvents = true; // to allow gui click events pass through mouseHelper protection (see MouseHelper.OnPres:105 code string)
-        if (mineScreen != null) // if reflection failed - pocket pc still would work but with no mouse move mechanic
-        {
-            minecraft.mouseHandler.grabMouse();
-            try {
-                mineScreen.set(minecraft, this);
-            } catch (IllegalAccessException e) {
-                e.printStackTrace();
-            }
-        }
-
+        minecraft.screen = this;
         super.init();
         minecraft.keyboardHandler.setSendRepeatsToGui( true );
 
@@ -66,33 +51,6 @@ public class NoTermComputerScreen<T extends ContainerComputerBase> extends Scree
         terminal.visible = false;
         terminal.active = false;
         setFocused( terminal );
-    }
-
-    // There is only one field in Minecraft that has net.minecraft.client.gui.screen.Screen type: it is field_71462_r (for 1.16.5)
-    // I am not sure that using this name could be safe, so I search for screen using it's Type
-    private static Field TryFindEncodedField()
-    {
-        final String success = "Screen found. Pocket pc mouse move enabled.";
-        try { // trying to find screen by in_game name (faster means better)
-            Field field = Minecraft.class.getDeclaredField("field_71462_r");
-            if (field.getType() == Screen.class) {
-                field.setAccessible(true);
-                ComputerCraft.log.info(success);
-                return field;
-            }
-        } catch (NoSuchFieldException ignored){} //there is nothing to wright or do if Exception caught, so...
-        ComputerCraft.log.info("Fast screen finding failed. Try find by type.");
-
-        Field[] fields = Minecraft.class.getDeclaredFields();
-        for (Field field : fields) {
-            if (field.getType() == Screen.class) {
-                field.setAccessible(true);
-                ComputerCraft.log.info(success);
-                return field;
-            }
-        }
-        ComputerCraft.log.info("Unable to found screen. Pocket pc mouse move disabled");
-        return null;
     }
 
     @Override
@@ -110,9 +68,10 @@ public class NoTermComputerScreen<T extends ContainerComputerBase> extends Scree
     }
 
     @Override
-    public boolean mouseScrolled(double p_231043_1_, double p_231043_3_, double p_231043_5_) {
-        minecraft.player.inventory.swapPaint(p_231043_5_);
-        return super.mouseScrolled(p_231043_1_, p_231043_3_, p_231043_5_);
+    public boolean mouseScrolled( double pMouseX, double pMouseY, double pDelta )
+    {
+        minecraft.player.inventory.swapPaint( pDelta );
+        return super.mouseScrolled( pMouseX, pMouseY, pDelta );
     }
 
     @Override
@@ -155,4 +114,3 @@ public class NoTermComputerScreen<T extends ContainerComputerBase> extends Scree
         }
     }
 }
-

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -5,3 +5,4 @@ public net.minecraft.client.renderer.FirstPersonRenderer func_228403_a_(Lcom/moj
 # ClientTableFormatter
 public net.minecraft.client.gui.NewChatGui func_146234_a(Lnet/minecraft/util/text/ITextComponent;I)V # printChatMessageWithOptionalDeletion
 public net.minecraft.client.gui.NewChatGui func_146242_c(I)V # deleteChatLine
+public net.minecraft.client.Minecraft field_71462_r # currentScreen


### PR DESCRIPTION
Dear developers of CC:Tweaked! 

I hope I will see this feature in future versions of your modification. This thing will make players able to use their poket computers as keyboards, and monitors as mouses. With this it's now posible to create something like game with better resolution (monitor.setTextScale) or other cool things. I am sorry for using java.lang.reflect, but ther is no other way to make this function works. I realy want you to use my code in your project, or if it to cursed, because of reflection, make this work using better way. Thank you for your attantion, and sorry for my weird looking english.

P.S. I decide to fully remade my request case I mess up with git and branches too much

This is a simple remake of NoTermComputerScreen.java that makes player able to move his head and interact with world objects by right clicking while poket computer in his second hand opened with no terminal.

Stuff you can interact with: 
Any Items that can be right clicked; Items/Blocks with GUI(workbench) (will close the poket computer); sScrooll menu; Move camera; Place blocks; Eat.

Stuff you can't do: 
Any actions that start with left click; Move player (case keyboard is connected with computer lol :P ).

The case you can't left click: the key.mouse.left is really deep inside game code and have strict rule - it can't be used while any GUI open, and it is to difficult to override it (even with reflection).

Demo video:

[Demo video](https://user-images.githubusercontent.com/56871670/131592321-07b0b639-dc56-46c0-809f-ff58fbe86444.mp4)
