### PR TITLE
fix: sort compounds in NBT lists for hashing

### DIFF
--- a/projects/common/src/main/java/dan200/computercraft/shared/util/NBTUtil.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/util/NBTUtil.java
@@ -187,6 +187,10 @@ public final class NBTUtil {
             for (var key : keys) writeTag(output, key, Nullability.assertNonNull(compound.get(key)));
 
             output.writeByte(0);
+        } else if (tag instanceof ListTag list) {
+            output.writeInt(list.size());
+            output.writeByte(list.getElementType());
+            for (var value : list) writeTag(output, "", value);
         } else {
             tag.write(output);
         }

--- a/projects/common/src/main/java/dan200/computercraft/shared/util/NBTUtil.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/util/NBTUtil.java
@@ -4,6 +4,7 @@
 
 package dan200.computercraft.shared.util;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.io.BaseEncoding;
 import dan200.computercraft.core.util.Nullability;
 import net.minecraft.nbt.*;
@@ -23,7 +24,8 @@ import java.util.Map;
 
 public final class NBTUtil {
     private static final Logger LOG = LoggerFactory.getLogger(NBTUtil.class);
-    private static final BaseEncoding ENCODING = BaseEncoding.base16().lowerCase();
+    @VisibleForTesting
+    static final BaseEncoding ENCODING = BaseEncoding.base16().lowerCase();
 
     private NBTUtil() {
     }
@@ -156,7 +158,7 @@ public final class NBTUtil {
         try {
             var digest = MessageDigest.getInstance("MD5");
             DataOutput output = new DataOutputStream(new DigestOutputStream(digest));
-            writeTag(output, "", tag);
+            writeNamedTag(output, "", tag);
             var hash = digest.digest();
             return ENCODING.encode(hash);
         } catch (NoSuchAlgorithmException | IOException e) {
@@ -175,28 +177,33 @@ public final class NBTUtil {
      * @throws IOException If the underlying stream throws.
      * @see NbtIo#write(CompoundTag, DataOutput)
      * @see CompoundTag#write(DataOutput)
+     * @see ListTag#write(DataOutput)
      */
-    private static void writeTag(DataOutput output, String name, Tag tag) throws IOException {
+    private static void writeNamedTag(DataOutput output, String name, Tag tag) throws IOException {
         output.writeByte(tag.getId());
         if (tag.getId() == 0) return;
         output.writeUTF(name);
+        writeTag(output, tag);
+    }
 
+    private static void writeTag(DataOutput output, Tag tag) throws IOException {
         if (tag instanceof CompoundTag compound) {
             var keys = compound.getAllKeys().toArray(new String[0]);
             Arrays.sort(keys);
-            for (var key : keys) writeTag(output, key, Nullability.assertNonNull(compound.get(key)));
+            for (var key : keys) writeNamedTag(output, key, Nullability.assertNonNull(compound.get(key)));
 
             output.writeByte(0);
         } else if (tag instanceof ListTag list) {
+            output.writeByte(list.isEmpty() ? 0 : list.get(0).getId());
             output.writeInt(list.size());
-            output.writeByte(list.getElementType());
-            for (var value : list) writeTag(output, "", value);
+            for (var value : list) writeTag(output, value);
         } else {
             tag.write(output);
         }
     }
 
-    private static final class DigestOutputStream extends OutputStream {
+    @VisibleForTesting
+    static final class DigestOutputStream extends OutputStream {
         private final MessageDigest digest;
 
         DigestOutputStream(MessageDigest digest) {

--- a/projects/common/src/test/java/dan200/computercraft/shared/util/NBTUtilTest.java
+++ b/projects/common/src/test/java/dan200/computercraft/shared/util/NBTUtilTest.java
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: 2022 The CC: Tweaked Developers
+//
+// SPDX-License-Identifier: MPL-2.0
+
+package dan200.computercraft.shared.util;
+
+import dan200.computercraft.test.shared.WithMinecraft;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import org.junit.jupiter.api.Test;
+
+import static dan200.computercraft.shared.util.NBTUtil.getNBTHash;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@WithMinecraft
+public class NBTUtilTest {
+    @Test
+    public void testCompoundTagSorting() {
+        var nbt1 = makeCompoundTag(false);
+        var hash1 = getNBTHash(nbt1);
+
+        var nbt2 = makeCompoundTag(true);
+        var hash2 = getNBTHash(nbt2);
+
+        assertNotNull(hash1, "NBT hash should not be null");
+        assertNotNull(hash2, "NBT hash should not be null");
+        assertEquals(hash1, hash2, "NBT hashes should be equal");
+    }
+
+    @Test
+    public void testListTagSorting() {
+        var nbt1 = new CompoundTag();
+        nbt1.put("Items", makeListTag(false));
+        var hash1 = getNBTHash(nbt1);
+
+        var nbt2 = new CompoundTag();
+        nbt2.put("Items", makeListTag(true));
+        var hash2 = getNBTHash(nbt2);
+
+        assertNotNull(hash1, "NBT hash should not be null");
+        assertNotNull(hash2, "NBT hash should not be null");
+        assertEquals(hash1, hash2, "NBT hashes should be equal");
+    }
+
+    private static CompoundTag makeCompoundTag(boolean reverse) {
+        var nbt = new CompoundTag();
+
+        if (reverse) {
+            nbt.putString("c", "c");
+            nbt.putString("b", "b");
+            nbt.putString("a", "a");
+        } else {
+            nbt.putString("a", "a");
+            nbt.putString("b", "b");
+            nbt.putString("c", "c");
+        }
+
+        return nbt;
+    }
+
+    private static ListTag makeListTag(boolean reverse) {
+        var list = new ListTag();
+
+        for (int i = 0; i < 3; i++) {
+            list.add(makeCompoundTag(reverse));
+        }
+
+        return list;
+    }
+}


### PR DESCRIPTION
A follow-up from #1196, which 14cb97cba106a4981f7990c792ad5f8b7405172b addressed by sorting keys in NBT compounds. The existing code would only traverse compounds themselves, so if it hit a list containing compounds, those compounds would not get sorted.  

We ran into this on SwitchCraft with shulker boxes. I'm still not entirely sure how these compounds are ending up being sorted differently in the first place, I'm sure they're always using ContainerHelper when saving, but as of this change at least they now produce consistent hashes. ![](https://cdn.discordapp.com/attachments/420971315294371842/1089542801072586872/image.png)