### PR TITLE
Add certificate workaround for Let's Encrypt on 1.16

### DIFF
--- a/src/main/java/dan200/computercraft/core/apis/http/NetworkUtils.java
+++ b/src/main/java/dan200/computercraft/core/apis/http/NetworkUtils.java
@@ -24,12 +24,17 @@ import io.netty.handler.traffic.AbstractTrafficShapingHandler;
 import io.netty.handler.traffic.GlobalTrafficShapingHandler;
 
 import javax.annotation.Nonnull;
-import javax.net.ssl.SSLException;
-import javax.net.ssl.SSLHandshakeException;
-import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.*;
+import java.io.ByteArrayInputStream;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.security.KeyStore;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.KeyStoreException;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
@@ -68,6 +73,38 @@ public final class NetworkUtils
     private static SslContext sslContext;
     private static boolean triedSslContext = false;
 
+    private static final String letsEncryptRootCert = "-----BEGIN CERTIFICATE-----\n" +
+        "MIIFazCCA1OgAwIBAgIRAIIQz7DSQONZRGPgu2OCiwAwDQYJKoZIhvcNAQELBQAw\n" +
+        "TzELMAkGA1UEBhMCVVMxKTAnBgNVBAoTIEludGVybmV0IFNlY3VyaXR5IFJlc2Vh\n" +
+        "cmNoIEdyb3VwMRUwEwYDVQQDEwxJU1JHIFJvb3QgWDEwHhcNMTUwNjA0MTEwNDM4\n" +
+        "WhcNMzUwNjA0MTEwNDM4WjBPMQswCQYDVQQGEwJVUzEpMCcGA1UEChMgSW50ZXJu\n" +
+        "ZXQgU2VjdXJpdHkgUmVzZWFyY2ggR3JvdXAxFTATBgNVBAMTDElTUkcgUm9vdCBY\n" +
+        "MTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAK3oJHP0FDfzm54rVygc\n" +
+        "h77ct984kIxuPOZXoHj3dcKi/vVqbvYATyjb3miGbESTtrFj/RQSa78f0uoxmyF+\n" +
+        "0TM8ukj13Xnfs7j/EvEhmkvBioZxaUpmZmyPfjxwv60pIgbz5MDmgK7iS4+3mX6U\n" +
+        "A5/TR5d8mUgjU+g4rk8Kb4Mu0UlXjIB0ttov0DiNewNwIRt18jA8+o+u3dpjq+sW\n" +
+        "T8KOEUt+zwvo/7V3LvSye0rgTBIlDHCNAymg4VMk7BPZ7hm/ELNKjD+Jo2FR3qyH\n" +
+        "B5T0Y3HsLuJvW5iB4YlcNHlsdu87kGJ55tukmi8mxdAQ4Q7e2RCOFvu396j3x+UC\n" +
+        "B5iPNgiV5+I3lg02dZ77DnKxHZu8A/lJBdiB3QW0KtZB6awBdpUKD9jf1b0SHzUv\n" +
+        "KBds0pjBqAlkd25HN7rOrFleaJ1/ctaJxQZBKT5ZPt0m9STJEadao0xAH0ahmbWn\n" +
+        "OlFuhjuefXKnEgV4We0+UXgVCwOPjdAvBbI+e0ocS3MFEvzG6uBQE3xDk3SzynTn\n" +
+        "jh8BCNAw1FtxNrQHusEwMFxIt4I7mKZ9YIqioymCzLq9gwQbooMDQaHWBfEbwrbw\n" +
+        "qHyGO0aoSCqI3Haadr8faqU9GY/rOPNk3sgrDQoo//fb4hVC1CLQJ13hef4Y53CI\n" +
+        "rU7m2Ys6xt0nUW7/vGT1M0NPAgMBAAGjQjBAMA4GA1UdDwEB/wQEAwIBBjAPBgNV\n" +
+        "HRMBAf8EBTADAQH/MB0GA1UdDgQWBBR5tFnme7bl5AFzgAiIyBpY9umbbjANBgkq\n" +
+        "hkiG9w0BAQsFAAOCAgEAVR9YqbyyqFDQDLHYGmkgJykIrGF1XIpu+ILlaS/V9lZL\n" +
+        "ubhzEFnTIZd+50xx+7LSYK05qAvqFyFWhfFQDlnrzuBZ6brJFe+GnY+EgPbk6ZGQ\n" +
+        "3BebYhtF8GaV0nxvwuo77x/Py9auJ/GpsMiu/X1+mvoiBOv/2X/qkSsisRcOj/KK\n" +
+        "NFtY2PwByVS5uCbMiogziUwthDyC3+6WVwW6LLv3xLfHTjuCvjHIInNzktHCgKQ5\n" +
+        "ORAzI4JMPJ+GslWYHb4phowim57iaztXOoJwTdwJx4nLCgdNbOhdjsnvzqvHu7Ur\n" +
+        "TkXWStAmzOVyyghqpZXjFaH3pO3JLF+l+/+sKAIuvtd7u+Nxe5AW0wdeRlN8NwdC\n" +
+        "jNPElpzVmbUq4JUagEiuTDkHzsxHpFKVK7q4+63SM1N95R1NbdWhscdCb+ZAJzVc\n" +
+        "oyi3B43njTOQ5yOf+1CceWxG1bQVs5ZufpsMljq4Ui0/1lvh+wjChP4kqKOJ2qxq\n" +
+        "4RgqsahDYVvTH9w7jXbyLeiNdd8XM2w9U/t7y0Ff/9yi0GE44Za4rF2LN9d11TPA\n" +
+        "mRGunUHBcnWEvgJBQl9nJEiU0Zsnvgc/ubhPgXRR4Xq37Z0j4r7g1SgEEzwxA57d\n" +
+        "emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=\n" +
+        "-----END CERTIFICATE-----\n";
+
     private static TrustManagerFactory getTrustManager()
     {
         if( trustManager != null ) return trustManager;
@@ -78,7 +115,28 @@ public final class NetworkUtils
             TrustManagerFactory tmf = null;
             try
             {
-                tmf = TrustManagerFactory.getInstance( TrustManagerFactory.getDefaultAlgorithm() );
+                Certificate ca = CertificateFactory.getInstance( "X.509" )
+                    .generateCertificate( new ByteArrayInputStream( letsEncryptRootCert.getBytes() ) );
+
+                KeyStore ks = KeyStore.getInstance( KeyStore.getDefaultType() );
+                ks.load( null, null );
+                ks.setCertificateEntry( Integer.toString( 1 ), ca );
+
+                TrustManagerFactory additional = TrustManagerFactory.getInstance( TrustManagerFactory.getDefaultAlgorithm() );
+                additional.init( ks );
+
+                // Get hold of the extension trust manager
+                X509TrustManager x509tm = null;
+                for ( TrustManager tm : additional.getTrustManagers() )
+                {
+                    if ( tm instanceof X509TrustManager )
+                    {
+                        x509tm = (X509TrustManager) tm;
+                        break;
+                    }
+                }
+
+                tmf = new MergedTrustManagerFactory( TrustManagerFactory.getInstance( TrustManagerFactory.getDefaultAlgorithm() ), x509tm );
                 tmf.init( (KeyStore) null );
             }
             catch( Exception e )
@@ -208,6 +266,88 @@ public final class NetworkUtils
         else
         {
             return "Could not connect";
+        }
+    }
+
+    private static class MergedX509TrustManager implements X509TrustManager
+    {
+        private final X509TrustManager base, additional;
+
+        MergedX509TrustManager( X509TrustManager b, X509TrustManager a )
+        {
+            this.base = b;
+            this.additional = a;
+        }
+
+        @Override
+        public X509Certificate[] getAcceptedIssuers()
+        {
+            return base.getAcceptedIssuers();
+        }
+
+        @Override
+        public void checkServerTrusted( X509Certificate[] chain, String authType ) throws CertificateException
+        {
+            try
+            {
+                base.checkServerTrusted( chain, authType );
+            }
+            catch ( CertificateException e )
+            {
+                additional.checkServerTrusted( chain, authType );
+            }
+        }
+
+        @Override
+        public void checkClientTrusted( X509Certificate[] chain, String authType ) throws CertificateException
+        {
+            base.checkClientTrusted( chain, authType );
+        }
+    }
+
+    private static class MergedTrustManagerFactory extends TrustManagerFactory
+    {
+        private static class Spi extends TrustManagerFactorySpi
+        {
+            private final TrustManagerFactory base;
+            private final X509TrustManager additional;
+
+            Spi( TrustManagerFactory b, X509TrustManager a )
+            {
+                this.base = b;
+                this.additional = a;
+            }
+
+            @Override
+            protected void engineInit( KeyStore keyStore ) throws KeyStoreException
+            {
+                base.init( keyStore );
+            }
+
+            @Override
+            protected void engineInit( ManagerFactoryParameters managerFactoryParameters ) throws InvalidAlgorithmParameterException
+            {
+                base.init( managerFactoryParameters );
+            }
+
+            @Override
+            protected TrustManager[] engineGetTrustManagers()
+            {
+                TrustManager[] managers = base.getTrustManagers();
+                for ( int i = 0; i < managers.length; i++ )
+                {
+                    if ( managers[i] instanceof X509TrustManager )
+                    {
+                        managers[i] = new MergedX509TrustManager( (X509TrustManager) managers[i], additional );
+                    }
+                }
+                return managers;
+            }
+        }
+
+        MergedTrustManagerFactory( TrustManagerFactory b, X509TrustManager a )
+        {
+            super( new Spi( b, a ), b.getProvider(), b.getAlgorithm() );
         }
     }
 }

--- a/src/main/java/dan200/computercraft/core/apis/http/NetworkUtils.java
+++ b/src/main/java/dan200/computercraft/core/apis/http/NetworkUtils.java
@@ -26,7 +26,6 @@ import io.netty.handler.traffic.GlobalTrafficShapingHandler;
 import javax.annotation.Nonnull;
 import javax.net.ssl.*;
 import java.io.ByteArrayInputStream;
-import java.lang.System;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.security.KeyStore;


### PR DESCRIPTION
This PR adds some code to automatically insert the Let's Encrypt root CA into CC's certificate trust store on 1.16. Due to some intricacies with how Netty loads trust stores, I had to do a lot of weird class stuff, though I guess that's par for the course when it comes to Java. This should allow CC to finally be able to connect to LE websites without updating Java. I have tested this in the IDE using Java 8u51 as supplied by Minecraft, and can confirm it's able to access both non-LE and LE sites.

I understand 1.16 is effectively EoL at this point, but it would be great to slide this in before it's fully dead. I'm happy to port this to 1.12 too if you'd be willing to push a final-final update for it.

![image](https://user-images.githubusercontent.com/6236912/222025097-29f8e5b5-a4ec-4f3a-a2af-9d3fe45b1302.png)
