### PR TITLE
Add toggleModem method to Turtle API

### DIFF
--- a/projects/common/src/main/java/dan200/computercraft/shared/peripheral/modem/wired/WiredModemFullBlockEntity.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/peripheral/modem/wired/WiredModemFullBlockEntity.java
@@ -141,6 +141,10 @@ public class WiredModemFullBlockEntity extends BlockEntity {
         return InteractionResult.CONSUME;
     }
 
+    public void use() {
+        togglePeripheralAccess();
+    }
+
     private static void sendPeripheralChanges(Player player, String kind, Collection<String> peripherals) {
         if (peripherals.isEmpty()) return;
 

--- a/projects/common/src/main/java/dan200/computercraft/shared/turtle/apis/TurtleAPI.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/turtle/apis/TurtleAPI.java
@@ -768,6 +768,18 @@ public class TurtleAPI implements ILuaAPI {
     }
 
 
+    /**
+     * Toggle a wired modem block in front of the turtle to allow / disallow peripheral access.
+     *
+     * @return The turtle command result.
+     * @cc.treturn boolean If a modem was toggled.
+     */
+    @LuaFunction
+    public final MethodResult toggleModem() throws LuaException {
+        return trackCommand(new TurtleToggleModemCommand(InteractDirection.FORWARD));
+    }
+
+
     private static int checkSlot(int slot) throws LuaException {
         if (slot < 1 || slot > 16) throw new LuaException("Slot number " + slot + " out of range");
         return slot - 1;

--- a/projects/common/src/main/java/dan200/computercraft/shared/turtle/core/TurtleToggleModemCommand.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/turtle/core/TurtleToggleModemCommand.java
@@ -1,0 +1,36 @@
+package dan200.computercraft.shared.turtle.core;
+
+import dan200.computercraft.api.turtle.ITurtleAccess;
+import dan200.computercraft.api.turtle.TurtleCommand;
+import dan200.computercraft.api.turtle.TurtleCommandResult;
+import dan200.computercraft.shared.peripheral.modem.wired.WiredModemFullBlockEntity;
+
+public class TurtleToggleModemCommand implements TurtleCommand {
+    private final InteractDirection direction;
+
+    public TurtleToggleModemCommand(InteractDirection direction) {
+        this.direction = direction;
+    }
+
+    @Override
+    public TurtleCommandResult execute(ITurtleAccess turtle) {
+
+        // Get world direction from direction
+        var direction = this.direction.toWorldDir(turtle);
+
+        // Get entity for modem in front
+        var world = turtle.getLevel();
+        var turtlePosition = turtle.getPosition();
+        var modemPosition = turtlePosition.relative(direction);
+        var entity = world.getBlockEntity(modemPosition);
+
+        // Use modem
+        if (entity instanceof WiredModemFullBlockEntity wiredModemEntity) {
+            wiredModemEntity.use();
+            return TurtleCommandResult.success();
+        } else {
+            return TurtleCommandResult.failure("No modem found");
+        }
+
+    }
+}


### PR DESCRIPTION
I've been wanting a way to activate wired modem blocks via turtles, and I'm hoping I've found an elegant solution.

I think it would add a lot of creative ways to automate turtle wired networks if turtles could place and use wired modem blocks without needing a player to come right-click on them. I believe this was attempted here https://github.com/cc-tweaked/CC-Tweaked/pull/510, but apparently never finished.

My first approach was to add a "toggle" method to a wrapped wired modem block peripheral, but this ran into the issue of running in the wrong thread and not being able to access level block entities. Then I tried adding a new Turtle API method "toggleModem," and this seemed to be the best option, with the smallest footprint in terms of code changes.

I'm new to modding, so I'm definitely open to any feedback on this, but I really hope some version of this functionality can be added in. Thanks!