### PR TITLE
Deliver x86_64 Illuaminate binaries to all Macs

### DIFF
--- a/buildSrc/src/main/kotlin/cc/tweaked/gradle/Illuaminate.kt
+++ b/buildSrc/src/main/kotlin/cc/tweaked/gradle/Illuaminate.kt
@@ -66,9 +66,11 @@ class IlluaminatePlugin : Plugin<Project> {
 
         val osArch = System.getProperty("os.arch").toLowerCase()
         val arch = when {
+            // On macOS the x86_64 binary will work for both ARM and Intel Macs through Rosetta.
+            os == "macos" -> "x86_64"
             osArch == "arm" || osArch.startsWith("aarch") -> error("Unsupported architecture '$osArch' for illuaminate")
             osArch.contains("64") -> "x86_64"
-            else -> error("Unsupported architecture $osArch for illuaminate")
+            else -> error("Unsupported architecture '$osArch' for illuaminate")
         }
 
         return project.dependencies.create(


### PR DESCRIPTION
On ARM-based Macs Gradle will throw the following error while configuring the project or trying to run the Lua linting tasks:

```
Could not create task ':forge:lintLua'.
Could not create task of type 'IlluaminateExec'.
Failed to query the value of extension 'illuaminate' property 'file'.
Unsupported architecture 'aarch64' for illuaminate
```
This PR adds a special case to the Illuaminate dependency extension logic so that all Macs receive the x86_64 binary. ARM-based Macs will run this binary through Rosetta no problem.