### PR TITLE
Add binary option to WebSockets

### DIFF
--- a/projects/core/src/main/java/dan200/computercraft/core/apis/HTTPAPI.java
+++ b/projects/core/src/main/java/dan200/computercraft/core/apis/HTTPAPI.java
@@ -150,16 +150,19 @@ public class HTTPAPI implements ILuaAPI {
         String address;
         Map<?, ?> headerTable;
         Optional<Double> timeoutArg;
+        boolean binary;
 
         if (args.get(0) instanceof Map) {
             var options = args.getTable(0);
             address = getStringField(options, "url");
             headerTable = optTableField(options, "headers", Collections.emptyMap());
             timeoutArg = optRealField(options, "timeout");
+            binary = optBooleanField(options, "binary", false);
         } else {
             address = args.getString(0);
             headerTable = args.optTable(1, Collections.emptyMap());
             timeoutArg = Optional.empty();
+            binary = args.optBoolean(2, false);
         }
 
         var headers = getHeaders(headerTable);
@@ -167,7 +170,7 @@ public class HTTPAPI implements ILuaAPI {
 
         try {
             var uri = WebsocketClient.parseUri(address);
-            if (!new Websocket(websockets, apiEnvironment, uri, address, headers, timeout).queue(Websocket::connect)) {
+            if (!new Websocket(websockets, apiEnvironment, uri, address, headers, timeout, binary).queue(Websocket::connect)) {
                 throw new LuaException("Too many websockets already open");
             }
 

--- a/projects/core/src/main/java/dan200/computercraft/core/apis/http/websocket/Websocket.java
+++ b/projects/core/src/main/java/dan200/computercraft/core/apis/http/websocket/Websocket.java
@@ -56,14 +56,16 @@ public class Websocket extends Resource<Websocket> implements WebsocketClient {
     private final String address;
     private final HttpHeaders headers;
     private final int timeout;
+    private final boolean binary;
 
-    public Websocket(ResourceGroup<Websocket> limiter, IAPIEnvironment environment, URI uri, String address, HttpHeaders headers, int timeout) {
+    public Websocket(ResourceGroup<Websocket> limiter, IAPIEnvironment environment, URI uri, String address, HttpHeaders headers, int timeout, boolean binary) {
         super(limiter);
         this.environment = environment;
         this.uri = uri;
         this.address = address;
         this.headers = headers;
         this.timeout = timeout;
+        this.binary = binary;
     }
 
     public void connect() {
@@ -183,5 +185,10 @@ public class Websocket extends Resource<Websocket> implements WebsocketClient {
 
         var channel = channel();
         if (channel != null) channel.writeAndFlush(new BinaryWebSocketFrame(Unpooled.wrappedBuffer(message)));
+    }
+
+    @Override
+    public boolean isBinary() {
+        return binary;
     }
 }

--- a/projects/core/src/main/java/dan200/computercraft/core/apis/http/websocket/WebsocketClient.java
+++ b/projects/core/src/main/java/dan200/computercraft/core/apis/http/websocket/WebsocketClient.java
@@ -50,6 +50,15 @@ public interface WebsocketClient extends Closeable {
     void sendBinary(ByteBuffer message);
 
     /**
+     * Determine whether the websocket sends binary messages by default.
+     * 
+     * @return Whether the websocket sends binary messages by default.
+     */
+    default boolean isBinary() {
+        return false;
+    }
+
+    /**
      * Parse an address, ensuring it is a valid websocket URI.
      *
      * @param address The address to parse.

--- a/projects/core/src/main/java/dan200/computercraft/core/apis/http/websocket/WebsocketClient.java
+++ b/projects/core/src/main/java/dan200/computercraft/core/apis/http/websocket/WebsocketClient.java
@@ -51,7 +51,7 @@ public interface WebsocketClient extends Closeable {
 
     /**
      * Determine whether the websocket sends binary messages by default.
-     * 
+     *
      * @return Whether the websocket sends binary messages by default.
      */
     default boolean isBinary() {

--- a/projects/core/src/main/java/dan200/computercraft/core/apis/http/websocket/WebsocketHandle.java
+++ b/projects/core/src/main/java/dan200/computercraft/core/apis/http/websocket/WebsocketHandle.java
@@ -90,7 +90,10 @@ public class WebsocketHandle {
                     var bytes = new byte[buf.capacity()];
                     buf.get(bytes);
                     data = new String(bytes, StandardCharsets.UTF_8);
-                } catch (UnsupportedCharsetException ignored) {}
+                } catch (UnsupportedCharsetException ignored) {
+                    // Suppress warnings.
+                    data = text;
+                }
             }
             websocket.sendText(data);
         }

--- a/projects/core/src/main/java/dan200/computercraft/core/apis/http/websocket/WebsocketHandler.java
+++ b/projects/core/src/main/java/dan200/computercraft/core/apis/http/websocket/WebsocketHandler.java
@@ -50,7 +50,7 @@ class WebsocketHandler extends SimpleChannelInboundHandler<Object> {
         }
 
         var frame = (WebSocketFrame) msg;
-        if (websocket.isBinary() || (frame instanceof BinaryWebSocketFrame)) {
+        if (websocket.isBinary() || frame instanceof BinaryWebSocketFrame) {
             var converted = NetworkUtils.toBytes(frame.content());
 
             websocket.environment().observe(Metrics.WEBSOCKET_INCOMING, converted.length);

--- a/projects/core/src/main/resources/data/computercraft/lua/rom/apis/http/http.lua
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/apis/http/http.lua
@@ -275,6 +275,7 @@ local function check_websocket_options(options, body)
     check_key(options, "url", "string")
     check_key(options, "headers", "table", true)
     check_key(options, "timeout", "number", true)
+    check_key(options, "binary", "boolean", true)
 end
 
 
@@ -299,7 +300,7 @@ these options behave.
 @see websocket_success
 @see websocket_failure
 ]]
-function websocketAsync(url, headers)
+function websocketAsync(url, headers, binary)
     local actual_url
     if type(url) == "table" then
         check_websocket_options(url)
@@ -307,10 +308,11 @@ function websocketAsync(url, headers)
     else
         expect(1, url, "string")
         expect(2, headers, "table", "nil")
+        expect(3, binary, "boolean", "nil")
         actual_url = url
     end
 
-    local ok, err = nativeWebsocket(url, headers)
+    local ok, err = nativeWebsocket(url, headers, binary)
     if not ok then
         os.queueEvent("websocket_failure", actual_url, err)
     end
@@ -355,7 +357,7 @@ from above are passed in as fields instead (for instance,
     ws.close()
 
 ]]
-function websocket(url, headers)
+function websocket(url, headers, binary)
     local actual_url
     if type(url) == "table" then
         check_websocket_options(url)
@@ -363,10 +365,11 @@ function websocket(url, headers)
     else
         expect(1, url, "string")
         expect(2, headers, "table", "nil")
+        expect(3, binary, "boolean", "nil")
         actual_url = url
     end
 
-    local ok, err = nativeWebsocket(url, headers)
+    local ok, err = nativeWebsocket(url, headers, binary)
     if not ok then return ok, err end
 
     while true do

--- a/projects/web/src/main/java/dan200/computercraft/core/apis/http/websocket/TWebsocket.java
+++ b/projects/web/src/main/java/dan200/computercraft/core/apis/http/websocket/TWebsocket.java
@@ -27,14 +27,16 @@ public class TWebsocket extends Resource<TWebsocket> implements WebsocketClient 
     private final IAPIEnvironment environment;
     private final URI uri;
     private final String address;
+    private final boolean binary;
 
     private @Nullable WebSocket websocket;
 
-    public TWebsocket(ResourceGroup<TWebsocket> limiter, IAPIEnvironment environment, URI uri, String address, HttpHeaders headers, int timeout) {
+    public TWebsocket(ResourceGroup<TWebsocket> limiter, IAPIEnvironment environment, URI uri, String address, HttpHeaders headers, int timeout, boolean binary) {
         super(limiter);
         this.environment = environment;
         this.uri = uri;
         this.address = address;
+        this.binary = binary;
     }
 
     public void connect() {
@@ -74,6 +76,11 @@ public class TWebsocket extends Resource<TWebsocket> implements WebsocketClient 
         var array = Int8Array.create(message.remaining());
         for (var i = 0; i < array.getLength(); i++) array.set(i, message.get(i));
         websocket.send(array);
+    }
+
+    @Override
+    public boolean isBinary() {
+        return binary;
     }
 
     @Override


### PR DESCRIPTION
Currently, handling of UTF-8 codes in WebSocket text messages is handled entirely on the Java side. This is understandable for most uses, but some users may want to interact with the bytes directly (e.g. with `utf8`) without Java meddling with codepoints outside CC's range.

This PR adds a binary flag to `http.websocket` that disables UTF-8 decoding of text messages on the Java side. When enabled, the binary flag of each message remains intact, but the data received will always be interpreted as binary data - no more `?`s replacing out-of-range codes. Sending text messages on a binary handle will cause Java to reinterpret the bytes as UTF-8 before sending, preserving manually-encoded codepoints. (This is an implementation detail, since `TextWebSocketFrame` takes a UTF-16 `String`, so we need to convert it from UTF-8 ourselves.) If that fails for some reason, the sender will fall back to normal bytewise strings.

The syntax for this flag matches `http.get`'s argument list, so there should be no confusion between the two lists, and no compatibility issues should arise - WebSockets still default to normal/text handles. I've added a test suite as well (which duplicates the original WS test) that ensures that UTF-8 bytes are preserved through the socket.

![image](https://github.com/cc-tweaked/CC-Tweaked/assets/6236912/a5e74f68-371c-4178-bf28-c2437dc9490b)