### PR TITLE
Serialize better repetition error and infinity+nan handling.

### DIFF
--- a/src/main/resources/data/computercraft/lua/rom/apis/textutils.lua
+++ b/src/main/resources/data/computercraft/lua/rom/apis/textutils.lua
@@ -273,7 +273,7 @@ local function serialize_impl(t, tracking, indent, opts)
     local sType = type(t)
     if sType == "table" then
         if tracking[t] ~= nil then
-            if tracking[t] == t then
+            if tracking[t] == false then
                 error("Cannot serialize table with repeated entries", 0)
             else
                 error("Cannot serialize table with recursive entries", 0)
@@ -315,7 +315,7 @@ local function serialize_impl(t, tracking, indent, opts)
         if opts.allow_repetitions then
             tracking[t] = nil
         else
-            tracking[t] = t
+            tracking[t] = false
         end
         return result
 

--- a/src/main/resources/data/computercraft/lua/rom/apis/textutils.lua
+++ b/src/main/resources/data/computercraft/lua/rom/apis/textutils.lua
@@ -325,8 +325,10 @@ local function serialize_impl(t, tracking, indent, opts)
     elseif sType == "number" then
         if t ~= t then --nan
             return "0/0"
-        elseif t == serialize_infinity then 
+        elseif t == serialize_infinity then
             return "1/0"
+        elseif t == -serialize_infinity then
+            return "-1/0"
         else
             return tostring(t)
         end

--- a/src/test/resources/test-rom/spec/apis/textutils_spec.lua
+++ b/src/test/resources/test-rom/spec/apis/textutils_spec.lua
@@ -82,8 +82,8 @@ describe("The textutils library", function()
             expect(textutils.serialise({ 1, 2, 3, a = 1, b = {} }))
                 :eq("{\n  1,\n  2,\n  3,\n  a = 1,\n  b = {},\n}")
 
-            expect(textutils.serialise({ 0 / 0, 1 / 0 }))
-                :eq("{\n  0/0,\n  1/0,\n}")
+            expect(textutils.serialise({ 0 / 0, 1 / 0, -1 / 0 }))
+                :eq("{\n  0/0,\n  1/0,\n  -1/0,\n}")
         end)
 
         it("fails on recursive/repeated tables", function()

--- a/src/test/resources/test-rom/spec/apis/textutils_spec.lua
+++ b/src/test/resources/test-rom/spec/apis/textutils_spec.lua
@@ -82,7 +82,7 @@ describe("The textutils library", function()
             expect(textutils.serialise({ 1, 2, 3, a = 1, b = {} }))
                 :eq("{\n  1,\n  2,\n  3,\n  a = 1,\n  b = {},\n}")
 
-            expect(textutils.serialise({ 0/0, 1/0 }))
+            expect(textutils.serialise({ 0 / 0, 1 / 0 }))
                 :eq("{\n  0/0,\n  1/0,\n}")
         end)
 

--- a/src/test/resources/test-rom/spec/apis/textutils_spec.lua
+++ b/src/test/resources/test-rom/spec/apis/textutils_spec.lua
@@ -81,14 +81,17 @@ describe("The textutils library", function()
         it("serialises basic tables", function()
             expect(textutils.serialise({ 1, 2, 3, a = 1, b = {} }))
                 :eq("{\n  1,\n  2,\n  3,\n  a = 1,\n  b = {},\n}")
+
+            expect(textutils.serialise({ 0/0, 1/0 }))
+                :eq("{\n  0/0,\n  1/0,\n}")
         end)
 
-        it("fails on recursive tables", function()
+        it("fails on recursive/repeated tables", function()
             local rep = {}
-            expect.error(textutils.serialise, { rep, rep }):eq("Cannot serialize table with recursive entries")
+            expect.error(textutils.serialise, { rep, rep }):eq("Cannot serialize table with repeated entries")
 
             local rep2 = { 1 }
-            expect.error(textutils.serialise, { rep2, rep2 }):eq("Cannot serialize table with recursive entries")
+            expect.error(textutils.serialise, { rep2, rep2 }):eq("Cannot serialize table with repeated entries")
 
             local recurse = {}
             recurse[1] = recurse


### PR DESCRIPTION
This PR changes 2 things in serialize logic:

1. Changes way tracking table works to allow differentiating errors between repeated and recursive table to allow end user to understand why it did not serialize and be able to optionally use allow_repetitions option if they want to.

2. Allows for nan and infinity values to be correctly serialized and not disappear in the process like they do with current logic (due to use of `tostring(num)` on them leading to nil value).

