### PR TITLE
Fixed a typo in CableBlockEntity

### DIFF
--- a/projects/common/src/main/java/dan200/computercraft/shared/peripheral/modem/wired/CableBlockEntity.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/peripheral/modem/wired/CableBlockEntity.java
@@ -35,7 +35,7 @@ import javax.annotation.Nullable;
 import java.util.Collections;
 
 public class CableBlockEntity extends BlockEntity {
-    private static final String NBT_PERIPHERAL_ENABLED = "PeirpheralAccess";
+    private static final String NBT_PERIPHERAL_ENABLED = "PeripheralAccess";
 
     private class CableElement extends WiredModemElement {
         @Override


### PR DESCRIPTION
There was a typo in the CableBlockEntity class

Changed From:
```java
private static final String NBT_PERIPHERAL_ENABLED = "PeirpheralAccess";
```

to 

```java
private static final String NBT_PERIPHERAL_ENABLED = "PeripheralAccess";
```