### PR TITLE
Update lua.lua require logic.

### DIFF
--- a/projects/core/src/main/resources/data/computercraft/lua/rom/programs/lua.lua
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/programs/lua.lua
@@ -25,21 +25,13 @@ local tEnv = {
 }
 setmetatable(tEnv, { __index = _ENV })
 
--- Replace our package.path, so that it loads from the current directory, rather
--- than from /rom/programs. This makes it a little more friendly to use and
--- closer to what you'd expect.
+-- Replace our require with new instance that loads from the current directory
+-- rather than from /rom/programs. This makes it more friendly to use and closer
+-- to what you'd expect.
 do
+    local make_package = require "cc.require".make
     local dir = shell.dir()
-    if dir:sub(1, 1) ~= "/" then dir = "/" .. dir end
-    if dir:sub(-1) ~= "/" then dir = dir .. "/" end
-
-    local strip_path = "?;?.lua;?/init.lua;"
-    local path = package.path
-    if path:sub(1, #strip_path) == strip_path then
-        path = path:sub(#strip_path + 1)
-    end
-
-    package.path = dir .. "?;" .. dir .. "?.lua;" .. dir .. "?/init.lua;" .. path
+    _ENV.require, _ENV.package = make_package(_ENV, dir)
 end
 
 if term.isColour() then


### PR DESCRIPTION
This makes it more consistent with how normal require works in situations when someone requires with path starting with /.

### Problem
`lua.lua` program is executed from `/rom/programs` directory so require would incorrectly try to require files relative to there instead of user current directory (which we assume is the program directory) and lead to bad user experience.

### Current solution and issue with it
There is code that rewrites `package.path` to explicitly require files relative to user current directory. But this does mean that if someone provides it with absolute path starting with `/` it will fail to find a module and treat it as relative path while in normal program require would find said module.

### Proposed solution
Instead of modifying package.path we create new instance of require that is targeting current dir and use that. This should make it act perfectly same as if this was a program ran in current directory.

### Issue with proposed solution
I am not sure and was unable to find if requiring absolute path is something lua 5.1+ require is supposed to support or if its emergent behavior from our implementation of it.