### PR TITLE
Small update to help newbies a bit.

### DIFF
--- a/projects/core/src/main/resources/data/computercraft/lua/rom/modules/main/cc/internal/syntax/errors.lua
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/modules/main/cc/internal/syntax/errors.lua
@@ -528,7 +528,7 @@ function errors.unclosed_brackets(open_start, open_end, token, start_pos, end_po
 
     -- TODO: Do we want to be smarter here with where we report the error?
     return {
-        "Unexpected " .. token_names[token] .. ". Are you missing a closing bracket?",
+        "Unexpected " .. token_names[token] .. ". Are you missing a comma or a closing bracket?",
         annotate(open_start, open_end, "Brackets were opened here."),
         annotate(start_pos, end_pos, "Unexpected " .. token_names[token] .. " here."),
 


### PR DESCRIPTION
A common error with tables is that you miss a comma whilst defining them. For those who know Lua, searching for missing commas on a "missing closing bracket" error is just a "standard procedure." However, for those who are new to Lua, they'll see the error and likely take it at face-value, looking instead for some spot they may have missed a closing bracket.

![Reasoning: a table missing a comma outputting an error stating it is missing a closing bracket.](https://media.discordapp.net/attachments/872883444970033243/1076191867512819802/SmartSelect_20230217_102205_Discord.jpg)

# Quick notice
I don't know if this module has any tests or if this will affect anything else negatively. I just had the idea today when looking at an error someone got on the CC:Aide bot and decided to quickly throw in a PR from my phone while at work.

## A quick checklist
 - If there's a existing issue, please link to it. If not, provide fill out the same information you would in a normal issue - reproduction steps for bugs, rationale for use-case.
 - If you're working on CraftOS, try to write a few test cases so we can ensure everything continues to work in the future. Tests live in `src/test/resources/test-rom/spec` and can be run with `./gradlew check`.
