### PR TITLE
Add support for HTTP timeouts 

### DIFF
--- a/projects/common/src/main/java/dan200/computercraft/shared/config/AddressRuleConfig.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/config/AddressRuleConfig.java
@@ -32,9 +32,6 @@ class AddressRuleConfig {
         config.add("action", action.name().toLowerCase(Locale.ROOT));
 
         if (host.equals("*") && action == Action.ALLOW) {
-            config.setComment("timeout", "The period of time (in milliseconds) to wait before a HTTP request times out. Set to 0 for unlimited.");
-            config.add("timeout", AddressRule.TIMEOUT);
-
             config.setComment("max_download", """
                 The maximum size (in bytes) that a computer can download in a single request.
                 Note that responses may receive more data than allowed, but this data will not
@@ -58,7 +55,6 @@ class AddressRuleConfig {
         var port = unboxOptInt(get(builder, "port", Number.class));
         return hostObj != null && checkEnum(builder, "action", Action.class)
             && check(builder, "port", Number.class)
-            && check(builder, "timeout", Number.class)
             && check(builder, "max_upload", Number.class)
             && check(builder, "max_download", Number.class)
             && check(builder, "websocket_message", Number.class)
@@ -72,7 +68,6 @@ class AddressRuleConfig {
 
         var action = getEnum(builder, "action", Action.class).orElse(null);
         var port = unboxOptInt(get(builder, "port", Number.class));
-        var timeout = unboxOptInt(get(builder, "timeout", Number.class));
         var maxUpload = unboxOptLong(get(builder, "max_upload", Number.class).map(Number::longValue));
         var maxDownload = unboxOptLong(get(builder, "max_download", Number.class).map(Number::longValue));
         var websocketMessage = unboxOptInt(get(builder, "websocket_message", Number.class).map(Number::intValue));
@@ -81,7 +76,6 @@ class AddressRuleConfig {
             action,
             maxUpload,
             maxDownload,
-            timeout,
             websocketMessage
         );
 

--- a/projects/core/src/main/java/dan200/computercraft/core/apis/TableHelper.java
+++ b/projects/core/src/main/java/dan200/computercraft/core/apis/TableHelper.java
@@ -9,6 +9,7 @@ import dan200.computercraft.api.lua.LuaValues;
 
 import javax.annotation.Nullable;
 import java.util.Map;
+import java.util.Optional;
 
 import static dan200.computercraft.api.lua.LuaValues.getNumericType;
 
@@ -97,6 +98,15 @@ public final class TableHelper {
             return (int) ((Number) value).longValue();
         } else {
             throw badKey(key, "number", value);
+        }
+    }
+
+    public static Optional<Double> optRealField(Map<?, ?> table, String key) throws LuaException {
+        var value = table.get(key);
+        if(value == null) {
+            return Optional.empty();
+        } else {
+            return Optional.of(getRealField(table, key));
         }
     }
 

--- a/projects/core/src/main/java/dan200/computercraft/core/apis/http/options/Action.java
+++ b/projects/core/src/main/java/dan200/computercraft/core/apis/http/options/Action.java
@@ -12,7 +12,7 @@ public enum Action {
     DENY;
 
     private final PartialOptions partial = new PartialOptions(
-        this, OptionalLong.empty(), OptionalLong.empty(), OptionalInt.empty(), OptionalInt.empty()
+        this, OptionalLong.empty(), OptionalLong.empty(), OptionalInt.empty()
     );
 
     public PartialOptions toPartial() {

--- a/projects/core/src/main/java/dan200/computercraft/core/apis/http/options/AddressRule.java
+++ b/projects/core/src/main/java/dan200/computercraft/core/apis/http/options/AddressRule.java
@@ -23,7 +23,6 @@ import java.util.regex.Pattern;
 public final class AddressRule {
     public static final long MAX_DOWNLOAD = 16 * 1024 * 1024;
     public static final long MAX_UPLOAD = 4 * 1024 * 1024;
-    public static final int TIMEOUT = 30_000;
     public static final int WEBSOCKET_MESSAGE = 128 * 1024;
 
     private final AddressPredicate predicate;

--- a/projects/core/src/main/java/dan200/computercraft/core/apis/http/options/Options.java
+++ b/projects/core/src/main/java/dan200/computercraft/core/apis/http/options/Options.java
@@ -12,14 +12,12 @@ public final class Options {
     public final Action action;
     public final long maxUpload;
     public final long maxDownload;
-    public final int timeout;
     public final int websocketMessage;
 
-    Options(Action action, long maxUpload, long maxDownload, int timeout, int websocketMessage) {
+    Options(Action action, long maxUpload, long maxDownload, int websocketMessage) {
         this.action = action;
         this.maxUpload = maxUpload;
         this.maxDownload = maxDownload;
-        this.timeout = timeout;
         this.websocketMessage = websocketMessage;
     }
 }

--- a/projects/core/src/main/java/dan200/computercraft/core/apis/http/options/PartialOptions.java
+++ b/projects/core/src/main/java/dan200/computercraft/core/apis/http/options/PartialOptions.java
@@ -13,23 +13,21 @@ import java.util.OptionalLong;
 @Immutable
 public final class PartialOptions {
     public static final PartialOptions DEFAULT = new PartialOptions(
-        null, OptionalLong.empty(), OptionalLong.empty(), OptionalInt.empty(), OptionalInt.empty()
+        null, OptionalLong.empty(), OptionalLong.empty(), OptionalInt.empty()
     );
 
     private final @Nullable Action action;
     private final OptionalLong maxUpload;
     private final OptionalLong maxDownload;
-    private final OptionalInt timeout;
     private final OptionalInt websocketMessage;
 
     @SuppressWarnings("Immutable") // Lazily initialised, so this mutation is invisible in the public API
     private @Nullable Options options;
 
-    public PartialOptions(@Nullable Action action, OptionalLong maxUpload, OptionalLong maxDownload, OptionalInt timeout, OptionalInt websocketMessage) {
+    public PartialOptions(@Nullable Action action, OptionalLong maxUpload, OptionalLong maxDownload, OptionalInt websocketMessage) {
         this.action = action;
         this.maxUpload = maxUpload;
         this.maxDownload = maxDownload;
-        this.timeout = timeout;
         this.websocketMessage = websocketMessage;
     }
 
@@ -40,7 +38,6 @@ public final class PartialOptions {
             action == null ? Action.DENY : action,
             maxUpload.orElse(AddressRule.MAX_UPLOAD),
             maxDownload.orElse(AddressRule.MAX_DOWNLOAD),
-            timeout.orElse(AddressRule.TIMEOUT),
             websocketMessage.orElse(AddressRule.WEBSOCKET_MESSAGE)
         );
     }
@@ -59,7 +56,6 @@ public final class PartialOptions {
             action == null && other.action != null ? other.action : action,
             maxUpload.isPresent() ? maxUpload : other.maxUpload,
             maxDownload.isPresent() ? maxDownload : other.maxDownload,
-            timeout.isPresent() ? timeout : other.timeout,
             websocketMessage.isPresent() ? websocketMessage : other.websocketMessage
         );
     }

--- a/projects/core/src/main/java/dan200/computercraft/core/apis/http/request/HttpRequest.java
+++ b/projects/core/src/main/java/dan200/computercraft/core/apis/http/request/HttpRequest.java
@@ -52,12 +52,13 @@ public class HttpRequest extends Resource<HttpRequest> {
     private final ByteBuf postBuffer;
     private final HttpHeaders headers;
     private final boolean binary;
+    private final int timeout;
 
     final AtomicInteger redirects;
 
     public HttpRequest(
         ResourceGroup<HttpRequest> limiter, IAPIEnvironment environment, String address, @Nullable String postText,
-        HttpHeaders headers, boolean binary, boolean followRedirects
+        HttpHeaders headers, boolean binary, boolean followRedirects, int timeout
     ) {
         super(limiter);
         this.environment = environment;
@@ -68,6 +69,7 @@ public class HttpRequest extends Resource<HttpRequest> {
         this.headers = headers;
         this.binary = binary;
         redirects = new AtomicInteger(followRedirects ? MAX_REDIRECTS : 0);
+        this.timeout = timeout;
 
         if (postText != null) {
             if (!headers.contains(HttpHeaderNames.CONTENT_TYPE)) {
@@ -143,20 +145,10 @@ public class HttpRequest extends Resource<HttpRequest> {
                 .handler(new ChannelInitializer<SocketChannel>() {
                     @Override
                     protected void initChannel(SocketChannel ch) {
-
-                        if (options.timeout > 0) {
-                            ch.config().setConnectTimeoutMillis(options.timeout);
-                        }
+                        NetworkUtils.initChannel(ch, uri, socketAddress, sslContext, timeout);
 
                         var p = ch.pipeline();
-                        p.addLast(NetworkUtils.SHAPING_HANDLER);
-                        if (sslContext != null) {
-                            p.addLast(sslContext.newHandler(ch.alloc(), uri.getHost(), socketAddress.getPort()));
-                        }
-
-                        if (options.timeout > 0) {
-                            p.addLast(new ReadTimeoutHandler(options.timeout, TimeUnit.MILLISECONDS));
-                        }
+                        if (timeout > 0) p.addLast(new ReadTimeoutHandler(timeout, TimeUnit.MILLISECONDS));
 
                         p.addLast(
                             new HttpClientCodec(),

--- a/projects/core/src/main/java/dan200/computercraft/core/apis/http/websocket/Websocket.java
+++ b/projects/core/src/main/java/dan200/computercraft/core/apis/http/websocket/Websocket.java
@@ -23,7 +23,7 @@ import io.netty.handler.codec.http.HttpClientCodec;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpObjectAggregator;
-import io.netty.handler.codec.http.websocketx.WebSocketClientHandshaker;
+import io.netty.handler.codec.http.websocketx.WebSocketClientProtocolHandler;
 import io.netty.handler.codec.http.websocketx.WebSocketVersion;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -130,7 +130,7 @@ public class Websocket extends Resource<Websocket> {
                         NetworkUtils.initChannel(ch, uri, socketAddress, sslContext, timeout);
 
                         var subprotocol = headers.get(HttpHeaderNames.SEC_WEBSOCKET_PROTOCOL);
-                        WebSocketClientHandshaker handshaker = new NoOriginWebSocketHandshaker(
+                        var handshaker = new NoOriginWebSocketHandshaker(
                             uri, WebSocketVersion.V13, subprotocol, true, headers,
                             options.websocketMessage <= 0 ? MAX_MESSAGE_SIZE : options.websocketMessage
                         );
@@ -140,7 +140,8 @@ public class Websocket extends Resource<Websocket> {
                             new HttpClientCodec(),
                             new HttpObjectAggregator(8192),
                             WebsocketCompressionHandler.INSTANCE,
-                            new WebsocketHandler(Websocket.this, handshaker, options)
+                            new WebSocketClientProtocolHandler(handshaker, false, timeout),
+                            new WebsocketHandler(Websocket.this, options)
                         );
                     }
                 })

--- a/projects/core/src/test/kotlin/http/TestHttpApi.kt
+++ b/projects/core/src/test/kotlin/http/TestHttpApi.kt
@@ -4,6 +4,7 @@
 
 package http
 
+import dan200.computercraft.api.lua.ObjectArguments
 import dan200.computercraft.core.CoreConfig
 import dan200.computercraft.core.apis.HTTPAPI
 import dan200.computercraft.core.apis.http.options.Action
@@ -45,7 +46,7 @@ class TestHttpApi {
         LuaTaskRunner.runTest {
             val httpApi = addApi(HTTPAPI(environment))
 
-            val result = httpApi.websocket(WS_ADDRESS, Optional.empty())
+            val result = httpApi.websocket(ObjectArguments(WS_ADDRESS))
             assertArrayEquals(arrayOf(true), result, "Should have created websocket")
 
             val event = pullEvent()


### PR DESCRIPTION
Closes #1280.

I'm not thrilled about this - ideally we'd have a connection-wide timeout for HTTP requests, rather than just doing a read+connect timeout, but it's a good first iteration at least.