### PR TITLE
Fix crash when turtle digs with a full inventory and any slot other than slot 1 is selected

### DIFF
--- a/projects/common/src/main/java/dan200/computercraft/shared/util/InventoryUtil.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/util/InventoryUtil.java
@@ -51,14 +51,12 @@ public final class InventoryUtil {
     }
 
     private static ItemStack storeItemsImpl(Container container, ItemStack stack, int offset, int slotCount) {
-        var limit = container.getMaxStackSize();
         var maxSize = Math.min(stack.getMaxStackSize(), container.getMaxStackSize());
         if (maxSize <= 0) return stack;
 
         for (var i = 0; i < slotCount; i++) {
             var slot = i + offset;
-            if (slot > limit) slot -= limit;
-
+            if (slot >= slotCount) slot -= slotCount;
             var currentStack = container.getItem(slot);
             if (currentStack.isEmpty()) {
                 // If the current slot is empty and we can place them item then there's two cases:

--- a/projects/common/src/main/java/dan200/computercraft/shared/util/InventoryUtil.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/util/InventoryUtil.java
@@ -51,12 +51,13 @@ public final class InventoryUtil {
     }
 
     private static ItemStack storeItemsImpl(Container container, ItemStack stack, int offset, int slotCount) {
+        var limit = container.getContainerSize();
         var maxSize = Math.min(stack.getMaxStackSize(), container.getMaxStackSize());
         if (maxSize <= 0) return stack;
 
         for (var i = 0; i < slotCount; i++) {
             var slot = i + offset;
-            if (slot >= slotCount) slot -= slotCount;
+            if (slot >= limit) slot -= limit;
             var currentStack = container.getItem(slot);
             if (currentStack.isEmpty()) {
                 // If the current slot is empty and we can place them item then there's two cases:

--- a/projects/common/src/test/java/dan200/computercraft/shared/util/InventoryUtilTest.java
+++ b/projects/common/src/test/java/dan200/computercraft/shared/util/InventoryUtilTest.java
@@ -1,0 +1,38 @@
+/*
+ * This file is part of ComputerCraft - http://www.computercraft.info
+ * Copyright Daniel Ratcliffe, 2011-2022. Do not distribute without permission.
+ * Send enquiries to dratcliffe@gmail.com
+ */
+package dan200.computercraft.shared.util;
+
+import dan200.computercraft.test.shared.WithMinecraft;
+import net.minecraft.world.SimpleContainer;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import org.junit.jupiter.api.Test;
+
+import static dan200.computercraft.test.shared.ItemStackMatcher.isStack;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@WithMinecraft
+public class InventoryUtilTest {
+    @Test
+    public void testStoreOffset() {
+        var container = new SimpleContainer(9);
+
+        var remainder = InventoryUtil.storeItemsFromOffset(container, new ItemStack(Items.COBBLESTONE, 32), 4);
+        assertThat("Remainder is empty", remainder, isStack(ItemStack.EMPTY));
+        assertThat("Was inserted into slot", container.getItem(4), isStack(new ItemStack(Items.COBBLESTONE, 32)));
+    }
+
+    @Test
+    public void testStoreOffsetWraps() {
+        var container = new SimpleContainer(9);
+        container.setItem(0, new ItemStack(Items.DIRT));
+        for (var slot = 4; slot < 9; slot++) container.setItem(slot, new ItemStack(Items.DIRT));
+
+        var remainder = InventoryUtil.storeItemsFromOffset(container, new ItemStack(Items.COBBLESTONE, 32), 4);
+        assertThat("Remainder is empty", remainder, isStack(ItemStack.EMPTY));
+        assertThat("Was inserted into slot", container.getItem(1), isStack(new ItemStack(Items.COBBLESTONE, 32)));
+    }
+}


### PR DESCRIPTION
There appears to be a bug where the game will crash if a turtle digs while having any slot other than the first selected, and that slot plus all slots after that are full or don't match the dug item.

Reproduction steps:
1. Place a mining turtle
2. Execute turtle.select(16)
3. Fill its inventory with dirt
4. Place a stone block in front of the turtle
5. Run turtle.dig()