### PR TITLE
Basic NFC Modem functionality for Pocket Computer

### DIFF
--- a/projects/common-api/src/main/java/dan200/computercraft/api/ComputerCraftAPI.java
+++ b/projects/common-api/src/main/java/dan200/computercraft/api/ComputerCraftAPI.java
@@ -166,6 +166,7 @@ public final class ComputerCraftAPI {
      * Attempt to get the NFC network for a player.
      *
      * @param server The current Minecraft server.
+     * @param entity The entity whose NFC network should be obtained.
      * @return The NFC network, or {@code null} if it could not be fetched.
      */
     public static PacketNetwork getNfcNetwork(MinecraftServer server, Entity entity) {

--- a/projects/common-api/src/main/java/dan200/computercraft/api/ComputerCraftAPI.java
+++ b/projects/common-api/src/main/java/dan200/computercraft/api/ComputerCraftAPI.java
@@ -22,6 +22,7 @@ import dan200.computercraft.impl.ComputerCraftAPIService;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 
@@ -159,6 +160,16 @@ public final class ComputerCraftAPI {
      */
     public static PacketNetwork getWirelessNetwork(MinecraftServer server) {
         return getInstance().getWirelessNetwork(server);
+    }
+
+    /**
+     * Attempt to get the NFC network for a player.
+     *
+     * @param server The current Minecraft server.
+     * @return The NFC network, or {@code null} if it could not be fetched.
+     */
+    public static PacketNetwork getNfcNetwork(MinecraftServer server, Entity entity) {
+        return getInstance().getNfcNetwork(server, entity);
     }
 
     /**

--- a/projects/common-api/src/main/java/dan200/computercraft/api/network/PacketNetwork.java
+++ b/projects/common-api/src/main/java/dan200/computercraft/api/network/PacketNetwork.java
@@ -53,4 +53,19 @@ public interface PacketNetwork {
      * @see PacketReceiver#receiveDifferentDimension(Packet)
      */
     void transmitInterdimensional(Packet packet);
+
+    static void tryTransmit(PacketReceiver receiver, Packet packet, double range, boolean interdimensional) {
+        var sender = packet.sender();
+        if (receiver.getLevel() == sender.getLevel()) {
+            var receiveRange = Math.max(range, receiver.getRange()); // Ensure range is symmetrical
+            var distanceSq = receiver.getPosition().distanceToSqr(sender.getPosition());
+            if (interdimensional || receiver.isInterdimensional() || distanceSq <= receiveRange * receiveRange) {
+                receiver.receiveSameDimension(packet, Math.sqrt(distanceSq));
+            }
+        } else {
+            if (interdimensional || receiver.isInterdimensional()) {
+                receiver.receiveDifferentDimension(packet);
+            }
+        }
+    }
 }

--- a/projects/common-api/src/main/java/dan200/computercraft/api/pocket/IPocketAccess.java
+++ b/projects/common-api/src/main/java/dan200/computercraft/api/pocket/IPocketAccess.java
@@ -47,22 +47,40 @@ public interface IPocketAccess {
     void setColour(int colour);
 
     /**
-     * Get the colour of this pocket computer's light as a RGB number.
+     * Get the primary colour of this pocket computer's light as a RGB number.
      *
-     * @return The colour this light is. This will be a RGB colour between {@code 0x000000} and {@code 0xFFFFFF} or
+     * @return The primary colour this light is. This will be a RGB colour between {@code 0x000000} and {@code 0xFFFFFF} or
      * -1 if it has no colour.
-     * @see #setLight(int)
+     * @see #setLightPrimary(int)
      */
-    int getLight();
+    int getLightPrimary();
 
     /**
-     * Set the colour of the pocket computer's light to a RGB number.
+     * Set the primary colour of the pocket computer's light to a RGB number.
      *
-     * @param colour The colour this modem's light will be changed to. This should be a RGB colour between
+     * @param colour The primary colour this modem's light will be changed to. This should be a RGB colour between
      *               {@code 0x000000} and {@code 0xFFFFFF} or -1 to reset to the default colour.
-     * @see #getLight()
+     * @see #getLightPrimary()
      */
-    void setLight(int colour);
+    void setLightPrimary(int colour);
+
+    /**
+     * Get the secondary colour of this pocket computer's light as a RGB number.
+     *
+     * @return The secondary colour this light is. This will be a RGB colour between {@code 0x000000} and {@code 0xFFFFFF} or
+     * -1 if it has no colour.
+     * @see #setLightSecondary(int)
+     */
+    int getLightSecondary();
+
+    /**
+     * Set the secondary colour of the pocket computer's light to a RGB number.
+     *
+     * @param colour The secondary colour this modem's light will be changed to. This should be a RGB colour between
+     *               {@code 0x000000} and {@code 0xFFFFFF} or -1 to reset to the default colour.
+     * @see #getLightSecondary()
+     */
+    void setLightSecondary(int colour);
 
     /**
      * Get the upgrade-specific NBT.

--- a/projects/common-api/src/main/java/dan200/computercraft/impl/ComputerCraftAPIService.java
+++ b/projects/common-api/src/main/java/dan200/computercraft/impl/ComputerCraftAPIService.java
@@ -24,6 +24,7 @@ import net.minecraft.core.Direction;
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.ApiStatus;
@@ -60,6 +61,8 @@ public interface ComputerCraftAPIService {
     void registerMediaProvider(MediaProvider provider);
 
     PacketNetwork getWirelessNetwork(MinecraftServer server);
+
+    PacketNetwork getNfcNetwork(MinecraftServer server, Entity entity);
 
     void registerAPIFactory(ILuaAPIFactory factory);
 

--- a/projects/common/src/client/java/dan200/computercraft/client/FrameInfo.java
+++ b/projects/common/src/client/java/dan200/computercraft/client/FrameInfo.java
@@ -24,6 +24,10 @@ public final class FrameInfo {
         return renderFrame;
     }
 
+    public static int getTick() {
+        return tick;
+    }
+
     public static void onTick() {
         tick++;
     }

--- a/projects/common/src/client/java/dan200/computercraft/client/platform/ClientNetworkContextImpl.java
+++ b/projects/common/src/client/java/dan200/computercraft/client/platform/ClientNetworkContextImpl.java
@@ -67,9 +67,9 @@ public final class ClientNetworkContextImpl implements ClientNetworkContext {
     }
 
     @Override
-    public void handlePocketComputerData(int instanceId, ComputerState state, int lightState, TerminalState terminal) {
+    public void handlePocketComputerData(int instanceId, ComputerState state, int primaryLightState, int secondaryLightState, TerminalState terminal) {
         var computer = ClientPocketComputers.get(instanceId, terminal.colour);
-        computer.setState(state, lightState);
+        computer.setState(state, primaryLightState, secondaryLightState);
         if (terminal.hasTerminal()) computer.setTerminal(terminal);
     }
 

--- a/projects/common/src/client/java/dan200/computercraft/client/pocket/PocketComputerData.java
+++ b/projects/common/src/client/java/dan200/computercraft/client/pocket/PocketComputerData.java
@@ -39,7 +39,7 @@ public class PocketComputerData {
             } else if (primaryLightColour == -1) {
                 return secondaryLightColour;
             } else {
-                double weight = ((Math.sin(((double)(FrameInfo.getTick() % 41) / 40)*Math.PI*2)+1)/2);
+                double weight = (Math.sin(((double)(FrameInfo.getTick() % 41) / 40) * Math.PI * 2) + 1) / 2;
                 return blend(primaryLightColour, secondaryLightColour, weight);
             }
         }
@@ -48,13 +48,13 @@ public class PocketComputerData {
 
     private static int blend(int a, int b, double weight) {
         int[][] rgb = {
-            { a >> 16,  b >> 16 },
+            { a >> 16, b >> 16 },
             { (a & 0x00ff00) >> 8, (b & 0x00ff00) >> 8 },
-            { a & 0x0000ff, b & 0x0000ff }
+            { a & 0x0000ff, b & 0x0000ff },
         };
         int[] channels = new int[3];
         for (int i = 0; i < 3; i++) {
-            channels[i] = (int)Math.sqrt(Math.pow(rgb[i][0], 2)*weight + Math.pow(rgb[i][1], 2)*(1-weight));
+            channels[i] = (int)Math.sqrt(Math.pow(rgb[i][0], 2) * weight + Math.pow(rgb[i][1], 2) * (1 - weight));
         }
         int color = 0;
         for (int channel : channels) {

--- a/projects/common/src/client/java/dan200/computercraft/client/pocket/PocketComputerData.java
+++ b/projects/common/src/client/java/dan200/computercraft/client/pocket/PocketComputerData.java
@@ -54,7 +54,7 @@ public class PocketComputerData {
         };
         int[] channels = new int[3];
         for (int i = 0; i < 3; i++) {
-            channels[i] = (int)Math.sqrt((Math.pow(rgb[i][0], 2)*weight + Math.pow(rgb[i][1], 2)*(1-weight))/2);
+            channels[i] = (int)Math.sqrt(Math.pow(rgb[i][0], 2)*weight + Math.pow(rgb[i][1], 2)*(1-weight));
         }
         int color = 0;
         for (int channel : channels) {

--- a/projects/common/src/client/java/dan200/computercraft/client/pocket/PocketComputerData.java
+++ b/projects/common/src/client/java/dan200/computercraft/client/pocket/PocketComputerData.java
@@ -4,6 +4,7 @@
 
 package dan200.computercraft.client.pocket;
 
+import dan200.computercraft.client.FrameInfo;
 import dan200.computercraft.core.terminal.Terminal;
 import dan200.computercraft.shared.computer.core.ComputerState;
 import dan200.computercraft.shared.computer.terminal.NetworkedTerminal;
@@ -24,14 +25,42 @@ import dan200.computercraft.shared.pocket.core.PocketServerComputer;
 public class PocketComputerData {
     private final NetworkedTerminal terminal;
     private ComputerState state = ComputerState.OFF;
-    private int lightColour = -1;
+    private int primaryLightColour = -1;
+    private int secondaryLightColour = -1;
 
     public PocketComputerData(boolean colour) {
         terminal = new NetworkedTerminal(Config.pocketTermWidth, Config.pocketTermHeight, colour);
     }
 
     public int getLightState() {
-        return state != ComputerState.OFF ? lightColour : -1;
+        if (state != ComputerState.OFF) {
+            if (secondaryLightColour == -1) {
+                return primaryLightColour;
+            } else if (primaryLightColour == -1) {
+                return secondaryLightColour;
+            } else {
+                double weight = ((Math.sin(((double)(FrameInfo.getTick() % 41) / 40)*Math.PI*2)+1)/2);
+                return blend(primaryLightColour, secondaryLightColour, weight);
+            }
+        }
+        return -1;
+    }
+
+    private static int blend(int a, int b, double weight) {
+        int[][] rgb = {
+            { a >> 16,  b >> 16 },
+            { (a & 0x00ff00) >> 8, (b & 0x00ff00) >> 8 },
+            { a & 0x0000ff, b & 0x0000ff }
+        };
+        int[] channels = new int[3];
+        for (int i = 0; i < 3; i++) {
+            channels[i] = (int)Math.sqrt((Math.pow(rgb[i][0], 2)*weight + Math.pow(rgb[i][1], 2)*(1-weight))/2);
+        }
+        int color = 0;
+        for (int channel : channels) {
+            color = (color << 8) + channel;
+        }
+        return color;
     }
 
     public Terminal getTerminal() {
@@ -42,9 +71,10 @@ public class PocketComputerData {
         return state;
     }
 
-    public void setState(ComputerState state, int lightColour) {
+    public void setState(ComputerState state, int primaryLightColour, int secondaryLightColor) {
         this.state = state;
-        this.lightColour = lightColour;
+        this.primaryLightColour = primaryLightColour;
+        this.secondaryLightColour = secondaryLightColor;
     }
 
     public void setTerminal(TerminalState state) {

--- a/projects/common/src/main/java/dan200/computercraft/impl/AbstractComputerCraftAPI.java
+++ b/projects/common/src/main/java/dan200/computercraft/impl/AbstractComputerCraftAPI.java
@@ -32,6 +32,7 @@ import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 
@@ -98,6 +99,11 @@ public abstract class AbstractComputerCraftAPI implements ComputerCraftAPIServic
     @Override
     public final PacketNetwork getWirelessNetwork(MinecraftServer server) {
         return ServerContext.get(server).wirelessNetwork();
+    }
+
+    @Override
+    public final PacketNetwork getNfcNetwork(MinecraftServer server, Entity entity) {
+        return ServerContext.get(server).nfcNetwork(entity);
     }
 
     @Override

--- a/projects/common/src/main/java/dan200/computercraft/shared/computer/core/ServerContext.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/computer/core/ServerContext.java
@@ -22,10 +22,12 @@ import dan200.computercraft.impl.GenericSources;
 import dan200.computercraft.shared.CommonHooks;
 import dan200.computercraft.shared.computer.metrics.GlobalMetrics;
 import dan200.computercraft.shared.config.ConfigSpec;
+import dan200.computercraft.shared.peripheral.modem.wireless.NFCNetworkManager;
 import dan200.computercraft.shared.peripheral.modem.wireless.WirelessNetwork;
 import dan200.computercraft.shared.util.IDAssigner;
 import net.minecraft.SharedConstants;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.storage.LevelResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -64,6 +66,7 @@ public final class ServerContext {
     private final MainThread mainThread;
     private final IDAssigner idAssigner;
     private final WirelessNetwork wirelessNetwork = new WirelessNetwork();
+    private final NFCNetworkManager nfcNetworkManager = new NFCNetworkManager();
     private final Path storageDir;
 
     private ServerContext(MinecraftServer server) {
@@ -207,6 +210,18 @@ public final class ServerContext {
      */
     public PacketNetwork wirelessNetwork() {
         return wirelessNetwork;
+    }
+
+    /**
+     * Get a player's NFC network.
+     * <p>
+     * Use {@link ComputerCraftAPI#getNfcNetwork(MinecraftServer, Entity)} instead of this method.
+     *
+     * @return The NFC network.
+     */
+    public PacketNetwork nfcNetwork(Entity entity) {
+        PacketNetwork network = nfcNetworkManager.get(entity);
+        return network == null ? nfcNetworkManager.addNetwork(entity) : network;
     }
 
     private record Environment(MinecraftServer server) implements GlobalEnvironment {

--- a/projects/common/src/main/java/dan200/computercraft/shared/computer/core/ServerContext.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/computer/core/ServerContext.java
@@ -216,7 +216,7 @@ public final class ServerContext {
      * Get a player's NFC network.
      * <p>
      * Use {@link ComputerCraftAPI#getNfcNetwork(MinecraftServer, Entity)} instead of this method.
-     *
+     * @param entity The entity whose NFC network should be obtained.
      * @return The NFC network.
      */
     public PacketNetwork nfcNetwork(Entity entity) {

--- a/projects/common/src/main/java/dan200/computercraft/shared/network/client/ClientNetworkContext.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/network/client/ClientNetworkContext.java
@@ -30,7 +30,7 @@ public interface ClientNetworkContext {
 
     void handlePlayRecord(BlockPos pos, @Nullable SoundEvent sound, @Nullable String name);
 
-    void handlePocketComputerData(int instanceId, ComputerState state, int lightState, TerminalState terminal);
+    void handlePocketComputerData(int instanceId, ComputerState state, int primaryLightColor, int secondaryLightColor, TerminalState terminal);
 
     void handlePocketComputerDeleted(int instanceId);
 

--- a/projects/common/src/main/java/dan200/computercraft/shared/network/client/PocketComputerDataMessage.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/network/client/PocketComputerDataMessage.java
@@ -19,20 +19,23 @@ import net.minecraft.network.FriendlyByteBuf;
 public class PocketComputerDataMessage implements NetworkMessage<ClientNetworkContext> {
     private final int instanceId;
     private final ComputerState state;
-    private final int lightState;
+    private final int primaryLightState;
+    private final int secondaryLightState;
     private final TerminalState terminal;
 
     public PocketComputerDataMessage(PocketServerComputer computer, boolean sendTerminal) {
         instanceId = computer.getInstanceID();
         state = computer.getState();
-        lightState = computer.getLight();
+        primaryLightState = computer.getLightPrimary();
+        secondaryLightState = computer.getLightSecondary();
         terminal = sendTerminal ? computer.getTerminalState() : new TerminalState((NetworkedTerminal) null);
     }
 
     public PocketComputerDataMessage(FriendlyByteBuf buf) {
         instanceId = buf.readVarInt();
         state = buf.readEnum(ComputerState.class);
-        lightState = buf.readVarInt();
+        primaryLightState = buf.readVarInt();
+        secondaryLightState = buf.readVarInt();
         terminal = new TerminalState(buf);
     }
 
@@ -40,13 +43,14 @@ public class PocketComputerDataMessage implements NetworkMessage<ClientNetworkCo
     public void write(FriendlyByteBuf buf) {
         buf.writeVarInt(instanceId);
         buf.writeEnum(state);
-        buf.writeVarInt(lightState);
+        buf.writeVarInt(primaryLightState);
+        buf.writeVarInt(secondaryLightState);
         terminal.write(buf);
     }
 
     @Override
     public void handle(ClientNetworkContext context) {
-        context.handlePocketComputerData(instanceId, state, lightState, terminal);
+        context.handlePocketComputerData(instanceId, state, primaryLightState, secondaryLightState, terminal);
     }
 
     @Override

--- a/projects/common/src/main/java/dan200/computercraft/shared/peripheral/modem/wireless/NFCNetworkManager.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/peripheral/modem/wireless/NFCNetworkManager.java
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2017 The CC: Tweaked Developers
+//
+// SPDX-License-Identifier: MPL-2.0
+
+package dan200.computercraft.shared.peripheral.modem.wireless;
+
+import net.minecraft.world.entity.Entity;
+
+import javax.annotation.Nullable;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class NFCNetworkManager {
+    private final Map<Entity, WirelessNetwork> networks = new ConcurrentHashMap<>();
+
+    public WirelessNetwork addNetwork(Entity entity) {
+        if (!networks.containsKey(entity)) {
+            networks.put(entity, new WirelessNetwork(() -> networks.remove(entity)));
+        }
+        return networks.get(entity);
+    }
+
+    public void removeNetwork(Entity entity) {
+        networks.remove(entity);
+    }
+
+    public @Nullable WirelessNetwork get(Entity entity) {
+        return networks.get(entity);
+    }
+}

--- a/projects/common/src/main/java/dan200/computercraft/shared/pocket/core/PocketServerComputer.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/pocket/core/PocketServerComputer.java
@@ -38,8 +38,10 @@ public class PocketServerComputer extends ServerComputer implements IPocketAcces
     private @Nullable Entity entity;
     private ItemStack stack = ItemStack.EMPTY;
 
-    private int lightColour = -1;
-    private boolean lightChanged = false;
+    private int primaryLightColour = -1;
+    private boolean primaryLightChanged = false;
+    private int secondaryLightColour = -1;
+    private boolean secondaryLightChanged = false;
 
     private final Set<ServerPlayer> tracking = new HashSet<>();
 
@@ -77,17 +79,31 @@ public class PocketServerComputer extends ServerComputer implements IPocketAcces
     }
 
     @Override
-    public int getLight() {
-        return lightColour;
+    public int getLightPrimary() {
+        return primaryLightColour;
     }
 
     @Override
-    public void setLight(int colour) {
+    public void setLightPrimary(int colour) {
         if (colour < 0 || colour > 0xFFFFFF) colour = -1;
 
-        if (lightColour == colour) return;
-        lightColour = colour;
-        lightChanged = true;
+        if (primaryLightColour == colour) return;
+        primaryLightColour = colour;
+        primaryLightChanged = true;
+    }
+
+    @Override
+    public int getLightSecondary() {
+        return secondaryLightColour;
+    }
+
+    @Override
+    public void setLightSecondary(int colour) {
+        if (colour < 0 || colour > 0xFFFFFF) colour = -1;
+
+        if (secondaryLightColour == colour) return;
+        secondaryLightColour = colour;
+        secondaryLightChanged = true;
     }
 
     @Override
@@ -161,8 +177,9 @@ public class PocketServerComputer extends ServerComputer implements IPocketAcces
         tracking.removeIf(player -> !player.isAlive() || player.level() != getLevel());
 
         // And now find any new players, add them to the tracking list, and broadcast state where appropriate.
-        var sendState = hasOutputChanged() || lightChanged;
-        lightChanged = false;
+        var sendState = hasOutputChanged() || primaryLightChanged || secondaryLightChanged;
+        primaryLightChanged = false;
+        secondaryLightChanged = false;
         if (sendState) {
             // Broadcast the state to all players
             tracking.addAll(getLevel().players());

--- a/projects/common/src/main/java/dan200/computercraft/shared/pocket/core/PocketServerComputer.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/pocket/core/PocketServerComputer.java
@@ -17,6 +17,7 @@ import dan200.computercraft.shared.network.client.PocketComputerDataMessage;
 import dan200.computercraft.shared.network.client.PocketComputerDeletedClientMessage;
 import dan200.computercraft.shared.network.server.ServerNetworking;
 import dan200.computercraft.shared.pocket.items.PocketComputerItem;
+import dan200.computercraft.shared.pocket.peripherals.PocketNFCPeripheral;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
@@ -33,6 +34,7 @@ import java.util.*;
 
 public class PocketServerComputer extends ServerComputer implements IPocketAccess {
     private @Nullable IPocketUpgrade upgrade;
+    private final PocketNFCPeripheral nfc = new PocketNFCPeripheral(this);
     private @Nullable Entity entity;
     private ItemStack stack = ItemStack.EMPTY;
 
@@ -141,6 +143,9 @@ public class PocketServerComputer extends ServerComputer implements IPocketAcces
 
         this.entity = entity;
         this.stack = stack;
+
+        if (getPeripheral(ComputerSide.TOP) != nfc) setPeripheral(ComputerSide.TOP, nfc);
+        nfc.update(this);
 
         if (this.upgrade != upgrade) {
             this.upgrade = upgrade;

--- a/projects/common/src/main/java/dan200/computercraft/shared/pocket/core/PocketServerComputer.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/pocket/core/PocketServerComputer.java
@@ -144,8 +144,8 @@ public class PocketServerComputer extends ServerComputer implements IPocketAcces
         this.entity = entity;
         this.stack = stack;
 
-        if (getPeripheral(ComputerSide.TOP) != nfc) setPeripheral(ComputerSide.TOP, nfc);
         nfc.update(this);
+        if (getPeripheral(ComputerSide.TOP) != nfc) setPeripheral(ComputerSide.TOP, nfc);
 
         if (this.upgrade != upgrade) {
             this.upgrade = upgrade;

--- a/projects/common/src/main/java/dan200/computercraft/shared/pocket/peripherals/PocketModem.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/pocket/peripherals/PocketModem.java
@@ -34,6 +34,6 @@ public class PocketModem extends AbstractPocketUpgrade {
         modem.setLocation(access);
 
         var state = modem.getModemState();
-        if (state.pollChanged()) access.setLight(state.isOpen() ? 0xBA0000 : -1);
+        if (state.pollChanged()) access.setLightPrimary(state.isOpen() ? 0xBA0000 : -1);
     }
 }

--- a/projects/common/src/main/java/dan200/computercraft/shared/pocket/peripherals/PocketNFCPeripheral.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/pocket/peripherals/PocketNFCPeripheral.java
@@ -1,0 +1,30 @@
+package dan200.computercraft.shared.pocket.peripherals;
+
+import dan200.computercraft.api.peripheral.IPeripheral;
+import dan200.computercraft.api.pocket.IPocketAccess;
+
+import javax.annotation.Nullable;
+
+public class PocketNFCPeripheral extends PocketModemPeripheral {
+
+    public PocketNFCPeripheral(IPocketAccess access) {
+        super(false, access);
+    }
+
+    public void update(IPocketAccess access) {
+        setLocation(access);
+
+        var state = getModemState();
+        if (state.pollChanged()) access.setLight(state.isOpen() ? 0xf39d20 : -1);
+    }
+
+    @Override
+    public double getRange() {
+        return 0;
+    }
+
+    @Override
+    public boolean equals(@Nullable IPeripheral other) {
+        return other instanceof PocketNFCPeripheral;
+    }
+}

--- a/projects/common/src/main/java/dan200/computercraft/shared/pocket/peripherals/PocketNFCPeripheral.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/pocket/peripherals/PocketNFCPeripheral.java
@@ -1,11 +1,21 @@
+// SPDX-FileCopyrightText: 2017 The CC: Tweaked Developers
+//
+// SPDX-License-Identifier: MPL-2.0
+
 package dan200.computercraft.shared.pocket.peripherals;
 
+import dan200.computercraft.api.ComputerCraftAPI;
+import dan200.computercraft.api.network.PacketNetwork;
 import dan200.computercraft.api.peripheral.IPeripheral;
 import dan200.computercraft.api.pocket.IPocketAccess;
+import dan200.computercraft.core.util.Nullability;
+import net.minecraft.world.entity.Entity;
 
 import javax.annotation.Nullable;
 
 public class PocketNFCPeripheral extends PocketModemPeripheral {
+
+    private @Nullable Entity entity = null;
 
     public PocketNFCPeripheral(IPocketAccess access) {
         super(false, access);
@@ -19,6 +29,12 @@ public class PocketNFCPeripheral extends PocketModemPeripheral {
     }
 
     @Override
+    void setLocation(IPocketAccess access) {
+        entity = access.getEntity();
+        super.setLocation(access);
+    }
+
+    @Override
     public double getRange() {
         return 0;
     }
@@ -26,5 +42,10 @@ public class PocketNFCPeripheral extends PocketModemPeripheral {
     @Override
     public boolean equals(@Nullable IPeripheral other) {
         return other instanceof PocketNFCPeripheral;
+    }
+
+    @Override
+    protected PacketNetwork getNetwork() {
+        return ComputerCraftAPI.getNfcNetwork(Nullability.assertNonNull(getLevel().getServer()), Nullability.assertNonNull(entity));
     }
 }

--- a/projects/common/src/main/java/dan200/computercraft/shared/pocket/peripherals/PocketNFCPeripheral.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/pocket/peripherals/PocketNFCPeripheral.java
@@ -25,7 +25,7 @@ public class PocketNFCPeripheral extends PocketModemPeripheral {
         setLocation(access);
 
         var state = getModemState();
-        if (state.pollChanged()) access.setLight(state.isOpen() ? 0xf39d20 : -1);
+        if (state.pollChanged()) access.setLightSecondary(state.isOpen() ? 0xf39d20 : -1);
     }
 
     @Override

--- a/projects/common/src/main/java/dan200/computercraft/shared/pocket/peripherals/PocketSpeakerPeripheral.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/pocket/peripherals/PocketSpeakerPeripheral.java
@@ -43,6 +43,6 @@ public class PocketSpeakerPeripheral extends UpgradeSpeakerPeripheral {
 
         super.update();
 
-        access.setLight(madeSound() ? 0x3320fc : -1);
+        access.setLightPrimary(madeSound() ? 0x3320fc : -1);
     }
 }


### PR DESCRIPTION
Attaches a 0-block radius "NFC" wireless modem to the top of the pocket computer. This is done to address the core issue presented in both #1406 and #1688.

TODO:
- [ ] ~~Rename peripheral type to "nfc"~~
- [x] Use per-player wireless network instead of the global one to prevent ender modem sniffing of NFC transmissions.
- [ ] ~~Rename transmission events to "nfc_message"~~

Feedback would be greatly appreciated on this to do list, specifically whether any/all of the items should actually be done.