### PR TITLE
#1256: "shell.complete should quote filenames with spaces in them"

### DIFF
--- a/projects/core/src/main/resources/data/computercraft/lua/rom/programs/shell.lua
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/programs/shell.lua
@@ -410,7 +410,7 @@ end
 -- @see shell.setCompletionFunction
 -- @see shell.getCompletionInfo
 -- @since 1.74
-function shell.complete(sLine)
+function shell.complete(sLine, bFull)
     expect(1, sLine, "string")
     if #sLine > 0 then
         local tWords = tokenise(sLine)
@@ -432,6 +432,17 @@ function shell.complete(sLine)
                         tResults[n] = sResult .. " "
                     end
                 end
+
+                if bFull then
+                    for i = 1, #tResults do
+                        tResults[i] = sLine..tResults[i] -- Make it the full name instead of suffix
+    
+                        if string.find(tResults[i], " ") then
+                            tResults[i] = '"'..tResults[i]..'"' -- Add quotes if space in name
+                        end
+                    end
+                end
+
                 return tResults
             end
 


### PR DESCRIPTION
Regarding issue #1256 

Added an optional parameter to Shell.complete(sLine, bFull):
-> if bFull is set to true, the function will return the full filenames of all files that start with sLine. It also quotes filenames if they have a space in them. Not supplying bFull has the same result as setting it to false.

This way you can choose which option to use and aren't tied to either one.