### PR TITLE
Fix duplicated swing animations on high-ping servers

### DIFF
--- a/projects/common/src/main/java/dan200/computercraft/shared/computer/blocks/AbstractComputerBlockEntity.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/computer/blocks/AbstractComputerBlockEntity.java
@@ -98,7 +98,7 @@ public abstract class AbstractComputerBlockEntity extends BlockEntity implements
                 setLabel(currentItem.getHoverName().getString());
                 currentItem.shrink(1);
             }
-            return InteractionResult.SUCCESS;
+            return InteractionResult.sidedSuccess(getLevel().isClientSide);
         } else if (!player.isCrouching()) {
             // Regular right click to activate computer
             if (!getLevel().isClientSide && isUsable(player)) {
@@ -110,7 +110,7 @@ public abstract class AbstractComputerBlockEntity extends BlockEntity implements
                     : ItemStack.EMPTY;
                 new ComputerContainerData(computer, stack).open(player, this);
             }
-            return InteractionResult.SUCCESS;
+            return InteractionResult.sidedSuccess(getLevel().isClientSide);
         }
         return InteractionResult.PASS;
     }

--- a/projects/common/src/main/java/dan200/computercraft/shared/media/items/PrintoutItem.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/media/items/PrintoutItem.java
@@ -56,7 +56,7 @@ public class PrintoutItem extends Item {
             new HeldItemContainerData(hand)
                 .open(player, new HeldItemMenu.Factory(ModRegistry.Menus.PRINTOUT.get(), player.getItemInHand(hand), hand));
         }
-        return new InteractionResultHolder<>(InteractionResult.SUCCESS, player.getItemInHand(hand));
+        return new InteractionResultHolder<>(InteractionResult.sidedSuccess(world.isClientSide), player.getItemInHand(hand));
     }
 
     private ItemStack createFromTitleAndText(@Nullable String title, @Nullable String[] text, @Nullable String[] colours) {

--- a/projects/common/src/main/java/dan200/computercraft/shared/peripheral/modem/wired/CableBlockEntity.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/peripheral/modem/wired/CableBlockEntity.java
@@ -193,7 +193,7 @@ public class CableBlockEntity extends BlockEntity {
             }
         }
 
-        return InteractionResult.SUCCESS;
+        return InteractionResult.CONSUME;
     }
 
     @Override

--- a/projects/common/src/main/java/dan200/computercraft/shared/peripheral/modem/wired/CableBlockItem.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/peripheral/modem/wired/CableBlockItem.java
@@ -78,7 +78,7 @@ public abstract class CableBlockItem extends BlockItem {
                     .setValue(CONNECTIONS.get(side), existingState.getValue(CABLE));
                 if (placeAt(world, pos, newState)) {
                     stack.shrink(1);
-                    return InteractionResult.SUCCESS;
+                    return InteractionResult.sidedSuccess(world.isClientSide);
                 }
             }
 
@@ -105,7 +105,7 @@ public abstract class CableBlockItem extends BlockItem {
             if (insideState.getBlock() == ModRegistry.Blocks.CABLE.get() && !insideState.getValue(CableBlock.CABLE)
                 && placeAtCorrected(world, insidePos, insideState.setValue(CableBlock.CABLE, true))) {
                 stack.shrink(1);
-                return InteractionResult.SUCCESS;
+                return InteractionResult.sidedSuccess(world.isClientSide);
             }
 
             // Try to add a cable to a modem adjacent to this block
@@ -113,7 +113,7 @@ public abstract class CableBlockItem extends BlockItem {
             if (existingState.getBlock() == ModRegistry.Blocks.CABLE.get() && !existingState.getValue(CableBlock.CABLE)
                 && placeAtCorrected(world, pos, existingState.setValue(CableBlock.CABLE, true))) {
                 stack.shrink(1);
-                return InteractionResult.SUCCESS;
+                return InteractionResult.sidedSuccess(world.isClientSide);
             }
 
             return super.place(context);

--- a/projects/common/src/main/java/dan200/computercraft/shared/peripheral/modem/wired/WiredModemFullBlockEntity.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/peripheral/modem/wired/WiredModemFullBlockEntity.java
@@ -139,7 +139,7 @@ public class WiredModemFullBlockEntity extends BlockEntity {
             sendPeripheralChanges(player, "chat.computercraft.wired_modem.peripheral_connected", periphNames);
         }
 
-        return InteractionResult.SUCCESS;
+        return InteractionResult.CONSUME;
     }
 
     private static void sendPeripheralChanges(Player player, String kind, Collection<String> peripherals) {

--- a/projects/common/src/main/java/dan200/computercraft/shared/peripheral/monitor/MonitorBlock.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/peripheral/monitor/MonitorBlock.java
@@ -110,7 +110,7 @@ public class MonitorBlock extends HorizontalDirectionalBlock implements EntityBl
             );
         }
 
-        return InteractionResult.SUCCESS;
+        return InteractionResult.sidedSuccess(level.isClientSide);
     }
 
     @Override

--- a/projects/common/src/main/java/dan200/computercraft/shared/pocket/items/PocketComputerItem.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/pocket/items/PocketComputerItem.java
@@ -141,7 +141,7 @@ public class PocketComputerItem extends Item implements IComputerItem, IMedia, I
                 new ComputerContainerData(computer, stack).open(player, new PocketComputerMenuProvider(computer, stack, this, hand, isTypingOnly));
             }
         }
-        return new InteractionResultHolder<>(InteractionResult.SUCCESS, stack);
+        return new InteractionResultHolder<>(InteractionResult.sidedSuccess(world.isClientSide), stack);
     }
 
     @Override

--- a/projects/common/src/main/java/dan200/computercraft/shared/turtle/blocks/TurtleBlockEntity.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/turtle/blocks/TurtleBlockEntity.java
@@ -104,7 +104,7 @@ public class TurtleBlockEntity extends AbstractComputerBlockEntity implements Ba
                         }
                     }
                 }
-                return InteractionResult.SUCCESS;
+                return InteractionResult.sidedSuccess(getLevel().isClientSide);
             } else if (currentItem.getItem() == Items.WATER_BUCKET && brain.getColour() != -1) {
                 // Water to remove turtle colour
                 if (!getLevel().isClientSide) {
@@ -116,7 +116,7 @@ public class TurtleBlockEntity extends AbstractComputerBlockEntity implements Ba
                         }
                     }
                 }
-                return InteractionResult.SUCCESS;
+                return InteractionResult.sidedSuccess(getLevel().isClientSide);
             }
         }
 


### PR DESCRIPTION
Use `InteractionResult.sidedSuccess` / `.CONSUME` where applicable instead of `.SUCCESS`. This prevents the server from sending an additional swing animation packet to the client. Normally this isn't a problem, since the client will de-duplicate swing packets if they are within the animation duration of the currently playing swing; however, when connected to a server with a high ping the packet is sent after the animation is already finished on the client, resulting in a duplicate animation.

To be clear, using `InteractionResult.sidedSuccess` causes a result of `SUCCESS` to be used on the client, and `CONSUME` on the server. This has the effect that the client will immediately play the swing animation when the interaction happens since it is a SUCCESS, and the server will treat the interaction as successful, but prevent sending any swing animation to players. For players other than the actor, the client sends a C2S packet for the player swing to the server which gets forwarded to everyone else nearby. This practice appears to be standard in Minecraft's vanilla source.

https://user-images.githubusercontent.com/65421017/208580800-7306516b-8fac-4c5b-95fb-e58504918177.mp4
