### PR TITLE
Fix introduction dates of os.cancel[Alarm|Timer]

### DIFF
--- a/projects/core/src/main/java/dan200/computercraft/core/apis/OSAPI.java
+++ b/projects/core/src/main/java/dan200/computercraft/core/apis/OSAPI.java
@@ -167,6 +167,7 @@ public class OSAPI implements ILuaAPI {
      *
      * @param token The ID of the timer to cancel.
      * @see #startTimer To start a timer.
+     * @cc.since 1.6
      */
     @LuaFunction
     public final void cancelTimer(int token) {
@@ -201,7 +202,7 @@ public class OSAPI implements ILuaAPI {
      * alarm from firing.
      *
      * @param token The ID of the alarm to cancel.
-     * @cc.since 1.2
+     * @cc.since 1.6
      * @see #setAlarm To set an alarm.
      */
     @LuaFunction


### PR DESCRIPTION
This PR updates the `os.cancelAlarm` and `os.cancelTimer` documentation to note that both functions were introduced in CC 1.6. This information was not mentioned in the changelog for 1.6, and as such was missed in the initial pass of `@since` additions.
