### PR TITLE
Add `peripheral_hub` type for wired-modem-like peripherals

### DIFF
--- a/src/main/java/dan200/computercraft/shared/peripheral/modem/wired/WiredModemPeripheral.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/modem/wired/WiredModemPeripheral.java
@@ -72,6 +72,13 @@ public abstract class WiredModemPeripheral extends ModemPeripheral implements IW
     protected abstract WiredModemLocalPeripheral getLocalPeripheral();
     //endregion
 
+    @Nonnull
+    @Override
+    public Set<String> getAdditionalTypes()
+    {
+        return Collections.singleton( "peripheral_hub" );
+    }
+
     //region Peripheral methods
 
     /**

--- a/src/main/resources/data/computercraft/lua/rom/apis/peripheral.lua
+++ b/src/main/resources/data/computercraft/lua/rom/apis/peripheral.lua
@@ -109,7 +109,7 @@ function getNames()
         local side = sides[n]
         if native.isPresent(side) then
             table.insert(results, side)
-            if native.hasType(side, "modem") and not native.call(side, "isWireless") then
+            if native.hasType(side, "peripheral_hub") then
                 local remote = native.call(side, "getNamesRemote")
                 for _, name in ipairs(remote) do
                     table.insert(results, name)
@@ -134,9 +134,7 @@ function isPresent(name)
 
     for n = 1, #sides do
         local side = sides[n]
-        if native.hasType(side, "modem") and not native.call(side, "isWireless") and
-            native.call(side, "isPresentRemote", name)
-        then
+        if native.hasType(side, "peripheral_hub") and native.call(side, "isPresentRemote", name) then
             return true
         end
     end
@@ -162,9 +160,7 @@ function getType(peripheral)
         end
         for n = 1, #sides do
             local side = sides[n]
-            if native.hasType(side, "modem") and not native.call(side, "isWireless") and
-                native.call(side, "isPresentRemote", peripheral)
-            then
+            if native.hasType(side, "peripheral_hub") and native.call(side, "isPresentRemote", peripheral) then
                 return native.call(side, "getTypeRemote", peripheral)
             end
         end
@@ -195,9 +191,7 @@ function hasType(peripheral, peripheral_type)
         end
         for n = 1, #sides do
             local side = sides[n]
-            if native.hasType(side, "modem") and not native.call(side, "isWireless") and
-                native.call(side, "isPresentRemote", peripheral)
-            then
+            if native.hasType(side, "peripheral_hub") and native.call(side, "isPresentRemote", peripheral) then
                 return native.call(side, "hasTypeRemote", peripheral, peripheral_type)
             end
         end
@@ -223,9 +217,7 @@ function getMethods(name)
     end
     for n = 1, #sides do
         local side = sides[n]
-        if native.hasType(side, "modem") and not native.call(side, "isWireless") and
-            native.call(side, "isPresentRemote", name)
-        then
+        if native.hasType(side, "peripheral_hub") and native.call(side, "isPresentRemote", peripheral) then
             return native.call(side, "getMethodsRemote", name)
         end
     end
@@ -265,9 +257,7 @@ function call(name, method, ...)
 
     for n = 1, #sides do
         local side = sides[n]
-        if native.hasType(side, "modem") and not native.call(side, "isWireless") and
-            native.call(side, "isPresentRemote", name)
-        then
+        if native.hasType(side, "peripheral_hub") and native.call(side, "isPresentRemote", peripheral) then
             return native.call(side, "callRemote", name, method, ...)
         end
     end


### PR DESCRIPTION
This allows other mods to create wired-modem alike blocks, which expose
peripherals on the wired network, without having to reimplement the main
modem interface.

This is not currently documented, but a peripheral_hub should provide
the following methods:

 - isPresentRemote
 - getTypeRemote
 - hasTypeRemote
 - getMethodsRemote
 - callRemote

Closes #902. CC @SirEdvin - does this look usable for your needs?
