### PR TITLE
Some printout fixes.

### DIFF
--- a/src/main/java/dan200/computercraft/client/gui/GuiPrintout.java
+++ b/src/main/java/dan200/computercraft/client/gui/GuiPrintout.java
@@ -52,8 +52,7 @@ public class GuiPrintout extends ContainerScreen<ContainerHeldItem>
     @Override
     public boolean keyPressed( int key, int scancode, int modifiers )
     {
-        if( super.keyPressed( key, scancode, modifiers ) ) return true;
-
+        // Check for key presses.
         if( key == GLFW.GLFW_KEY_RIGHT )
         {
             if( page < pages - 1 ) page++;
@@ -66,13 +65,16 @@ public class GuiPrintout extends ContainerScreen<ContainerHeldItem>
             return true;
         }
 
+        // Otherwise, default to parent function
+        if( super.keyPressed( key, scancode, modifiers ) ) return true;
+
         return false;
     }
 
     @Override
     public boolean mouseScrolled( double x, double y, double delta )
     {
-        if( super.mouseScrolled( x, y, delta ) ) return true;
+        // Check for key presses.
         if( delta < 0 )
         {
             // Scroll up goes to the next page
@@ -86,6 +88,9 @@ public class GuiPrintout extends ContainerScreen<ContainerHeldItem>
             if( page > 0 ) page--;
             return true;
         }
+
+        // Otherwise, default to parent function
+        if( super.mouseScrolled( x, y, delta ) ) return true;
 
         return false;
     }

--- a/src/main/java/dan200/computercraft/client/render/ItemPrintoutRenderer.java
+++ b/src/main/java/dan200/computercraft/client/render/ItemPrintoutRenderer.java
@@ -86,7 +86,7 @@ public final class ItemPrintoutRenderer extends ItemMapLikeRenderer
         double height = LINES_PER_PAGE * FONT_HEIGHT + Y_TEXT_MARGIN * 2;
 
         // Non-books will be left aligned
-        if( !book ) width += offsetAt( pages );
+        if( !book ) width += offsetAt( pages - 1 );
 
         double visualWidth = width, visualHeight = height;
 

--- a/src/main/java/dan200/computercraft/client/render/PrintoutRenderer.java
+++ b/src/main/java/dan200/computercraft/client/render/PrintoutRenderer.java
@@ -38,12 +38,12 @@ public final class PrintoutRenderer
     /**
      * Padding between the left and right of a page and the text.
      */
-    public static final int X_TEXT_MARGIN = 13;
+    public static final int X_TEXT_MARGIN = 11;
 
     /**
      * Padding between the top and bottom of a page and the text.
      */
-    public static final int Y_TEXT_MARGIN = 11;
+    public static final int Y_TEXT_MARGIN = 10;
 
     /**
      * Width of the extra page texture.

--- a/src/main/java/dan200/computercraft/client/render/PrintoutRenderer.java
+++ b/src/main/java/dan200/computercraft/client/render/PrintoutRenderer.java
@@ -119,8 +119,12 @@ public final class PrintoutRenderer
             }
         }
 
-        // Left half
-        drawTexture( transform, buffer, x, y, z, X_FOLD_SIZE * 2, 0, X_SIZE / 2.0f, Y_SIZE );
+        // Current page background
+        // z-offset is interleaved between the "zeroth" left/right page and the first left/right page, so that the
+        // "bold" border can be drawn over the edge where appropriate.
+        drawTexture( transform, buffer, x, y, z - 1e-3f * 0.5f, X_FOLD_SIZE * 2, 0, X_SIZE, Y_SIZE );
+
+        // Left pages
         for( int n = 0; n <= leftPages; n++ )
         {
             drawTexture( transform, buffer,
@@ -131,8 +135,7 @@ public final class PrintoutRenderer
             );
         }
 
-        // Right half
-        drawTexture( transform, buffer, x + X_SIZE / 2.0f, y, z, X_FOLD_SIZE * 2 + X_SIZE / 2.0f, 0, X_SIZE / 2.0f, Y_SIZE );
+        // Right pages
         for( int n = 0; n <= rightPages; n++ )
         {
             drawTexture( transform, buffer,


### PR DESCRIPTION
This is a small thing that was contributed downstream, but I want to make it available here in case there are more releases.

Non-book printouts weren't centered as a whole because the logic to left align the first page had an off-by-one error that added an extra bit of offset to the transformation matrix. Also the constants for the text margins were slightly different than what they should be, adding another ~1px of error to both the transform and the text location relative to background. Here's a comparison in an item frame, where it's most noticeable:

![centered-printouts](https://user-images.githubusercontent.com/748280/150450724-26fe3453-b38b-4d6d-9f6c-7d38a39549a3.png)

Note the little bit of item frame peeking out on the ~left~ right side in the before image. I know the text almost looks too far to the left in the after image, but it's because the cracks in the background extend further in on the left side. It's centered "properly" in the after image.

Also I fixed some z-fighting with the bold borders that render on the farthest left and right sides of the printouts. It doesn't really come across in a screenshot but was visible in motion.

Oh, and finally, there was a bug in `GuiPrintout` that made it not respond to the arrow keys. That was fixed too.
