### PR TITLE
Fix off-by-1 error in generic inventory's getItemLimit()

### DIFF
--- a/src/main/java/dan200/computercraft/shared/peripheral/generic/methods/InventoryMethods.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/generic/methods/InventoryMethods.java
@@ -166,7 +166,7 @@ public class InventoryMethods implements GenericPeripheral
     public static int getItemLimit( IItemHandler inventory, int slot ) throws LuaException
     {
         assertBetween( slot, 1, inventory.getSlots(), "Slot out of range (%s)" );
-        return inventory.getSlotLimit( slot );
+        return inventory.getSlotLimit( slot - 1 );
     }
 
     /**


### PR DESCRIPTION
It's difficult to think of a situation where this would matter or cause an issue except for the one I ran into, trying to use a StorageDrawers Drawer Controller as a generic inventory peripheral.

But when you do:
- `getItemLimit(0)` throws (fine)
- `getItemLimit(1)` returns the stack limit of the *second* drawer
- `getItemLimit(n)` returns 0.

Test setup:
![image](https://user-images.githubusercontent.com/97357465/177887390-aa262151-1119-4c6b-85a2-2493d1763e80.png)

Test script:
```lua
local dc = peripheral.wrap("right")
for slot,stack in pairs(dc.list()) do
    print(slot, stack.name, stack.count, dc.getItemLimit(slot))
end
```

Results (no upgrades):
![image](https://user-images.githubusercontent.com/97357465/177887578-d6191c76-76b5-4fa2-8fd5-cf8f9fb832c0.png)

Results (with a storage upgrade in the middle drawer -- the one with 2 cobble):
![image](https://user-images.githubusercontent.com/97357465/177887619-a9f409ea-1a16-49d1-9719-c20f7f21be7f.png)

In this specific case, the user can kind of work around this by instead calling `dc.getItemLimit(slot - 1)`, but this seems to rely on the fact that StorageDrawers starts their drawer indexing at 1 (or is using 0 for the controller or something).  (Note: When I say "1" here I'm talking about in the 0-based Java world, and therefore 2 in the 1-based Lua world as shown in first column of the the screenshot output)

This is a PR against the 1.16.x branch (since that's the version I ran into the issue on), but it looks like it exists across (at least some) others, e.g. [1.19.x](https://github.com/cc-tweaked/CC-Tweaked/blob/mc-1.19.x/src/main/java/dan200/computercraft/shared/peripheral/generic/methods/InventoryMethods.java#L171)