### PR TITLE
Added use_empty_json_array to textutils.unserialiseJSON

### DIFF
--- a/src/main/resources/data/computercraft/lua/rom/apis/textutils.lua
+++ b/src/main/resources/data/computercraft/lua/rom/apis/textutils.lua
@@ -1,5 +1,4 @@
---- The @{textutils} API provides helpful utilities for formatting and
--- manipulating strings.
+--- Helpful utilities for formatting and manipulating strings.
 --
 -- @module textutils
 -- @since 1.2
@@ -141,6 +140,7 @@ function pagedPrint(text, free_lines)
     for k, v in pairs(oldTerm) do
         newTerm[k] = v
     end
+
     newTerm.scroll = makePagedScroll(oldTerm, free_lines)
     term.redirect(newTerm)
 
@@ -411,7 +411,7 @@ do
     end
 
     serializeJSONString = function(s)
-        return ('"%s"'):format(s:gsub("[%z\1-\x1f\"\\]", map):gsub("[\x7f-\xff]", hexify))
+        return ('"%s"'):format(s:gsub("[\0-\x1f\"\\]", map):gsub("[\x7f-\xff]", hexify))
     end
 end
 
@@ -633,9 +633,9 @@ do
             if c == "" then return expected(pos, c, "']'") end
             if c == "]" then
                 if opts.use_empty_json_array then
-                    return empty_json_array, pos + 1 
+                    return empty_json_array, pos + 1
                 else
-                    return {}, pos + 1 
+                    return {}, pos + 1
                 end
             end
 

--- a/src/main/resources/data/computercraft/lua/rom/apis/textutils.lua
+++ b/src/main/resources/data/computercraft/lua/rom/apis/textutils.lua
@@ -1,4 +1,5 @@
---- Helpful utilities for formatting and manipulating strings.
+--- The @{textutils} API provides helpful utilities for formatting and
+-- manipulating strings.
 --
 -- @module textutils
 -- @since 1.2
@@ -140,7 +141,6 @@ function pagedPrint(text, free_lines)
     for k, v in pairs(oldTerm) do
         newTerm[k] = v
     end
-
     newTerm.scroll = makePagedScroll(oldTerm, free_lines)
     term.redirect(newTerm)
 
@@ -411,7 +411,7 @@ do
     end
 
     serializeJSONString = function(s)
-        return ('"%s"'):format(s:gsub("[\0-\x1f\"\\]", map):gsub("[\x7f-\xff]", hexify))
+        return ('"%s"'):format(s:gsub("[%z\1-\x1f\"\\]", map):gsub("[\x7f-\xff]", hexify))
     end
 end
 
@@ -631,7 +631,13 @@ do
             end
 
             if c == "" then return expected(pos, c, "']'") end
-            if c == "]" then return empty_json_array, pos + 1 end
+            if c == "]" then
+                if opts.use_empty_json_array then
+                    return empty_json_array, pos + 1 
+                else
+                    return {}, pos + 1 
+                end
+            end
 
             while true do
                 n, arr[n], pos = n + 1, decode_impl(str, pos, opts)

--- a/src/main/resources/data/computercraft/lua/rom/apis/textutils.lua
+++ b/src/main/resources/data/computercraft/lua/rom/apis/textutils.lua
@@ -632,7 +632,7 @@ do
 
             if c == "" then return expected(pos, c, "']'") end
             if c == "]" then
-                if opts.use_empty_json_array then
+                if opts.parse_empty_array ~= false then
                     return empty_json_array, pos + 1
                 else
                     return {}, pos + 1
@@ -658,32 +658,43 @@ do
         error_at(pos, "Unexpected character %q.", c)
     end
 
-    --- Converts a serialised JSON string back into a reassembled Lua object.
-    --
-    -- This may be used with @{textutils.serializeJSON}, or when communicating
-    -- with command blocks or web APIs.
-    --
-    -- @tparam string s The serialised string to deserialise.
-    -- @tparam[opt] { nbt_style? = boolean, parse_null? = boolean } options
-    -- Options which control how this JSON object is parsed.
-    --
-    --  - `nbt_style`: When true, this will accept [stringified NBT][nbt] strings,
-    --    as produced by many commands.
-    --  - `parse_null`: When true, `null` will be parsed as @{json_null}, rather
-    --    than `nil`.
-    --
-    --  [nbt]: https://minecraft.gamepedia.com/NBT_format
-    -- @return[1] The deserialised object
-    -- @treturn[2] nil If the object could not be deserialised.
-    -- @treturn string A message describing why the JSON string is invalid.
-    -- @since 1.87.0
+    --[[- Converts a serialised JSON string back into a reassembled Lua object.
+
+    This may be used with @{textutils.serializeJSON}, or when communicating
+    with command blocks or web APIs.
+
+    @tparam string s The serialised string to deserialise.
+    @tparam[opt] { nbt_style? = boolean, parse_null? = boolean, parse_empty_array? = boolean } options
+    Options which control how this JSON object is parsed.
+
+    - `nbt_style`: When true, this will accept [stringified NBT][nbt] strings,
+       as produced by many commands.
+    - `parse_null`: When true, `null` will be parsed as @{json_null}, rather than
+       `nil`.
+    - `parse_empty_array`: When false, empty arrays will be parsed as a new table.
+       By default (or when this value is true), they are parsed as @{empty_json_array}.
+
+    [nbt]: https://minecraft.gamepedia.com/NBT_format
+    @return[1] The deserialised object
+    @treturn[2] nil If the object could not be deserialised.
+    @treturn string A message describing why the JSON string is invalid.
+    @since 1.87.0
+    @usage Unserialise a basic JSON object
+
+        textutils.unserialiseJSON('{"name": "Steve", "age": null}')
+
+    @usage Unserialise a basic JSON object, returning null values as @{json_null}.
+
+        textutils.unserialiseJSON('{"name": "Steve", "age": null}', { parse_null = true })
+    ]]
     unserialise_json = function(s, options)
         expect(1, s, "string")
         expect(2, options, "table", "nil")
 
         if options then
             field(options, "nbt_style", "boolean", "nil")
-            field(options, "nbt_style", "boolean", "nil")
+            field(options, "parse_null", "boolean", "nil")
+            field(options, "parse_empty_array", "boolean", "nil")
         else
             options = {}
         end

--- a/src/test/resources/test-rom/spec/apis/textutils_spec.lua
+++ b/src/test/resources/test-rom/spec/apis/textutils_spec.lua
@@ -177,8 +177,15 @@ describe("The textutils library", function()
                 expect(textutils.unserializeJSON("null", { parse_null = false })):eq(nil)
             end)
 
-            it("an empty array", function()
-                expect(textutils.unserializeJSON("[]", { parse_null = false })):eq(textutils.empty_json_array)
+            it("an empty array when parse_empty_array is true", function()
+                expect(textutils.unserializeJSON("[]")):eq(textutils.empty_json_array)
+                expect(textutils.unserializeJSON("[]", { parse_empty_array = true })):eq(textutils.empty_json_array)
+            end)
+
+            it("an empty array when parse_empty_array is false", function()
+                expect(textutils.unserializeJSON("[]", { parse_empty_array = false }))
+                    :ne(textutils.empty_json_array)
+                    :same({})
             end)
 
             it("basic objects", function()


### PR DESCRIPTION
It  can be useful for users who are unaware that empty json arrays are replaced by `empty_json_array` instead of an empty LUA table, which can lead to unexpacted behaviors when using `table.insert` for example.
Adding on option to enable the usage of the `empty_json_array` can help with this, as well as better documentation about it.