### PR TITLE
docs: Fix turtle.refuel usage code

### DIFF
--- a/projects/common/src/main/java/dan200/computercraft/shared/turtle/apis/TurtleAPI.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/turtle/apis/TurtleAPI.java
@@ -555,7 +555,7 @@ public class TurtleAPI implements ILuaAPI {
      * @cc.usage Refuel a turtle from the currently selected slot.
      * <pre>{@code
      * local level = turtle.getFuelLevel()
-     * if new_level == "unlimited" then error("Turtle does not need fuel", 0) end
+     * if level == "unlimited" then error("Turtle does not need fuel", 0) end
      *
      * local ok, err = turtle.refuel()
      * if ok then


### PR DESCRIPTION
For usage example no. 1:
line 2 uses "new_level" before it was defined; changed to "level" instead

- the code *should* error when the fuel level is "unlimited", but never does (`nil == "unlimited"` is false)
