### PR TITLE
Fix typo in docs

### DIFF
--- a/projects/core/src/main/java/dan200/computercraft/core/apis/TermMethods.java
+++ b/projects/core/src/main/java/dan200/computercraft/core/apis/TermMethods.java
@@ -234,7 +234,7 @@ public abstract class TermMethods {
     }
 
     /**
-     * Writes {@code text} to the terminal with the specific foreground and background characters.
+     * Writes {@code text} to the terminal with the specific foreground and background colours.
      * <p>
      * As with {@link #write(IArguments)}, the text will be written at the current cursor location, with the cursor
      * moving to the end of the text.


### PR DESCRIPTION
foreground and background *characters* -> foreground and background *colours*