### PR TITLE
Fix incorrect Lua list indexes

### DIFF
--- a/projects/common/src/main/java/dan200/computercraft/shared/computer/blocks/CommandComputerBlockEntity.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/computer/blocks/CommandComputerBlockEntity.java
@@ -20,28 +20,24 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.Vec2;
 import net.minecraft.world.phys.Vec3;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
 
 public class CommandComputerBlockEntity extends ComputerBlockEntity {
     public class CommandReceiver implements CommandSource {
-        private final Map<Integer, String> output = new HashMap<>();
+        private final List<String> output = new ArrayList<>();
 
         public void clearOutput() {
             output.clear();
         }
 
-        public Map<Integer, String> getOutput() {
-            return output;
-        }
-
-        public Map<Integer, String> copyOutput() {
-            return new HashMap<>(output);
+        public List<String> copyOutput() {
+            return new ArrayList<>(output);
         }
 
         @Override
         public void sendSystemMessage(Component textComponent) {
-            output.put(output.size() + 1, textComponent.getString());
+            output.add(textComponent.getString());
         }
 
         @Override

--- a/projects/common/src/main/java/dan200/computercraft/shared/util/NBTUtil.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/util/NBTUtil.java
@@ -150,7 +150,7 @@ public final class NBTUtil {
             case Tag.TAG_LIST: {
                 var list = (ListTag) tag;
                 Map<Integer, Object> map = new HashMap<>(list.size());
-                for (var i = 0; i < list.size(); i++) map.put(i, toLua(list.get(i)));
+                for (var i = 0; i < list.size(); i++) map.put(i + 1, toLua(list.get(i)));
                 return map;
             }
             case Tag.TAG_BYTE_ARRAY: {

--- a/projects/common/src/main/java/dan200/computercraft/shared/util/NBTUtil.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/util/NBTUtil.java
@@ -19,9 +19,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 public final class NBTUtil {
     private static final Logger LOG = LoggerFactory.getLogger(NBTUtil.class);
@@ -149,20 +147,20 @@ public final class NBTUtil {
             }
             case Tag.TAG_LIST: {
                 var list = (ListTag) tag;
-                Map<Integer, Object> map = new HashMap<>(list.size());
-                for (var i = 0; i < list.size(); i++) map.put(i + 1, toLua(list.get(i)));
+                List<Object> map = new ArrayList<>(list.size());
+                for (var value : list) map.add(toLua(value));
                 return map;
             }
             case Tag.TAG_BYTE_ARRAY: {
                 var array = ((ByteArrayTag) tag).getAsByteArray();
-                Map<Integer, Byte> map = new HashMap<>(array.length);
-                for (var i = 0; i < array.length; i++) map.put(i + 1, array[i]);
+                List<Byte> map = new ArrayList<>(array.length);
+                for (var b : array) map.add(b);
                 return map;
             }
             case Tag.TAG_INT_ARRAY: {
                 var array = ((IntArrayTag) tag).getAsIntArray();
-                Map<Integer, Integer> map = new HashMap<>(array.length);
-                for (var i = 0; i < array.length; i++) map.put(i + 1, array[i]);
+                List<Integer> map = new ArrayList<>(array.length);
+                for (var j : array) map.add(j);
                 return map;
             }
 


### PR DESCRIPTION
Without this change, tag lists in Lua look like this (key/value pairs):
1 first_value
2 second_value
3 third_value
0 fourth_value

This means that the last value isn't reached with ipairs().

With this change, they look like this and can be iterated with ipairs():
1 first_value
2 second_value
3 third_value
4 fourth_value