### PR TITLE
Add new `getCommandID` API to turtles make it possible to perform crash/state recovery

### DIFF
--- a/src/main/java/dan200/computercraft/api/turtle/ITurtleAccess.java
+++ b/src/main/java/dan200/computercraft/api/turtle/ITurtleAccess.java
@@ -45,6 +45,13 @@ public interface ITurtleAccess
     BlockPos getPosition();
 
     /**
+     * Returns the ID of the last executed command.
+     *
+     * @return the ID of the last executed command.
+     */
+    int getCommandID();
+
+    /**
      * Attempt to move this turtle to a new position.
      *
      * This will preserve the turtle's internal state, such as it's inventory, computer and upgrades. It should

--- a/src/main/java/dan200/computercraft/shared/turtle/apis/TurtleAPI.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/apis/TurtleAPI.java
@@ -55,6 +55,18 @@ public class TurtleAPI implements ILuaAPI
     }
 
     /**
+     * Get the ID of the last successful command.
+     *
+     * @return the ID of the last successful command
+     * @cc.return The ID of the last successful command
+     */
+    @LuaFunction
+    public final int getCommandID()
+    {
+        return turtle.getCommandID();
+    }
+
+    /**
      * Move the turtle forward one block.
      *
      * @return The turtle command result.

--- a/src/main/java/dan200/computercraft/shared/turtle/core/TurtleBrain.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/core/TurtleBrain.java
@@ -59,6 +59,7 @@ public class TurtleBrain implements ITurtleAccess
     public static final String NBT_LEFT_UPGRADE = "LeftUpgrade";
     public static final String NBT_LEFT_UPGRADE_DATA = "LeftUpgradeNbt";
     public static final String NBT_FUEL = "Fuel";
+    public static final String NBT_COMMANDS_SUCCESS = "CommandsSuccess";
     public static final String NBT_OVERLAY = "Overlay";
 
     private static final String NBT_SLOT = "Slot";
@@ -74,6 +75,7 @@ public class TurtleBrain implements ITurtleAccess
 
     private final Queue<TurtleCommandQueueEntry> commandQueue = new ArrayDeque<>();
     private int commandsIssued = 0;
+    private int commandsSuccess = 0;
 
     private final Map<TurtleSide, ITurtleUpgrade> upgrades = new EnumMap<>( TurtleSide.class );
     private final Map<TurtleSide, IPeripheral> peripherals = new EnumMap<>( TurtleSide.class );
@@ -157,6 +159,7 @@ public class TurtleBrain implements ITurtleAccess
         // Read fields
         colourHex = nbt.contains( NBT_COLOUR ) ? nbt.getInt( NBT_COLOUR ) : -1;
         fuelLevel = nbt.contains( NBT_FUEL ) ? nbt.getInt( NBT_FUEL ) : 0;
+        commandsSuccess = nbt.contains( NBT_COMMANDS_SUCCESS ) ? nbt.getInt( NBT_COMMANDS_SUCCESS ) : 0;
         overlay = nbt.contains( NBT_OVERLAY ) ? new ResourceLocation( nbt.getString( NBT_OVERLAY ) ) : null;
 
         // Read upgrades
@@ -178,6 +181,7 @@ public class TurtleBrain implements ITurtleAccess
     private void writeCommon( CompoundNBT nbt )
     {
         nbt.putInt( NBT_FUEL, fuelLevel );
+        nbt.putInt( NBT_COMMANDS_SUCCESS, commandsSuccess );
         if( colourHex != -1 ) nbt.putInt( NBT_COLOUR, colourHex );
         if( overlay != null ) nbt.putString( NBT_OVERLAY, overlay.toString() );
 
@@ -281,6 +285,12 @@ public class TurtleBrain implements ITurtleAccess
     public BlockPos getPosition()
     {
         return owner.getBlockPos();
+    }
+
+    @Override
+    public int getCommandID()
+    {
+        return commandsSuccess;
     }
 
     @Override
@@ -792,6 +802,7 @@ public class TurtleBrain implements ITurtleAccess
 
         if( result != null && result.isSuccess() )
         {
+            commandsSuccess++;
             Object[] results = result.getResults();
             if( results != null )
             {


### PR DESCRIPTION
The following pattern is commonly implemented to track the current position of the turtle when a script needs to be able to keep track of where the turtle is in the world.

```lua
loadState()

turtle.forward()
state.x = state.x + 1
saveState()
```

The problem is if the script is terminated before the state is saved, but after the turtle has moved, the state information does not get updated and the script no longer knows where the turtle is located. This change resolves this by making it possible to implement an intent log/journal by providing a persistent running ID to the lua script.

For example

```lua
function processJournal()
  local lastID = turtle.getCommandID()
  
  while next(state.journal) do
    local entry = table.remove(state.journal, 1)
    
    -- only process journal entries with newer IDs
    if entry[0] > lastID then
      if entry[1] == 'f' then turtle.forward()
      elseif entry[1] == 'b' then turtle.back()          
      elseif entry[1] == 'u' then turtle.up()
      elseif entry[1] == 'd' then turtle.down()
      elseif entry[1] == 'l' then turtle.turnLeft()
      elseif entry[1] == 'r' then turtle.turnRight() 
      end
    end
  end

  saveState()
end

function forward()
  -- write the intent to move forward to the journal and update the position
  local id = turtle.getCommandID()  + 1
  table.insert(state.journal, {id, "f"})
  state.x = state.x + 1
  saveState()
    
  -- perform the action
  turtle.forward()
  
  -- remove the processed entry from the journal
  table.remove(state.journal, 1)
  saveState()  
end

loadState()
processJournal()
while state.x < 10 do
  forward()
end
```

This could also be further optimized to avoid excessive disk reads/writes, for example:

```lua
function forward()
  -- write the intent to move forward to the journal and update the position
  local id = turtle.getCommandID() + 1
  table.insert(state.journal, {id, "f"})
  state.x = state.x + 1
end

loadState()
processJournal()

while state.x < 10 do
  forward()
end
saveState()
processJournal()
```

Idea initially mentioned in #535 