### PR TITLE
Creating FabricComputeCraftAPI with turtle/pocket upgrade serializer registration methods

### DIFF
--- a/projects/fabric-api/src/main/java/dan200/computercraft/api/FabricComputerCraftAPI.java
+++ b/projects/fabric-api/src/main/java/dan200/computercraft/api/FabricComputerCraftAPI.java
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2022 The CC: Tweaked Developers
+//
+// SPDX-License-Identifier: MPL-2.0
+
+package dan200.computercraft.api;
+
+import dan200.computercraft.api.pocket.IPocketUpgrade;
+import dan200.computercraft.api.pocket.PocketUpgradeSerialiser;
+import dan200.computercraft.api.turtle.ITurtleUpgrade;
+import dan200.computercraft.api.turtle.TurtleUpgradeSerialiser;
+import dan200.computercraft.impl.ComputerCraftAPIFabricService;
+import net.minecraft.resources.ResourceLocation;
+
+/**
+ * The fabric-specific entrypoint for ComputerCraft's API.
+ */
+public final class FabricComputerCraftAPI {
+    private static ComputerCraftAPIFabricService getInstance() {
+        return ComputerCraftAPIFabricService.get();
+    }
+
+    /**
+     * Registers a turtle upgrade serializer.
+     *
+     * @param key Turtle upgrade serializer ID.
+     * @param serializer Turtle upgrade serializer for registration
+     * @see ITurtleUpgrade
+     * @see TurtleUpgradeSerialiser
+     */
+    public <T extends ITurtleUpgrade> TurtleUpgradeSerialiser<T> registerTurtleSerializer(ResourceLocation key, TurtleUpgradeSerialiser<T> serializer) {
+        return getInstance().registerTurtleSerializer(key, serializer);
+    }
+    /**
+     * Registers a pocket upgrade serializer.
+     *
+     * @param key Pocket upgrade serializer ID.
+     * @param serializer Pocket upgrade serializer for registration
+     * @see IPocketUpgrade
+     * @see PocketUpgradeSerialiser
+     */
+    public <T extends IPocketUpgrade> PocketUpgradeSerialiser<T> registerPocketSerializer(ResourceLocation key, PocketUpgradeSerialiser<T> serializer){
+        return getInstance().registerPocketSerializer(key, serializer);
+    }
+}

--- a/projects/fabric-api/src/main/java/dan200/computercraft/api/FabricComputerCraftAPI.java
+++ b/projects/fabric-api/src/main/java/dan200/computercraft/api/FabricComputerCraftAPI.java
@@ -24,8 +24,10 @@ public final class FabricComputerCraftAPI {
      *
      * @param key Turtle upgrade serializer ID.
      * @param serializer Turtle upgrade serializer for registration
+     * @param <T> Turtle upgrade type for registration
      * @see ITurtleUpgrade
      * @see TurtleUpgradeSerialiser
+     * @return registered turtle upgrade serializer
      */
     public <T extends ITurtleUpgrade> TurtleUpgradeSerialiser<T> registerTurtleSerializer(ResourceLocation key, TurtleUpgradeSerialiser<T> serializer) {
         return getInstance().registerTurtleSerializer(key, serializer);
@@ -35,10 +37,12 @@ public final class FabricComputerCraftAPI {
      *
      * @param key Pocket upgrade serializer ID.
      * @param serializer Pocket upgrade serializer for registration
+     * @param <T> Pocket upgrade type for registration
      * @see IPocketUpgrade
      * @see PocketUpgradeSerialiser
+     * @return registered pocket upgrade serializer
      */
-    public <T extends IPocketUpgrade> PocketUpgradeSerialiser<T> registerPocketSerializer(ResourceLocation key, PocketUpgradeSerialiser<T> serializer){
+    public <T extends IPocketUpgrade> PocketUpgradeSerialiser<T> registerPocketSerializer(ResourceLocation key, PocketUpgradeSerialiser<T> serializer) {
         return getInstance().registerPocketSerializer(key, serializer);
     }
 }

--- a/projects/fabric-api/src/main/java/dan200/computercraft/impl/ComputerCraftAPIFabricService.java
+++ b/projects/fabric-api/src/main/java/dan200/computercraft/impl/ComputerCraftAPIFabricService.java
@@ -5,8 +5,13 @@
 package dan200.computercraft.impl;
 
 import dan200.computercraft.api.detail.DetailRegistry;
+import dan200.computercraft.api.pocket.IPocketUpgrade;
+import dan200.computercraft.api.pocket.PocketUpgradeSerialiser;
+import dan200.computercraft.api.turtle.ITurtleUpgrade;
+import dan200.computercraft.api.turtle.TurtleUpgradeSerialiser;
 import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariant;
 import net.fabricmc.fabric.api.transfer.v1.storage.StorageView;
+import net.minecraft.resources.ResourceLocation;
 import org.jetbrains.annotations.ApiStatus;
 
 /**
@@ -21,4 +26,7 @@ public interface ComputerCraftAPIFabricService extends ComputerCraftAPIService {
     }
 
     DetailRegistry<StorageView<FluidVariant>> getFluidDetailRegistry();
+
+    <T extends ITurtleUpgrade> TurtleUpgradeSerialiser<T> registerTurtleSerializer(ResourceLocation key, TurtleUpgradeSerialiser<T> serializer);
+    <T extends IPocketUpgrade> PocketUpgradeSerialiser<T> registerPocketSerializer(ResourceLocation key, PocketUpgradeSerialiser<T> serializer);
 }

--- a/projects/fabric/src/main/java/dan200/computercraft/impl/ComputerCraftAPIImpl.java
+++ b/projects/fabric/src/main/java/dan200/computercraft/impl/ComputerCraftAPIImpl.java
@@ -7,11 +7,18 @@ package dan200.computercraft.impl;
 import com.google.auto.service.AutoService;
 import dan200.computercraft.api.ComputerCraftAPI;
 import dan200.computercraft.api.detail.DetailRegistry;
+import dan200.computercraft.api.pocket.IPocketUpgrade;
+import dan200.computercraft.api.pocket.PocketUpgradeSerialiser;
+import dan200.computercraft.api.turtle.ITurtleUpgrade;
+import dan200.computercraft.api.turtle.TurtleUpgradeSerialiser;
 import dan200.computercraft.impl.detail.DetailRegistryImpl;
+import dan200.computercraft.shared.ComputerCraft;
 import dan200.computercraft.shared.details.FluidDetails;
 import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariant;
 import net.fabricmc.fabric.api.transfer.v1.storage.StorageView;
 import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.core.Registry;
+import net.minecraft.resources.ResourceLocation;
 
 import javax.annotation.Nullable;
 
@@ -32,5 +39,15 @@ public final class ComputerCraftAPIImpl extends AbstractComputerCraftAPI impleme
     @Override
     public DetailRegistry<StorageView<FluidVariant>> getFluidDetailRegistry() {
         return fluidDetails;
+    }
+
+    @Override
+    public <T extends ITurtleUpgrade> TurtleUpgradeSerialiser<T> registerTurtleSerializer(ResourceLocation key, TurtleUpgradeSerialiser<T> serializer) {
+        return Registry.register(ComputerCraft.TURTLE_UPGRADE_SERIALISERS, key, serializer);
+    }
+
+    @Override
+    public <T extends IPocketUpgrade> PocketUpgradeSerialiser<T> registerPocketSerializer(ResourceLocation key, PocketUpgradeSerialiser<T> serializer) {
+        return Registry.register(ComputerCraft.POCKET_UPGRADE_SERIALISERS, key, serializer);
     }
 }

--- a/projects/fabric/src/main/java/dan200/computercraft/shared/ComputerCraft.java
+++ b/projects/fabric/src/main/java/dan200/computercraft/shared/ComputerCraft.java
@@ -34,6 +34,7 @@ import net.fabricmc.fabric.api.loot.v2.LootTableEvents;
 import net.fabricmc.fabric.api.resource.IdentifiableResourceReloadListener;
 import net.fabricmc.fabric.api.resource.ResourceManagerHelper;
 import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.packs.PackType;
 import net.minecraft.server.packs.resources.PreparableReloadListener;
@@ -47,11 +48,11 @@ import java.util.concurrent.Executor;
 
 public class ComputerCraft {
     private static final LevelResource SERVERCONFIG = new LevelResource("serverconfig");
+    public static final Registry<TurtleUpgradeSerialiser<?>> TURTLE_UPGRADE_SERIALISERS = FabricRegistryBuilder.createSimple(TurtleUpgradeSerialiser.REGISTRY_ID).buildAndRegister();
+    public static final Registry<PocketUpgradeSerialiser<?>> POCKET_UPGRADE_SERIALISERS = FabricRegistryBuilder.createSimple(PocketUpgradeSerialiser.REGISTRY_ID).buildAndRegister();
 
     public static void init() {
         NetworkHandler.init();
-        FabricRegistryBuilder.createSimple(TurtleUpgradeSerialiser.REGISTRY_ID).buildAndRegister();
-        FabricRegistryBuilder.createSimple(PocketUpgradeSerialiser.REGISTRY_ID).buildAndRegister();
         ModRegistry.register();
         ModRegistry.registerMainThread();
         ModRegistry.registerCreativeTab(FabricItemGroup.builder(new ResourceLocation(ComputerCraftAPI.MOD_ID, "tab"))).build();


### PR DESCRIPTION
So, this is continuation of #1432, specific turtle and pocket upgrade serializer API for registration, that will help get rid of postpone registration.

For now, due to postpone registration I am not able to have links to registered serializers in minecraft mod code and postpone registration a significant mess right now. 