### PR TITLE
feat: add player name to monitor_touch events

### DIFF
--- a/doc/events/monitor_touch.md
+++ b/doc/events/monitor_touch.md
@@ -15,12 +15,13 @@ The [`monitor_touch`] event is fired when an adjacent or networked Advanced Moni
 2. [`string`]: The side or network ID of the monitor that was touched.
 3. [`number`]: The X coordinate of the touch, in characters.
 4. [`number`]: The Y coordinate of the touch, in characters.
+5. [`string`]: The name of the player who touched the monitor.
 
 ## Example
 Prints a message when a monitor is touched:
 ```lua
 while true do
-  local event, side, x, y = os.pullEvent("monitor_touch")
-  print("The monitor on side " .. side .. " was touched at (" .. x .. ", " .. y .. ")")
+  local event, side, x, y, player = os.pullEvent("monitor_touch")
+  print("The monitor on side " .. side .. " was touched at (" .. x .. ", " .. y .. ") by " .. player)
 end
 ```

--- a/projects/common/src/main/java/dan200/computercraft/shared/peripheral/monitor/MonitorBlock.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/peripheral/monitor/MonitorBlock.java
@@ -105,7 +105,8 @@ public class MonitorBlock extends HorizontalDirectionalBlock implements EntityBl
             monitor.monitorTouched(
                 (float) (hit.getLocation().x - hit.getBlockPos().getX()),
                 (float) (hit.getLocation().y - hit.getBlockPos().getY()),
-                (float) (hit.getLocation().z - hit.getBlockPos().getZ())
+                (float) (hit.getLocation().z - hit.getBlockPos().getZ()),
+                player.getName().getString()
             );
         }
 

--- a/projects/common/src/main/java/dan200/computercraft/shared/peripheral/monitor/MonitorBlockEntity.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/peripheral/monitor/MonitorBlockEntity.java
@@ -455,7 +455,7 @@ public class MonitorBlockEntity extends BlockEntity {
     }
     // endregion
 
-    void monitorTouched(float xPos, float yPos, float zPos) {
+    void monitorTouched(float xPos, float yPos, float zPos, String player) {
         if (!advanced) return;
 
         var pair = XYPair
@@ -478,7 +478,7 @@ public class MonitorBlockEntity extends BlockEntity {
         var xCharPos = (int) Math.min(originTerminal.getWidth(), Math.max((pair.x() - RENDER_BORDER - RENDER_MARGIN) / xCharWidth + 1.0, 1.0));
         var yCharPos = (int) Math.min(originTerminal.getHeight(), Math.max((pair.y() - RENDER_BORDER - RENDER_MARGIN) / yCharHeight + 1.0, 1.0));
 
-        eachComputer(c -> c.queueEvent("monitor_touch", c.getAttachmentName(), xCharPos, yCharPos));
+        eachComputer(c -> c.queueEvent("monitor_touch", c.getAttachmentName(), xCharPos, yCharPos, player));
     }
 
     private void eachComputer(Consumer<IComputerAccess> fun) {

--- a/projects/core/src/main/resources/data/computercraft/lua/rom/help/monitors.txt
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/help/monitors.txt
@@ -19,5 +19,5 @@ setPaletteColor( color, r, g, b )
 getPaletteColor( color )
 
 Events fired by the Monitor:
-"monitor_touch" when an Advanced Monitor is touched by the player. Arguments are name, x, y
+"monitor_touch" when an Advanced Monitor is touched by the player. Arguments are name, x, y, playerName
 "monitor_resize" when the size of a Monitor changes. Argument is the name of the monitor.


### PR DESCRIPTION
Adds a player name argument to the `monitor_touch` event so that different player interactions can be distinguished.

I'm not sure if `player.getName().getString()` is affected by server nicknames, ideally it would return the real player name. Alternatively it might be better to use the player UUID?