### PR TITLE
GPS - Use distance the server received.

### DIFF
--- a/projects/core/src/main/resources/data/computercraft/lua/rom/apis/gps.lua
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/apis/gps.lua
@@ -149,7 +149,7 @@ function locate(_nTimeout, _bDebug)
             if sSide == sModemSide and sChannel == CHANNEL_GPS and sReplyChannel == CHANNEL_GPS and nDistance then
                 -- Received the correct message from the correct modem: use it to determine position
                 if type(tMessage) == "table" and #tMessage == 4 and tonumber(tMessage[1]) and tonumber(tMessage[2]) and tonumber(tMessage[3]) and tonumber(tMessage[4]) then
-                    local tFix = { vPosition = vector.new(tMessage[1], tMessage[2], tMessage[3]), nDistance = tMessage[4] }
+                    local tFix = { vPosition = vector.new(tMessage[1], tMessage[2], tMessage[3]), nDistance = tonumber(tMessage[4]) and tMessage[4] or nDistance }
                     if _bDebug then
                         print(tFix.nDistance .. " metres from " .. tostring(tFix.vPosition))
                     end

--- a/projects/core/src/main/resources/data/computercraft/lua/rom/apis/gps.lua
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/apis/gps.lua
@@ -148,8 +148,8 @@ function locate(_nTimeout, _bDebug)
             local sSide, sChannel, sReplyChannel, tMessage, nDistance = p1, p2, p3, p4, p5
             if sSide == sModemSide and sChannel == CHANNEL_GPS and sReplyChannel == CHANNEL_GPS and nDistance then
                 -- Received the correct message from the correct modem: use it to determine position
-                if type(tMessage) == "table" and #tMessage == 3 and tonumber(tMessage[1]) and tonumber(tMessage[2]) and tonumber(tMessage[3]) then
-                    local tFix = { vPosition = vector.new(tMessage[1], tMessage[2], tMessage[3]), nDistance = nDistance }
+                if type(tMessage) == "table" and #tMessage == 4 and tonumber(tMessage[1]) and tonumber(tMessage[2]) and tonumber(tMessage[3]) and tonumber(tMessage[4]) then
+                    local tFix = { vPosition = vector.new(tMessage[1], tMessage[2], tMessage[3]), nDistance = tMessage[4] }
                     if _bDebug then
                         print(tFix.nDistance .. " metres from " .. tostring(tFix.vPosition))
                     end

--- a/projects/core/src/main/resources/data/computercraft/lua/rom/apis/gps.lua
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/apis/gps.lua
@@ -148,7 +148,7 @@ function locate(_nTimeout, _bDebug)
             local sSide, sChannel, sReplyChannel, tMessage, nDistance = p1, p2, p3, p4, p5
             if sSide == sModemSide and sChannel == CHANNEL_GPS and sReplyChannel == CHANNEL_GPS and nDistance then
                 -- Received the correct message from the correct modem: use it to determine position
-                if type(tMessage) == "table" and #tMessage == 4 and tonumber(tMessage[1]) and tonumber(tMessage[2]) and tonumber(tMessage[3]) and tonumber(tMessage[4]) then
+                if type(tMessage) == "table" and #tMessage == 4 and tonumber(tMessage[1]) and tonumber(tMessage[2]) and tonumber(tMessage[3]) then
                     local tFix = { vPosition = vector.new(tMessage[1], tMessage[2], tMessage[3]), nDistance = tonumber(tMessage[4]) and tMessage[4] or nDistance }
                     if _bDebug then
                         print(tFix.nDistance .. " metres from " .. tostring(tFix.vPosition))

--- a/projects/core/src/main/resources/data/computercraft/lua/rom/apis/gps.lua
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/apis/gps.lua
@@ -148,8 +148,8 @@ function locate(_nTimeout, _bDebug)
             local sSide, sChannel, sReplyChannel, tMessage, nDistance = p1, p2, p3, p4, p5
             if sSide == sModemSide and sChannel == CHANNEL_GPS and sReplyChannel == CHANNEL_GPS and nDistance then
                 -- Received the correct message from the correct modem: use it to determine position
-                if type(tMessage) == "table" and #tMessage == 4 and tonumber(tMessage[1]) and tonumber(tMessage[2]) and tonumber(tMessage[3]) then
-                    local tFix = { vPosition = vector.new(tMessage[1], tMessage[2], tMessage[3]), nDistance = tonumber(tMessage[4]) and tMessage[4] or nDistance }
+                if type(tMessage) == "table" and (#tMessage == 3 or #tMessage == 4 and tonumber(tMessage[4])) and tonumber(tMessage[1]) and tonumber(tMessage[2]) and tonumber(tMessage[3]) then
+                    local tFix = { vPosition = vector.new(tMessage[1], tMessage[2], tMessage[3]), nDistance = tonumber(tMessage[4]) or nDistance }
                     if _bDebug then
                         print(tFix.nDistance .. " metres from " .. tostring(tFix.vPosition))
                     end

--- a/projects/core/src/main/resources/data/computercraft/lua/rom/programs/gps.lua
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/programs/gps.lua
@@ -79,7 +79,7 @@ elseif sCommand == "host" then
             local sSide, sChannel, sReplyChannel, sMessage, nDistance = p1, p2, p3, p4, p5
             if sSide == sModemSide and sChannel == gps.CHANNEL_GPS and sMessage == "PING" and nDistance then
                 -- We received a ping message on the GPS channel, send a response
-                modem.transmit(sReplyChannel, gps.CHANNEL_GPS, { x, y, z })
+                modem.transmit(sReplyChannel, gps.CHANNEL_GPS, { x, y, z, nDistance })
 
                 -- Print the number of requests handled
                 nServed = nServed + 1


### PR DESCRIPTION
I had a very random thought at 2 am today.

The GPS hosts receive a distance from the client, but then the hosts all send *separate* messages to the client. These separate messages may be sent at different times, meaning the player, turtle, or whatever, might have moved a slight bit in that time.

Thus, my thoughts are as follows:

1. Each host receives a distance at the same time, assumedly originating from the same location.
2. Each host can send that distance back to the client.
3. The client can use that distance instead to calculate its position. It *should* be more accurate, since the distances come from one message sent to all servers at the exact same time.

This is a really half-baked idea and fueled by way too much caffeine, but I thought I'd get the thought out there before I forgot about it. I have no idea how I'd test if this actually is happening (or if these changes even mitigate anything), but I recall having minor accuracy issues with GPS in the past. *In theory* (if my theory is right), this would resolve some accuracy issues.