### PR TITLE
Remove compression from terminal/monitor packets

### DIFF
--- a/projects/common/src/test/java/dan200/computercraft/shared/computer/terminal/TerminalStateTest.java
+++ b/projects/common/src/test/java/dan200/computercraft/shared/computer/terminal/TerminalStateTest.java
@@ -18,22 +18,11 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 public class TerminalStateTest {
     @RepeatedTest(5)
-    public void testCompressed() {
+    public void testRoundTrip() {
         var terminal = randomTerminal();
 
         var buffer = new FriendlyByteBuf(Unpooled.directBuffer());
-        new TerminalState(terminal, true).write(buffer);
-
-        checkEqual(terminal, read(buffer));
-        assertEquals(0, buffer.readableBytes());
-    }
-
-    @RepeatedTest(5)
-    public void testUncompressed() {
-        var terminal = randomTerminal();
-
-        var buffer = new FriendlyByteBuf(Unpooled.directBuffer());
-        new TerminalState(terminal, false).write(buffer);
+        new TerminalState(terminal).write(buffer);
 
         checkEqual(terminal, read(buffer));
         assertEquals(0, buffer.readableBytes());


### PR DESCRIPTION
Minecraft already adds its own compression, so there's not much reason to do this. Well, I _think_ - I need to test the effects of this change on a server.