### PR TITLE
Cauldrons and Bucket / Bottle interaction (and levers/buttons....)

### DIFF
--- a/projects/common/src/main/java/dan200/computercraft/shared/turtle/apis/TurtleAPI.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/turtle/apis/TurtleAPI.java
@@ -212,8 +212,8 @@ public class TurtleAPI implements ILuaAPI {
      * Place a block or item into the world in front of the turtle.
      * <p>
      * "Placing" an item allows it to interact with blocks and entities in front of the turtle. For instance, buckets
-     * can pick up and place down fluids, and wheat can be used to breed cows. However, you cannot use {@link #place} to
-     * perform arbitrary block interactions, such as clicking buttons or flipping levers.
+     * can pick up and place down fluids, and wheat can be used to breed cows. You can use {@link #place} to
+     * perform arbitrary block interactions (such as clicking buttons or flipping levers) if the turtle is holding a bucket or bottle.
      *
      * @param args Arguments to place.
      * @return The turtle command result.


### PR DESCRIPTION
First time messing around in a mod, so feedback welcome! 

This attempts to use the selected item on the hit block on `place`.  (Only attempts if the block is right beside/above/below to not interfere with actually placing blocks)

This enables:  
- turtles to fill/empty their buckets/bottles at cauldrons. (My main purpose)
- It also has the side effect of enabling turtles to interact with adjacent lever/buttons.
- You can also collect honey from bee hives with bottles, and shear honeycombs with shears (though they drop as items and don't directly go into the turtle's inventory)

Consequently changed behaviors:  
- If a chest is right beside a turtle, and you `place` a water bucket on it, nothing happens. (Previously it would waterlog the chest.)  But, you can still waterlog chests by calling `place` when the chest is not immediately beside the turtle.

Feedback:  
- Maybe there is something already existing to replace `areAdjacent`?
  - Or a better name? o.o;;
- Can anyone think of any other unintended side effects?

---
Tests

`./gradlew check` No new tests fail.  (These 2 failed before I made any changes, so I don't think it was me)

```
> Task :core:test

ComputerTestDelegate > get() > The os library > os.date > produces output consistent with PUC Lua > dan200.computercraft.core.ComputerTestDelegate.get()[73][1][1][26] FAILED
    org.opentest4j.AssertionFailedError at ComputerTestDelegate.java:420

ComputerTestDelegate > get() > The os library > os.date > produces output consistent with PUC Lua > dan200.computercraft.core.ComputerTestDelegate.get()[73][1][1][30] FAILED
    org.opentest4j.AssertionFailedError at ComputerTestDelegate.java:420
```