### PR TITLE
Add alternative API for retriving peripheral object of pocket computer

### DIFF
--- a/projects/common-api/src/main/java/dan200/computercraft/api/pocket/IPocketAccess.java
+++ b/projects/common-api/src/main/java/dan200/computercraft/api/pocket/IPocketAccess.java
@@ -99,4 +99,12 @@ public interface IPocketAccess {
      */
     @Deprecated(forRemoval = true)
     Map<ResourceLocation, IPeripheral> getUpgrades();
+
+    /**
+     * Returns the peripheral created by the upgrade of pocket computer, if there is one.
+     *
+     * @return The peripheral created by the upgrade of pocket computer, if there is one, {@code null} if none exists.
+     */
+    @Nullable
+    IPeripheral getPeripheral();
 }

--- a/projects/common/src/main/java/dan200/computercraft/shared/pocket/core/PocketServerComputer.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/pocket/core/PocketServerComputer.java
@@ -110,6 +110,12 @@ public class PocketServerComputer extends ServerComputer implements IPocketAcces
         return upgrade == null ? Collections.emptyMap() : Collections.singletonMap(upgrade.getUpgradeID(), getPeripheral(ComputerSide.BACK));
     }
 
+    @Nullable
+    @Override
+    public IPeripheral getPeripheral() {
+        return getPeripheral(ComputerSide.BACK);
+    }
+
     public @Nullable UpgradeData<IPocketUpgrade> getUpgrade() {
         return upgrade == null ? null : UpgradeData.of(upgrade, getUpgradeNBTData());
     }


### PR DESCRIPTION
Method `getUpgrades()` for Pocket Computers now deprecated and should not be used anymore, but in some cases getting peripheral object from Pocket Computer can be quite useful (in my case I need access to it to extract information about internal upgrades, that stored inside this one), so this PR adds another method to solve this issue. 