### PR TITLE
Add `id` to the GPS response packet

### DIFF
--- a/projects/core/src/main/resources/data/computercraft/lua/rom/programs/gps.lua
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/programs/gps.lua
@@ -75,7 +75,7 @@ elseif sCommand == "host" then
             local sSide, sChannel, sReplyChannel, sMessage, nDistance = p1, p2, p3, p4, p5
             if sSide == sModemSide and sChannel == gps.CHANNEL_GPS and sMessage == "PING" and nDistance then
                 -- We received a ping message on the GPS channel, send a response
-                modem.transmit(sReplyChannel, gps.CHANNEL_GPS, { x, y, z, id=os.getComputerId() })
+                modem.transmit(sReplyChannel, gps.CHANNEL_GPS, { x, y, z, id=os.getComputerID() })
 
                 -- Print the number of requests handled
                 nServed = nServed + 1

--- a/projects/core/src/main/resources/data/computercraft/lua/rom/programs/gps.lua
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/programs/gps.lua
@@ -75,7 +75,7 @@ elseif sCommand == "host" then
             local sSide, sChannel, sReplyChannel, sMessage, nDistance = p1, p2, p3, p4, p5
             if sSide == sModemSide and sChannel == gps.CHANNEL_GPS and sMessage == "PING" and nDistance then
                 -- We received a ping message on the GPS channel, send a response
-                modem.transmit(sReplyChannel, gps.CHANNEL_GPS, { x, y, z })
+                modem.transmit(sReplyChannel, gps.CHANNEL_GPS, { x, y, z, id=os.getComputerId() })
 
                 -- Print the number of requests handled
                 nServed = nServed + 1


### PR DESCRIPTION
This adds an `id` field to the GPS response packet.
This idea came from some discussion in [SwitchCraft chat](https://i.skystuff.games/P0ht1gYBJdtN.png) about figuring out what dimension a player is in.
This can be used to check against a list of GPS hosts that are known to be in a certain dimension, like:
```lua
local hosts = {
  [1] = "minecraft:overworld",
  [2] = "minecraft:nether",
  [3] = "minecraft:end",
}```
Then a program could just pull the `modem_message` event itself and check the `id` parameter against the list of hosts.