### PR TITLE
Update event docs

### DIFF
--- a/doc/events/computer_command.md
+++ b/doc/events/computer_command.md
@@ -6,7 +6,7 @@ The @{computer_command} event is fired when the `/computercraft queue` command i
 
 ## Return Values
 1. @{string}: The event name.
-<br>... @{string}: The arguments passed to the command.
+2. @{string}<abbr title="Variable number of arguments">&hellip;</abbr>: The arguments passed to the command.
 
 ## Example
 Prints the contents of messages sent:

--- a/doc/events/computer_command.md
+++ b/doc/events/computer_command.md
@@ -6,7 +6,7 @@ The @{computer_command} event is fired when the `/computercraft queue` command i
 
 ## Return Values
 1. @{string}: The event name.
-... @{string}: The arguments passed to the command.
+<br>... @{string}: The arguments passed to the command.
 
 ## Example
 Prints the contents of messages sent:

--- a/doc/events/redstone.md
+++ b/doc/events/redstone.md
@@ -4,6 +4,9 @@ module: [kind=event] redstone
 
 The @{event!redstone} event is fired whenever any redstone inputs on the computer change.
 
+## Return values
+1. @{string}: The event name.
+
 ## Example
 Prints a message when a redstone input changes:
 ```lua

--- a/doc/events/task_complete.md
+++ b/doc/events/task_complete.md
@@ -10,7 +10,7 @@ The @{task_complete} event is fired when an asynchronous task completes. This is
 2. @{number}: The ID of the task that completed.
 3. @{boolean}: Whether the command succeeded.
 4. @{string}: If the command failed, an error message explaining the failure. (This is not present if the command succeeded.)
-...: Any parameters returned from the command.
+5. <abbr title="Variable number of arguments">&hellip;</abbr>: Any parameters returned from the command.
 
 ## Example
 Prints the results of an asynchronous command:

--- a/doc/events/term_resize.md
+++ b/doc/events/term_resize.md
@@ -9,6 +9,9 @@ The @{term_resize} event is fired when the main terminal is resized. For instanc
 When this event fires, some parts of the terminal may have been moved or deleted. Simple terminal programs (those
 not using @{term.setCursorPos}) can ignore this event, but more complex GUI programs should redraw the entire screen.
 
+## Return values
+1. @{string}: The event name.
+
 ## Example
 Prints :
 ```lua

--- a/doc/events/terminate.md
+++ b/doc/events/terminate.md
@@ -8,6 +8,9 @@ This event is normally handled by @{os.pullEvent}, and will not be returned. How
 
 @{terminate} will be sent even when a filter is provided to @{os.pullEventRaw}. When using @{os.pullEventRaw} with a filter, make sure to check that the event is not @{terminate}.
 
+## Return values
+1. @{string}: The event name.
+
 ## Example
 Prints a message when Ctrl-T is held:
 ```lua

--- a/doc/events/turtle_inventory.md
+++ b/doc/events/turtle_inventory.md
@@ -4,6 +4,9 @@ module: [kind=event] turtle_inventory
 
 The @{turtle_inventory} event is fired when a turtle's inventory is changed.
 
+## Return values
+1. @{string}: The event name.
+
 ## Example
 Prints a message when the inventory is changed:
 ```lua


### PR DESCRIPTION
Add "return values" for those events that only return their name. Add break in return values for `computer_command` event.