### PR TITLE
Documentation: Fix wrong function being named

### DIFF
--- a/projects/core/src/main/resources/data/computercraft/lua/rom/modules/main/cc/image/nft.lua
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/modules/main/cc/image/nft.lua
@@ -87,7 +87,7 @@ end
 
 --- Draw an nft image to the screen.
 --
--- @tparam table image An image, as returned from @{load} or @{draw}.
+-- @tparam table image An image, as returned from @{load} or @{parse}.
 -- @tparam number xPos The x position to start drawing at.
 -- @tparam number xPos The y position to start drawing at.
 -- @tparam[opt] term.Redirect target The terminal redirect to draw to. Defaults to the


### PR DESCRIPTION
Simple documentation fix where `cc.image.nft.draw` was erroneously referring to `cc.image.nft.parse` as `cc.image.nft.draw`. (`cc.image.nft.draw` does not return an image table, `cc.image.nft.parse` does.)

If I forgot something I need to do, let me know.