### PR TITLE
Read computer threads directly from the config object

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,7 +26,7 @@ nightConfig = "3.6.5"
 slf4j = "1.7.36"
 
 # Minecraft mods
-forgeConfig = "5.0.3"
+forgeConfig = "5.0.4"
 iris = "1.19.3-v1.4.6"
 jei = "11.3.0.262"
 modmenu = "5.0.1"

--- a/projects/common/src/main/java/dan200/computercraft/shared/computer/core/ServerContext.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/computer/core/ServerContext.java
@@ -18,7 +18,7 @@ import dan200.computercraft.core.lua.ILuaMachine;
 import dan200.computercraft.impl.AbstractComputerCraftAPI;
 import dan200.computercraft.shared.CommonHooks;
 import dan200.computercraft.shared.computer.metrics.GlobalMetrics;
-import dan200.computercraft.shared.config.Config;
+import dan200.computercraft.shared.config.ConfigSpec;
 import dan200.computercraft.shared.peripheral.modem.wireless.WirelessNetwork;
 import dan200.computercraft.shared.util.IDAssigner;
 import net.minecraft.SharedConstants;
@@ -69,7 +69,7 @@ public final class ServerContext {
         mainThread = new MainThread();
         context = new ComputerContext(
             new Environment(server),
-            new ComputerThread(Config.computerThreads),
+            new ComputerThread(ConfigSpec.computerThreads.get()),
             mainThread, luaMachine
         );
         idAssigner = new IDAssigner(storageDir.resolve("ids.json"));

--- a/projects/common/src/main/java/dan200/computercraft/shared/config/Config.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/config/Config.java
@@ -17,8 +17,6 @@ public final class Config {
     public static int floppySpaceLimit = 125 * 1000;
     public static boolean commandRequireCreative = true;
 
-    public static int computerThreads = 1;
-
     public static boolean enableCommandBlock = false;
     public static int modemRange = 64;
     public static int modemHighAltitudeRange = 384;

--- a/projects/common/src/main/java/dan200/computercraft/shared/config/ConfigSpec.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/config/ConfigSpec.java
@@ -142,7 +142,7 @@ public final class ConfigSpec {
                     computers can run at once, but may induce lag. Please note that some mods may
                     not work with a thread count higher than 1. Use with caution.""")
                 .worldRestart()
-                .defineInRange("computer_threads", Config.computerThreads, 1, Integer.MAX_VALUE);
+                .defineInRange("computer_threads", 1, 1, Integer.MAX_VALUE);
 
             maxMainGlobalTime = builder
                 .comment("""
@@ -342,11 +342,9 @@ public final class ConfigSpec {
         CoreConfig.maximumFilesOpen = maximumFilesOpen.get();
         CoreConfig.disableLua51Features = disableLua51Features.get();
         CoreConfig.defaultComputerSettings = defaultComputerSettings.get();
-        Config.computerThreads = computerThreads.get();
         Config.commandRequireCreative = commandRequireCreative.get();
 
         // Execution
-        Config.computerThreads = computerThreads.get();
         CoreConfig.maxMainGlobalTime = TimeUnit.MILLISECONDS.toNanos(maxMainGlobalTime.get());
         CoreConfig.maxMainComputerTime = TimeUnit.MILLISECONDS.toNanos(maxMainComputerTime.get());
 

--- a/projects/fabric/src/main/java/dan200/computercraft/shared/ComputerCraft.java
+++ b/projects/fabric/src/main/java/dan200/computercraft/shared/ComputerCraft.java
@@ -23,6 +23,8 @@ import dan200.computercraft.shared.peripheral.modem.wired.WiredModemFullBlockEnt
 import dan200.computercraft.shared.peripheral.modem.wireless.WirelessModemBlockEntity;
 import dan200.computercraft.shared.platform.NetworkHandler;
 import dan200.computercraft.shared.platform.PlatformHelper;
+import fuzs.forgeconfigapiport.api.config.v2.ForgeConfigRegistry;
+import fuzs.forgeconfigapiport.api.config.v2.ModConfigEvents;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
@@ -39,8 +41,6 @@ import net.minecraft.server.packs.resources.PreparableReloadListener;
 import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraft.util.profiling.ProfilerFiller;
 import net.minecraft.world.level.block.entity.BlockEntityType;
-import net.minecraftforge.api.ModLoadingContext;
-import net.minecraftforge.api.fml.event.config.ModConfigEvents;
 import net.minecraftforge.fml.config.ModConfig;
 
 import java.util.concurrent.CompletableFuture;
@@ -99,8 +99,8 @@ public class ComputerCraft {
         CommonHooks.onDatapackReload((name, listener) -> ResourceManagerHelper.get(PackType.SERVER_DATA).registerReloadListener(new ReloadListener(name, listener)));
 
         // Config loading
-        ModLoadingContext.registerConfig(ComputerCraftAPI.MOD_ID, ModConfig.Type.SERVER, ConfigSpec.serverSpec);
-        ModLoadingContext.registerConfig(ComputerCraftAPI.MOD_ID, ModConfig.Type.CLIENT, ConfigSpec.clientSpec);
+        ForgeConfigRegistry.INSTANCE.register(ComputerCraftAPI.MOD_ID, ModConfig.Type.SERVER, ConfigSpec.serverSpec);
+        ForgeConfigRegistry.INSTANCE.register(ComputerCraftAPI.MOD_ID, ModConfig.Type.CLIENT, ConfigSpec.clientSpec);
         ModConfigEvents.loading(ComputerCraftAPI.MOD_ID).register(ConfigSpec::sync);
         ModConfigEvents.reloading(ComputerCraftAPI.MOD_ID).register(ConfigSpec::sync);
 


### PR DESCRIPTION
This gives us slightly better guarantees that the config has actually been loaded.

Marking as draft until https://github.com/Fuzss/forgeconfigapiport/pull/34 has been merged - currently this will fail on Fabric.
