### PR TITLE
Update Minecraft wiki links to new domain

### DIFF
--- a/projects/common/src/main/java/dan200/computercraft/shared/details/ItemDetails.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/details/ItemDetails.java
@@ -61,7 +61,7 @@ public class ItemDetails {
 
         /*
          * Used to hide some data from ItemStack tooltip.
-         * @see https://minecraft.gamepedia.com/Tutorials/Command_NBT_tags
+         * @see https://minecraft.wiki/w/Tutorials/Command_NBT_tags
          * @see ItemStack#getTooltip
          */
         var hideFlags = tag != null ? tag.getInt("HideFlags") : 0;

--- a/projects/common/src/main/java/dan200/computercraft/shared/peripheral/speaker/SpeakerPeripheral.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/peripheral/speaker/SpeakerPeripheral.java
@@ -188,7 +188,7 @@ public abstract class SpeakerPeripheral implements IPeripheral {
      * {@literal false}.
      * <p>
      * ### Valid instruments
-     * The speaker supports [all of Minecraft's noteblock instruments](https://minecraft.fandom.com/wiki/Note_Block#Instruments).
+     * The speaker supports [all of Minecraft's noteblock instruments](https://minecraft.wiki/w/Note_Block#Instruments).
      * These are:
      * <p>
      * {@code "harp"}, {@code "basedrum"}, {@code "snare"}, {@code "hat"}, {@code "bass"}, {@code "flute"},
@@ -228,7 +228,7 @@ public abstract class SpeakerPeripheral implements IPeripheral {
     /**
      * Plays a Minecraft sound through the speaker.
      * <p>
-     * This takes the [name of a Minecraft sound](https://minecraft.fandom.com/wiki/Sounds.json), such as
+     * This takes the [name of a Minecraft sound](https://minecraft.wiki/w/Sounds.json), such as
      * {@code "minecraft:block.note_block.harp"}, as well as an optional volume and pitch.
      * <p>
      * Only one sound can be played at once. This function will return {@literal false} if another sound was started

--- a/projects/core/src/main/java/dan200/computercraft/core/apis/RedstoneAPI.java
+++ b/projects/core/src/main/java/dan200/computercraft/core/apis/RedstoneAPI.java
@@ -49,7 +49,7 @@ import java.util.List;
  * end
  * }</pre>
  * <p>
- * [comparator]: https://minecraft.gamepedia.com/Redstone_Comparator#Subtract_signal_strength "Redstone Comparator on
+ * [comparator]: https://minecraft.wiki/w/Redstone_Comparator#Subtract_signal_strength "Redstone Comparator on
  * the Minecraft wiki."
  * @cc.module redstone
  */

--- a/projects/core/src/main/resources/data/computercraft/lua/rom/apis/command/commands.lua
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/apis/command/commands.lua
@@ -17,7 +17,7 @@ instance, `commands.say("Hi!")` is equivalent to `commands.exec("say Hi!")`.
 commands. `commands.async.say("Hi!")` is equivalent to
 `commands.execAsync("say Hi!")`.
 
-[mc]: https://minecraft.gamepedia.com/Commands
+[mc]: https://minecraft.wiki/w/Commands
 
 @module commands
 @usage Set the block above this computer to stone:

--- a/projects/core/src/main/resources/data/computercraft/lua/rom/apis/disk.lua
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/apis/disk.lua
@@ -96,7 +96,7 @@ end
 --
 -- If this returns true, you will can [play][`disk.playAudio`] the record.
 --
--- [disk]: https://minecraft.gamepedia.com/Music_Disc
+-- [disk]: https://minecraft.wiki/w/Music_Disc
 --
 -- @tparam string name The name of the disk drive.
 -- @treturn boolean If the disk is present and has audio saved on it.

--- a/projects/core/src/main/resources/data/computercraft/lua/rom/apis/textutils.lua
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/apis/textutils.lua
@@ -722,7 +722,7 @@ do
     - `parse_empty_array`: When false, empty arrays will be parsed as a new table.
        By default (or when this value is true), they are parsed as [`empty_json_array`].
 
-    [nbt]: https://minecraft.gamepedia.com/NBT_format
+    [nbt]: https://minecraft.wiki/w/NBT_format
     @return[1] The deserialised object
     @treturn[2] nil If the object could not be deserialised.
     @treturn string A message describing why the JSON string is invalid.

--- a/projects/core/src/main/resources/data/computercraft/lua/rom/help/commandsapi.txt
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/help/commandsapi.txt
@@ -12,4 +12,4 @@ commands.give( "dan200", "minecraft:diamond", 64 )
 This works with any command. Use "commands.async" instead of "commands" to execute asynchronously.
 
 The commands API is only available on Command Computers.
-Visit http://minecraft.wiki/w/Commands for documentation on all commands.
+Visit https://minecraft.wiki/w/Commands for documentation on all commands.

--- a/projects/core/src/main/resources/data/computercraft/lua/rom/help/commandsapi.txt
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/help/commandsapi.txt
@@ -12,4 +12,4 @@ commands.give( "dan200", "minecraft:diamond", 64 )
 This works with any command. Use "commands.async" instead of "commands" to execute asynchronously.
 
 The commands API is only available on Command Computers.
-Visit http://minecraft.gamepedia.com/Commands for documentation on all commands.
+Visit http://minecraft.wiki/w/Commands for documentation on all commands.

--- a/projects/core/src/main/resources/data/computercraft/lua/rom/help/keys.txt
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/help/keys.txt
@@ -6,4 +6,4 @@ if sEvent == "key" and nKey == keys.enter then
    -- Do something
 end
 
-See http://www.minecraftwiki.net/wiki/Key_codes, or the source code, for a complete reference.
+See http://www.minecraft.wiki/w/Key_codes, or the source code, for a complete reference.

--- a/projects/core/src/main/resources/data/computercraft/lua/rom/help/keys.txt
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/help/keys.txt
@@ -6,4 +6,4 @@ if sEvent == "key" and nKey == keys.enter then
    -- Do something
 end
 
-See http://www.minecraft.wiki/w/Key_codes, or the source code, for a complete reference.
+See https://www.minecraft.wiki/w/Key_codes, or the source code, for a complete reference.


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all URLs accordingly.