### PR TITLE
Inventory peripheral API tweaks

### DIFF
--- a/src/main/java/dan200/computercraft/shared/peripheral/generic/data/ItemData.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/generic/data/ItemData.java
@@ -10,6 +10,7 @@ import dan200.computercraft.shared.util.NBTUtil;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.item.EnchantedBookItem;
+import net.minecraft.item.ItemGroup;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.nbt.INBT;
@@ -32,7 +33,6 @@ public class ItemData
     {
         data.put( "name", DataHelpers.getId( stack.getItem() ) );
         data.put( "count", stack.getCount() );
-
         return data;
     }
 
@@ -40,6 +40,15 @@ public class ItemData
     public static <T extends Map<? super String, Object>> T fillBasic( @Nonnull T data, @Nonnull ItemStack stack )
     {
         fillBasicSafe( data, stack );
+        Collection<ItemGroup> groups = stack.getItem().getCreativeTabs();
+        if ( !groups.isEmpty() )
+        {
+            data.put( "groups", groups.stream()
+                .map( ItemGroup::getDisplayName )
+                .map( ITextComponent::getString )
+                .collect( Collectors.toList() ) );
+        }
+
         String hash = NBTUtil.getNBTHash( stack.getTag() );
         if( hash != null ) data.put( "nbt", hash );
         return data;

--- a/src/main/java/dan200/computercraft/shared/peripheral/generic/data/ItemData.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/generic/data/ItemData.java
@@ -44,8 +44,7 @@ public class ItemData
         if ( !groups.isEmpty() )
         {
             data.put( "groups", groups.stream()
-                .map( ItemGroup::getDisplayName )
-                .map( ITextComponent::getString )
+                .map( ItemGroup::getId )
                 .collect( Collectors.toList() ) );
         }
 

--- a/src/main/java/dan200/computercraft/shared/peripheral/generic/methods/InventoryMethods.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/generic/methods/InventoryMethods.java
@@ -107,7 +107,7 @@ public class InventoryMethods implements GenericPeripheral
      *
      * The returned information contains the same information as each item in
      * {@link #list}, as well as additional details like the display name
-     * (`displayName`), item groups (`groups`), which are the name of creative tabs the item appears under, and item
+     * (`displayName`), item groups (`groups`), which are the IDs of creative tabs the item appears under, and item
      * durability (`damage`, `maxDamage`, `durability`).
      *
      * Some items include more information (such as enchantments) - it is
@@ -131,7 +131,7 @@ public class InventoryMethods implements GenericPeripheral
      *
      * if item.groups then
      *   for _, group in ipairs(item.groups) do
-     *     print(("Group: %s"):format(group))
+     *     print(("Group ID: %d"):format(group))
      *   end
      * end
      *


### PR DESCRIPTION
Adds a method for swapping item stacks between slots/inventories without the need for a buffer slot and now returns the item groups (Creative tabs) an item pertains to when calling **getItemDetail**().

Gives the generic inventory api some love, allowing for more elaborate and faster systems like item sorting. The **swapItems** method isn't completely failsafe, just like the current **pushItems** and **pullItems** aren't, as there's no real great way to do it. This should allow for more dynamic item movement, as it will no longer require a buffer slot, which currently makes thing slower and more cumbersome. Returns the creative tabs an item is part of in an effort to make the **getItemDetail**() method return data a bit more detailed.