### PR TITLE
Always add HTTP programs to the path

### DIFF
--- a/src/main/resources/data/computercraft/lua/rom/programs/http/pastebin.lua
+++ b/src/main/resources/data/computercraft/lua/rom/programs/http/pastebin.lua
@@ -13,8 +13,8 @@ if #tArgs < 2 then
 end
 
 if not http then
-    printError("Pastebin requires the http API")
-    printError("Set http.enabled to true in CC: Tweaked's config")
+    printError("Pastebin requires the http API, but it is not enabled")
+    printError("Set http.enabled to true in CC: Tweaked's server config")
     return
 end
 

--- a/src/main/resources/data/computercraft/lua/rom/programs/http/wget.lua
+++ b/src/main/resources/data/computercraft/lua/rom/programs/http/wget.lua
@@ -21,8 +21,8 @@ end
 local url = table.remove(tArgs, 1)
 
 if not http then
-    printError("wget requires the http API")
-    printError("Set http.enabled to true in CC: Tweaked's config")
+    printError("wget requires the http API, but it is not enabled")
+    printError("Set http.enabled to true in CC: Tweaked's server config")
     return
 end
 

--- a/src/main/resources/data/computercraft/lua/rom/startup.lua
+++ b/src/main/resources/data/computercraft/lua/rom/startup.lua
@@ -1,7 +1,7 @@
 local completion = require "cc.shell.completion"
 
 -- Setup paths
-local sPath = ".:/rom/programs"
+local sPath = ".:/rom/programs:/rom/programs/http"
 if term.isColor() then
     sPath = sPath .. ":/rom/programs/advanced"
 end
@@ -18,9 +18,6 @@ if pocket then
 end
 if commands then
     sPath = sPath .. ":/rom/programs/command"
-end
-if http then
-    sPath = sPath .. ":/rom/programs/http"
 end
 shell.setPath(sPath)
 help.setPath("/rom/help")


### PR DESCRIPTION
An attempt to make the UX better when HTTP is disabled. See the discussion at https://github.com/SquidDev-CC/FAQBot-CC/pull/44.

The programs already failed with the existing message:

![wget requires the http API. Set http.enabled to true in CC: Tweaked's config](https://user-images.githubusercontent.com/4346137/192974918-c96170dc-5270-4f47-ba51-fe01cc1eaf69.png)

I'm not sure if this is as clear as it should be. Don't know if anyone has alternative phrasings?