### PR TITLE
fix #1367: Add `colors.fromBlit`

### DIFF
--- a/projects/core/src/main/resources/data/computercraft/lua/rom/apis/colors.lua
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/apis/colors.lua
@@ -351,39 +351,40 @@ for i = 0, 15 do
     color_hex_lookup[2 ^ i] = string.format("%x", i)
 end
 
---- Converts the given color to a paint/blit hex character (0-9a-f).
---
--- This is equivalent to converting floor(log_2(color)) to hexadecimal.
---
--- @tparam number color The color to convert.
--- @treturn string The blit hex code of the color.
--- @usage
--- ```lua
--- colors.toBlit(colors.red)
--- -- => "c"
--- ```
--- @see colors.fromBlit
--- @since 1.94.0
+--[[- Converts the given color to a paint/blit hex character (0-9a-f).
+
+This is equivalent to converting floor(log_2(color)) to hexadecimal.
+
+@tparam number color The color to convert.
+@treturn string The blit hex code of the color.
+@usage
+```lua
+colors.toBlit(colors.red)
+-- => "c"
+```
+@see colors.fromBlit
+@since 1.94.0
+]]
 function toBlit(color)
     expect(1, color, "number")
     return color_hex_lookup[color] or
         string.format("%x", math.floor(math.log(color) / math.log(2)))
 end
 
---- Converts the given paint/blit hex character (0-9a-f) to a color.
---
--- This is equivalent to converting the hex character to a number and then 2 ^ decimal
---
--- @tparam string hex The paint/blit hex character to convert
--- @treturn number The color
--- @usage
--- ```lua
--- colors.fromBlit("e")
--- -- => 16384
--- ```
--- @see colors.toBlit
--- @since 1.105.0
+--[[- Converts the given paint/blit hex character (0-9a-f) to a color.
 
+This is equivalent to converting the hex character to a number and then 2 ^ decimal
+
+@tparam string hex The paint/blit hex character to convert
+@treturn number The color
+@usage
+```lua
+colors.fromBlit("e")
+-- => 16384
+```
+@see colors.toBlit
+@since 1.105.0
+]]
 function fromBlit(hex)
     expect(1, hex, "string")
 

--- a/projects/core/src/main/resources/data/computercraft/lua/rom/apis/colors.lua
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/apis/colors.lua
@@ -363,3 +363,20 @@ function toBlit(color)
     return color_hex_lookup[color] or
         string.format("%x", math.floor(math.log(color) / math.log(2)))
 end
+
+--- Converts the given paint/blit hex character (0-9a-f) to a color.
+--
+-- This is equivalent to converting the hex character to decimal and then 2 ^ decimal
+--
+-- @tparam string hex The paint/blit hex character to convert
+-- @treturn number The color
+
+function fromBlit(hex)
+    expect(1, hex, "string")
+
+    if hex:find("[^0-9a-f]") or hex == "" then
+        return
+    end
+
+    return math.floor(2 ^ tonumber(hex, 16))
+end

--- a/projects/core/src/main/resources/data/computercraft/lua/rom/apis/colors.lua
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/apis/colors.lua
@@ -357,6 +357,12 @@ end
 --
 -- @tparam number color The color to convert.
 -- @treturn string The blit hex code of the color.
+-- @usage
+-- ```lua
+-- colors.toBlit(colors.red)
+-- -- => "c"
+-- ```
+-- @see colors.fromBlit
 -- @since 1.94.0
 function toBlit(color)
     expect(1, color, "number")
@@ -370,6 +376,13 @@ end
 --
 -- @tparam string hex The paint/blit hex character to convert
 -- @treturn number The color
+-- @usage
+-- ```lua
+-- colors.fromBlit("e")
+-- -- => 16384
+-- ```
+-- @see colors.toBlit
+-- @since 1.105.0
 
 function fromBlit(hex)
     expect(1, hex, "string")

--- a/projects/core/src/main/resources/data/computercraft/lua/rom/apis/colors.lua
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/apis/colors.lua
@@ -372,7 +372,7 @@ end
 
 --- Converts the given paint/blit hex character (0-9a-f) to a color.
 --
--- This is equivalent to converting the hex character to decimal and then 2 ^ decimal
+-- This is equivalent to converting the hex character to a number and then 2 ^ decimal
 --
 -- @tparam string hex The paint/blit hex character to convert
 -- @treturn number The color
@@ -387,9 +387,9 @@ end
 function fromBlit(hex)
     expect(1, hex, "string")
 
-    if hex:find("[^0-9a-f]") or hex == "" then
-        return
-    end
+    if #hex ~= 1 then return nil end
+    local value = tonumber(hex, 16)
+    if not value then return nil end
 
-    return math.floor(2 ^ tonumber(hex, 16))
+    return 2 ^ value
 end

--- a/projects/core/src/test/resources/test-rom/spec/apis/colors_spec.lua
+++ b/projects/core/src/test/resources/test-rom/spec/apis/colors_spec.lua
@@ -103,7 +103,7 @@ describe("The colors library", function()
 
         it("converts all colors", function()
             for i = 0, 15 do
-                expect(colors.fromBlit(string.format("%x", i))):eq(2 ^ i)
+                expect(colors.fromBlit(colors.toBlit(2 ^ i))):eq(2 ^ i)
             end
         end)
     end)

--- a/projects/core/src/test/resources/test-rom/spec/apis/colors_spec.lua
+++ b/projects/core/src/test/resources/test-rom/spec/apis/colors_spec.lua
@@ -93,4 +93,18 @@ describe("The colors library", function()
             expect(colors.toBlit(16385)):eq("e")
         end)
     end)
+
+    describe("colors.fromBlit", function()
+        it("validates arguments", function()
+            expect.error(colors.fromBlit, nil):eq("bad argument #1 (string expected, got nil)")
+            expect(colors.fromBlit("")):eq(nil)
+            expect(colors.fromBlit("not hex")):eq(nil)
+        end)
+
+        it("converts all colors", function()
+            for i = 0, 15 do
+                expect(colors.fromBlit(string.format("%x", i))):eq(2 ^ i)
+            end
+        end)
+    end)
 end)


### PR DESCRIPTION
Issue: fixes #1367 
Adds a `fromBlit` function in the `colors` API. I've added some tests, which are passing. I have ignored the index argument, as I am unsure how I should implement it. I am also returning `nil` instead of throwing, after talking with SquidDev.