### PR TITLE
Fixed typo in cc.image.nft docs

### DIFF
--- a/projects/core/src/main/resources/data/computercraft/lua/rom/modules/main/cc/image/nft.lua
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/modules/main/cc/image/nft.lua
@@ -2,7 +2,7 @@
 --
 -- SPDX-License-Identifier: MPL-2.0
 
---- Read and draw nbt ("Nitrogen Fingers Text") images.
+--- Read and draw nft ("Nitrogen Fingers Text") images.
 --
 -- nft ("Nitrogen Fingers Text") is a file format for drawing basic images.
 -- Unlike the images that @{paintutils.parseImage} uses, nft supports coloured


### PR DESCRIPTION
This PR fixes a tiny typo in the docs for `cc.image.nft` (which I haven't even opened until today :P).