### PR TITLE
Prototype of a way to get the name of inventories

### DIFF
--- a/src/main/java/dan200/computercraft/shared/peripheral/generic/methods/InventoryMethods.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/generic/methods/InventoryMethods.java
@@ -16,6 +16,7 @@ import dan200.computercraft.api.peripheral.PeripheralType;
 import dan200.computercraft.shared.peripheral.generic.data.ItemData;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.Container;
+import net.minecraft.world.Nameable;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
@@ -263,6 +264,27 @@ public class InventoryMethods implements GenericPeripheral
 
         if( actualLimit <= 0 ) return 0;
         return moveItem( from, fromSlot - 1, to, toSlot.orElse( 0 ) - 1, actualLimit );
+    }
+
+    /**
+     * Get the display name of the current inventory.
+     *
+     * This allows you to get the name of inventories renamed in an anvil.
+     *
+     * @param peripheral The current peripheral.
+     * @return The name of the inventory, or nil.
+     * @cc.usage find a chest, and print it's (custom) name.
+     * <pre>{@code
+     * local chest = peripheral.find("minecraft:chest")
+     *
+     * print(chest.displayName())
+     * }</pre>
+     */
+    @LuaFunction( mainThread = true )
+    public static String displayName(IPeripheral peripheral)
+    {
+        if (peripheral.getTarget() instanceof Nameable nameable) return nameable.getDisplayName().getString();
+        return null;
     }
 
     @Nullable


### PR DESCRIPTION
This is just a proof of concept, i do not expect this code to be merged as-is, or even inside this peripheral or this way:

During my most recent enigmatica 6 expert playthough me and my basemate opted for a basewide wired network, this of course meant lots of chests/barrels on the same network, which can get tricky to tell apart.

There are of course solutions to that, like having a disk drive with a floppy that contains a map of addresses, like:
- `ip.storage = 'minecraft:barrel_3'` (for a barrel that imports into refined storage)
- `ip.foundry = 'tconstruct:drain_0'` (for tinkers construct based fluid storage)

Of course those would still need to be manually maintained in case something gets moved, and all computers that imported it should be rebooted. (though that can be remedied with pulling peripheral change events and whatnot)

Another concept on the same wired network was using a special item in the 1st slot, for the output of several create contraptions we had a purple `active logistic provider frame` from pneumaticcraft signaling that that `inventory` should be emptied, and the `ip.storage` mentioned above had a yellow `storage logistic frame` in it to signal the destination, as well as a dedicated computer to orchestrate the bunch.

For recipe inputs this was a little more tricky since the "item in slot 1" should not be pulled into the machine, this of course was fixable by just blacklisting the item used for filtering from being pulled into the machine.

But in order for the computer(s) on the network to know which chest belonged to which machine's input we had to rename the slot 1 items in an anvil and then compare the `displayName`, here is a snippet that accomplished that goal:

```
_G.inventory_with_logistics_core = function(displayName)
  return peripheral.find('inventory', function(name, inventory)
    local item = inventory.getItemDetail(1)
    return item and item.displayName == displayName
  end)
end
```

This was stored on the networked floppy, the logistics core from pneumaticcraft was chosen because no recipes used it.

However, it would be easier if the names of chests (& other inventories) renamed in an anvil were accessible, then the input/output/storage chests could simply be named accordingly and there would be no more need for hardcoded `_#`'s or items inside inventories in order to tell them apart.

Some food for thought:
- `Nameable` exists on multiple things (including fluid/energy storage), so inventory methods might not be the best spot.
- `Nameable` supports `hasCustomName, getDisplayName & getCustomName`, maybe players would want access to all 3, or only custom names? perhaps its best made into its own generic peripheral, but those seem to demand capabilities.

This pull request is thus just a proof of concept, see it more as a suggestion/idea than code intended to merge as-is.
![2022-06-18_09 10 18](https://user-images.githubusercontent.com/3179271/174427726-83934751-8979-4f4e-a029-846463ea60df.png)

```
local chest = peripheral.wrap('right')

--print(textutils.serialize( getmetatable(chest) ))

for k, v in pairs(chest) do
    print(k)
end

print('-')

print('the chest on my left is called ', peripheral.wrap('left').displayName())
print('the chest on my right is called ', peripheral.wrap('right').displayName())
```
(ps, the docblock has not been generated/tested, it received minimal love 💔)