### PR TITLE
Add validation to printer slots

### DIFF
--- a/src/main/java/dan200/computercraft/shared/peripheral/printer/ContainerPrinter.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/printer/ContainerPrinter.java
@@ -7,6 +7,7 @@ package dan200.computercraft.shared.peripheral.printer;
 
 import dan200.computercraft.shared.Registry;
 import dan200.computercraft.shared.util.SingleIntArray;
+import dan200.computercraft.shared.util.ValidatingSlot;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.inventory.IInventory;
@@ -33,13 +34,13 @@ public class ContainerPrinter extends Container
         addDataSlots( properties );
 
         // Ink slot
-        addSlot( new Slot( inventory, 0, 13, 35 ) );
+        addSlot( new ValidatingSlot( inventory, 0, 13, 35, TilePrinter::isInk ) );
 
         // In-tray
-        for( int x = 0; x < 6; x++ ) addSlot( new Slot( inventory, x + 1, 61 + x * 18, 22 ) );
+        for( int x = 0; x < 6; x++ ) addSlot( new ValidatingSlot( inventory, x + 1, 61 + x * 18, 22, TilePrinter::isPaper ) );
 
         // Out-tray
-        for( int x = 0; x < 6; x++ ) addSlot( new Slot( inventory, x + 7, 61 + x * 18, 49 ) );
+        for( int x = 0; x < 6; x++ ) addSlot( new ValidatingSlot( inventory, x + 7, 61 + x * 18, 49, TilePrinter::isPage ) );
 
         // Player inv
         for( int y = 0; y < 3; y++ )

--- a/src/main/java/dan200/computercraft/shared/peripheral/printer/ContainerPrinter.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/printer/ContainerPrinter.java
@@ -40,7 +40,7 @@ public class ContainerPrinter extends Container
         for( int x = 0; x < 6; x++ ) addSlot( new ValidatingSlot( inventory, x + 1, 61 + x * 18, 22, TilePrinter::isPaper ) );
 
         // Out-tray
-        for( int x = 0; x < 6; x++ ) addSlot( new ValidatingSlot( inventory, x + 7, 61 + x * 18, 49, TilePrinter::isPage ) );
+        for( int x = 0; x < 6; x++ ) addSlot( new ValidatingSlot( inventory, x + 7, 61 + x * 18, 49, o -> false ) );
 
         // Player inv
         for( int y = 0; y < 3; y++ )

--- a/src/main/java/dan200/computercraft/shared/peripheral/printer/TilePrinter.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/printer/TilePrinter.java
@@ -308,11 +308,16 @@ public final class TilePrinter extends TileGeneric implements DefaultSidedInvent
         return ColourUtils.getStackColour( stack ) != null;
     }
 
-    private static boolean isPaper( @Nonnull ItemStack stack )
+    static boolean isPaper( @Nonnull ItemStack stack )
     {
         Item item = stack.getItem();
-        return item == Items.PAPER
-            || (item instanceof ItemPrintout && ((ItemPrintout) item).getType() == ItemPrintout.Type.PAGE);
+        return item == Items.PAPER || isPage( stack );
+    }
+
+    static boolean isPage( @Nonnull ItemStack stack )
+    {
+        Item item = stack.getItem();
+        return item instanceof ItemPrintout && ((ItemPrintout) item).getType() == ItemPrintout.Type.PAGE;
     }
 
     private boolean canInputPage()

--- a/src/main/java/dan200/computercraft/shared/peripheral/printer/TilePrinter.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/printer/TilePrinter.java
@@ -311,13 +311,8 @@ public final class TilePrinter extends TileGeneric implements DefaultSidedInvent
     static boolean isPaper( @Nonnull ItemStack stack )
     {
         Item item = stack.getItem();
-        return item == Items.PAPER || isPage( stack );
-    }
-
-    static boolean isPage( @Nonnull ItemStack stack )
-    {
-        Item item = stack.getItem();
-        return item instanceof ItemPrintout && ((ItemPrintout) item).getType() == ItemPrintout.Type.PAGE;
+        return item == Items.PAPER
+            || (item instanceof ItemPrintout && ((ItemPrintout) item).getType() == ItemPrintout.Type.PAGE);
     }
 
     private boolean canInputPage()

--- a/src/main/java/dan200/computercraft/shared/util/ValidatingSlot.java
+++ b/src/main/java/dan200/computercraft/shared/util/ValidatingSlot.java
@@ -10,17 +10,27 @@ import net.minecraft.inventory.container.Slot;
 import net.minecraft.item.ItemStack;
 
 import javax.annotation.Nonnull;
+import java.util.function.Predicate;
 
 public class ValidatingSlot extends Slot
 {
+    private final Predicate<ItemStack> predicate;
+
     public ValidatingSlot( IInventory inventoryIn, int index, int xPosition, int yPosition )
     {
         super( inventoryIn, index, xPosition, yPosition );
+        this.predicate = itemStack -> true;
+    }
+
+    public ValidatingSlot( IInventory inventoryIn, int index, int xPosition, int yPosition, Predicate<ItemStack> predicate )
+    {
+        super( inventoryIn, index, xPosition, yPosition );
+        this.predicate = predicate;
     }
 
     @Override
     public boolean mayPlace( @Nonnull ItemStack stack )
     {
-        return true; // inventory.isItemValidForSlot( slotNumber, stack );
+        return predicate.test( stack );
     }
 }

--- a/src/main/java/dan200/computercraft/shared/util/ValidatingSlot.java
+++ b/src/main/java/dan200/computercraft/shared/util/ValidatingSlot.java
@@ -16,12 +16,6 @@ public class ValidatingSlot extends Slot
 {
     private final Predicate<ItemStack> predicate;
 
-    public ValidatingSlot( IInventory inventoryIn, int index, int xPosition, int yPosition )
-    {
-        super( inventoryIn, index, xPosition, yPosition );
-        this.predicate = itemStack -> true;
-    }
-
     public ValidatingSlot( IInventory inventoryIn, int index, int xPosition, int yPosition, Predicate<ItemStack> predicate )
     {
         super( inventoryIn, index, xPosition, yPosition );


### PR DESCRIPTION
When playing, I spent far too long trying to figure out why my printer wasn't working. Turns out, Ink Sac isn't a dye anymore!

This PR adds validation to the slots for the printer, ensuring that only ink is inserted in the left slot, only paper/printed pages are inserted into the top slots, and only printed pages are inserted into the bottom slots. The bottom slots may be a slightly controversial change but I don't think it should really affect anything.

In theory, this should have no problems with existing worlds. Invalid items sat in those slots will remain untouched, but obviously they can't be added back again.

I noticed an existing ValidatingSlot class in the codebase when implementing this, which I piggybacked off by adding a constructor that takes a predicate. The class was unused in the mod's code, and a quick cs.github.com search shows no other known uses of it, but I kept the old constructor in just in case. I can remove it if you like.

Side-note: when trying to run `.\gradlew build` I kept running into this error during the in-game test runner:

```
[02:38:44] [Server thread/ERROR] [minecraft/MinecraftServer]: Encountered an unexpected exception
java.io.UncheckedIOException: com.google.common.io.InsecureRecursiveDeleteException: .\world\computercraft: unable to guarantee security of recursive delete
Caused by: com.google.common.io.InsecureRecursiveDeleteException: .\world\computercraft: unable to guarantee security of recursive delete

	at dan200.computercraft.ingame.mod.CCTestCommand.importFiles(CCTestCommand.java:106) ~[testMod/:?] {re:classloading}
	at dan200.computercraft.ingame.mod.TestHooks.onServerStarted(TestHooks.java:66) ~[testMod/:?] {re:classloading}
	at net.minecraftforge.eventbus.ASMEventHandler_16_TestHooks_onServerStarted_FMLServerStartedEvent.invoke(.dynamic) ~[?:?] {}
	at net.minecraftforge.eventbus.ASMEventHandler.invoke(ASMEventHandler.java:85) ~[eventbus-4.0.0.jar:?] {}
	at net.minecraftforge.eventbus.EventBus.post(EventBus.java:302) ~[eventbus-4.0.0.jar:?] {}
	at net.minecraftforge.eventbus.EventBus.post(EventBus.java:283) ~[eventbus-4.0.0.jar:?] {}
	at net.minecraftforge.fml.server.ServerLifecycleHooks.handleServerStarted(ServerLifecycleHooks.java:106) ~[forge:?] {re:classloading}
	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:644) ~[forge:?] {re:classloading,pl:accesstransformer:B,pl:runtimedistcleaner:A}
	at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:233) ~[forge:?] {re:classloading,pl:accesstransformer:B,pl:runtimedistcleaner:A}
	at java.lang.Thread.run(Thread.java:750) [?:1.8.0_322] {}
Caused by: com.google.common.io.InsecureRecursiveDeleteException: .\world\computercraft: unable to guarantee security of recursive delete
	at com.google.common.io.MoreFiles.checkAllowsInsecure(MoreFiles.java:686) ~[guava-21.0.jar:?] {}
	at com.google.common.io.MoreFiles.deleteRecursively(MoreFiles.java:472) ~[guava-21.0.jar:?] {}
	at dan200.computercraft.ingame.mod.Copier.replicate(Copier.java:58) ~[testMod/:?] {re:classloading}
	at dan200.computercraft.ingame.mod.Copier.replicate(Copier.java:53) ~[testMod/:?] {re:classloading}
	at dan200.computercraft.ingame.mod.CCTestCommand.importFiles(CCTestCommand.java:102) ~[testMod/:?] {re:classloading}
	... 9 more
```

The rest of the tests run fine, and the rest of the build runs fine, I get a jar, and the game works as expected. I haave a feeling this is an issue in my local environment unrelated to my code. Just thought I'd mention.