### PR TITLE
Peripheral tools

### DIFF
--- a/projects/common-api/src/main/java/dan200/computercraft/api/turtle/TurtleUpgradeDataProvider.java
+++ b/projects/common-api/src/main/java/dan200/computercraft/api/turtle/TurtleUpgradeDataProvider.java
@@ -63,6 +63,7 @@ public abstract class TurtleUpgradeDataProvider extends UpgradeDataProvider<ITur
         private @Nullable Item craftingItem;
         private @Nullable Float damageMultiplier = null;
         private @Nullable TagKey<Block> breakable;
+        private String peripheralType = "";
         private boolean allowEnchantments = false;
         private TurtleToolDurability consumeDurability = TurtleToolDurability.NEVER;
 
@@ -93,6 +94,11 @@ public abstract class TurtleUpgradeDataProvider extends UpgradeDataProvider<ITur
          */
         public ToolBuilder craftingItem(Item craftingItem) {
             this.craftingItem = craftingItem;
+            return this;
+        }
+
+        public ToolBuilder peripheralType(String peripheralType) {
+            this.peripheralType = peripheralType;
             return this;
         }
 
@@ -162,6 +168,7 @@ public abstract class TurtleUpgradeDataProvider extends UpgradeDataProvider<ITur
                 if (consumeDurability != TurtleToolDurability.NEVER) {
                     s.addProperty("consumeDurability", consumeDurability.getSerializedName());
                 }
+                s.addProperty("peripheralType", peripheralType);
             }));
         }
     }

--- a/projects/common/src/main/java/dan200/computercraft/data/TurtleUpgradeProvider.java
+++ b/projects/common/src/main/java/dan200/computercraft/data/TurtleUpgradeProvider.java
@@ -28,11 +28,11 @@ class TurtleUpgradeProvider extends TurtleUpgradeDataProvider {
         simpleWithCustomItem(id("wireless_modem_normal"), TurtleSerialisers.WIRELESS_MODEM_NORMAL.get(), Items.WIRELESS_MODEM_NORMAL.get()).add(addUpgrade);
         simpleWithCustomItem(id("wireless_modem_advanced"), TurtleSerialisers.WIRELESS_MODEM_ADVANCED.get(), Items.WIRELESS_MODEM_ADVANCED.get()).add(addUpgrade);
 
-        tool(vanilla("diamond_axe"), net.minecraft.world.item.Items.DIAMOND_AXE).damageMultiplier(6.0f).add(addUpgrade);
-        tool(vanilla("diamond_pickaxe"), net.minecraft.world.item.Items.DIAMOND_PICKAXE).add(addUpgrade);
-        tool(vanilla("diamond_hoe"), net.minecraft.world.item.Items.DIAMOND_HOE).breakable(Blocks.TURTLE_HOE_BREAKABLE).add(addUpgrade);
-        tool(vanilla("diamond_shovel"), net.minecraft.world.item.Items.DIAMOND_SHOVEL).breakable(Blocks.TURTLE_SHOVEL_BREAKABLE).add(addUpgrade);
-        tool(vanilla("diamond_sword"), net.minecraft.world.item.Items.DIAMOND_SWORD).breakable(Blocks.TURTLE_SWORD_BREAKABLE).damageMultiplier(9.0f).add(addUpgrade);
+        tool(vanilla("diamond_axe"), net.minecraft.world.item.Items.DIAMOND_AXE).peripheralType("axe").damageMultiplier(6.0f).add(addUpgrade);
+        tool(vanilla("diamond_pickaxe"), net.minecraft.world.item.Items.DIAMOND_PICKAXE).peripheralType("pickaxe").add(addUpgrade);
+        tool(vanilla("diamond_hoe"), net.minecraft.world.item.Items.DIAMOND_HOE).breakable(Blocks.TURTLE_HOE_BREAKABLE).peripheralType("hoe").add(addUpgrade);
+        tool(vanilla("diamond_shovel"), net.minecraft.world.item.Items.DIAMOND_SHOVEL).breakable(Blocks.TURTLE_SHOVEL_BREAKABLE).peripheralType("shovel").add(addUpgrade);
+        tool(vanilla("diamond_sword"), net.minecraft.world.item.Items.DIAMOND_SWORD).breakable(Blocks.TURTLE_SWORD_BREAKABLE).peripheralType("sword").damageMultiplier(9.0f).add(addUpgrade);
     }
 
     private static ResourceLocation id(String id) {

--- a/projects/common/src/main/java/dan200/computercraft/shared/turtle/upgrades/ToolPeripheral.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/turtle/upgrades/ToolPeripheral.java
@@ -1,8 +1,5 @@
 package dan200.computercraft.shared.turtle.upgrades;
 
-
-import javax.annotation.Nullable;
-
 import dan200.computercraft.api.lua.LuaException;
 import dan200.computercraft.api.lua.LuaFunction;
 import dan200.computercraft.api.lua.MethodResult;
@@ -12,7 +9,9 @@ import dan200.computercraft.api.turtle.TurtleSide;
 import dan200.computercraft.shared.turtle.core.InteractDirection;
 import dan200.computercraft.shared.turtle.core.TurtleToolCommand;
 
-public class ToolPeripheral implements IPeripheral{
+import javax.annotation.Nullable;
+
+public class ToolPeripheral implements IPeripheral {
     private final ITurtleAccess turtle;
     private final TurtleSide side;
     private final String type;

--- a/projects/common/src/main/java/dan200/computercraft/shared/turtle/upgrades/ToolPeripheral.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/turtle/upgrades/ToolPeripheral.java
@@ -1,0 +1,70 @@
+package dan200.computercraft.shared.turtle.upgrades;
+
+
+import javax.annotation.Nullable;
+
+import dan200.computercraft.api.lua.LuaException;
+import dan200.computercraft.api.lua.LuaFunction;
+import dan200.computercraft.api.lua.MethodResult;
+import dan200.computercraft.api.peripheral.IPeripheral;
+import dan200.computercraft.api.turtle.ITurtleAccess;
+import dan200.computercraft.api.turtle.TurtleSide;
+import dan200.computercraft.shared.turtle.core.InteractDirection;
+import dan200.computercraft.shared.turtle.core.TurtleToolCommand;
+
+public class ToolPeripheral implements IPeripheral{
+    private final ITurtleAccess turtle;
+    private final TurtleSide side;
+    private final String type;
+
+    public ToolPeripheral(ITurtleAccess turtle, TurtleSide side, String type) {
+        this.turtle = turtle;
+        this.side = side;
+        this.type = type;
+    }
+
+    @Override
+    public String getType() {
+        return type;
+    }
+
+    @LuaFunction
+    public final MethodResult digDown() throws LuaException {
+        return turtle.executeCommand(TurtleToolCommand.dig(InteractDirection.DOWN, side));
+    }
+
+    @LuaFunction
+    public final MethodResult digUp() throws LuaException {
+        return turtle.executeCommand(TurtleToolCommand.dig(InteractDirection.UP, side));
+    }
+
+    @LuaFunction
+    public final MethodResult dig() throws LuaException {
+        return turtle.executeCommand(TurtleToolCommand.dig(InteractDirection.FORWARD, side));
+    }
+
+    @LuaFunction
+    public final MethodResult attackDown() throws LuaException {
+        return turtle.executeCommand(TurtleToolCommand.attack(InteractDirection.DOWN, side));
+    }
+
+    @LuaFunction
+    public final MethodResult attackUp() throws LuaException {
+        return turtle.executeCommand(TurtleToolCommand.attack(InteractDirection.UP, side));
+    }
+
+    @LuaFunction
+    public final MethodResult attack() throws LuaException {
+        return turtle.executeCommand(TurtleToolCommand.attack(InteractDirection.FORWARD, side));
+    }
+
+    @Override
+    public boolean equals(@Nullable IPeripheral other) {
+        return other instanceof ToolPeripheral && type.equals(other.getType());
+    }
+
+    @Override
+    public Object getTarget() {
+        return turtle;
+    }
+}

--- a/projects/common/src/main/java/dan200/computercraft/shared/turtle/upgrades/TurtleTool.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/turtle/upgrades/TurtleTool.java
@@ -5,6 +5,7 @@
 package dan200.computercraft.shared.turtle.upgrades;
 
 import dan200.computercraft.api.ComputerCraftTags;
+import dan200.computercraft.api.peripheral.IPeripheral;
 import dan200.computercraft.api.turtle.*;
 import dan200.computercraft.shared.platform.PlatformHelper;
 import dan200.computercraft.shared.turtle.TurtleUtil;
@@ -55,17 +56,19 @@ public class TurtleTool extends AbstractTurtleUpgrade {
     final boolean allowEnchantments;
     final TurtleToolDurability consumeDurability;
     final @Nullable TagKey<Block> breakable;
+    final String peripheralType;
 
     public TurtleTool(
         ResourceLocation id, String adjective, Item craftItem, ItemStack toolItem, float damageMulitiplier,
-        boolean allowEnchantments, TurtleToolDurability consumeDurability, @Nullable TagKey<Block> breakable
+        boolean allowEnchantments, TurtleToolDurability consumeDurability, @Nullable TagKey<Block> breakable, String peripheralType
     ) {
-        super(id, TurtleUpgradeType.TOOL, adjective, new ItemStack(craftItem));
+        super(id, TurtleUpgradeType.BOTH, adjective, new ItemStack(craftItem));
         item = toolItem;
         this.damageMulitiplier = damageMulitiplier;
         this.allowEnchantments = allowEnchantments;
         this.consumeDurability = consumeDurability;
         this.breakable = breakable;
+        this.peripheralType = peripheralType;
     }
 
     @Override
@@ -102,6 +105,11 @@ public class TurtleTool extends AbstractTurtleUpgrade {
         var item = super.getUpgradeItem(upgradeData).copy();
         item.setTag(upgradeData.contains(TAG_ITEM_TAG, TAG_COMPOUND) ? upgradeData.getCompound(TAG_ITEM_TAG) : null);
         return item;
+    }
+
+    @Override
+    public IPeripheral createPeripheral(ITurtleAccess turtle, TurtleSide side) {
+        return new ToolPeripheral(turtle, side, peripheralType);
     }
 
     private ItemStack getToolStack(ITurtleAccess turtle, TurtleSide side) {

--- a/projects/common/src/main/java/dan200/computercraft/shared/turtle/upgrades/TurtleToolSerialiser.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/turtle/upgrades/TurtleToolSerialiser.java
@@ -32,6 +32,7 @@ public final class TurtleToolSerialiser implements TurtleUpgradeSerialiser<Turtl
         var craftingItem = GsonHelper.getAsItem(object, "craftingItem", toolItem);
         var damageMultiplier = GsonHelper.getAsFloat(object, "damageMultiplier", 3.0f);
         var allowEnchantments = GsonHelper.getAsBoolean(object, "allowEnchantments", false);
+        var peripheralType = GsonHelper.getAsString(object, "peripheralType", "");
         var consumeDurability = TurtleToolDurability.CODEC.byName(GsonHelper.getAsString(object, "consumeDurability", null), TurtleToolDurability.NEVER);
 
         TagKey<Block> breakable = null;
@@ -40,7 +41,7 @@ public final class TurtleToolSerialiser implements TurtleUpgradeSerialiser<Turtl
             breakable = TagKey.create(Registries.BLOCK, tag);
         }
 
-        return new TurtleTool(id, adjective, craftingItem, new ItemStack(toolItem), damageMultiplier, allowEnchantments, consumeDurability, breakable);
+        return new TurtleTool(id, adjective, craftingItem, new ItemStack(toolItem), damageMultiplier, allowEnchantments, consumeDurability, breakable, peripheralType);
     }
 
     @Override
@@ -54,9 +55,10 @@ public final class TurtleToolSerialiser implements TurtleUpgradeSerialiser<Turtl
         var damageMultiplier = buffer.readFloat();
         var allowsEnchantments = buffer.readBoolean();
         var consumesDurability = buffer.readEnum(TurtleToolDurability.class);
+        var peripheralType = buffer.readUtf();
 
         var breakable = buffer.readNullable(b -> TagKey.create(Registries.BLOCK, b.readResourceLocation()));
-        return new TurtleTool(id, adjective, craftingItem, toolItem, damageMultiplier, allowsEnchantments, consumesDurability, breakable);
+        return new TurtleTool(id, adjective, craftingItem, toolItem, damageMultiplier, allowsEnchantments, consumesDurability, breakable, peripheralType);
     }
 
     @Override
@@ -67,6 +69,7 @@ public final class TurtleToolSerialiser implements TurtleUpgradeSerialiser<Turtl
         buffer.writeFloat(upgrade.damageMulitiplier);
         buffer.writeBoolean(upgrade.allowEnchantments);
         buffer.writeEnum(upgrade.consumeDurability);
+        buffer.writeUtf(upgrade.peripheralType);
         buffer.writeNullable(upgrade.breakable, (b, x) -> b.writeResourceLocation(x.location()));
     }
 }

--- a/projects/forge/src/generated/resources/data/minecraft/computercraft/turtle_upgrades/diamond_axe.json
+++ b/projects/forge/src/generated/resources/data/minecraft/computercraft/turtle_upgrades/diamond_axe.json
@@ -1,1 +1,1 @@
-{"type": "computercraft:tool", "damageMultiplier": 6.0, "item": "minecraft:diamond_axe"}
+{"type": "computercraft:tool", "damageMultiplier": 6.0, "item": "minecraft:diamond_axe", "peripheralType": "axe"}

--- a/projects/forge/src/generated/resources/data/minecraft/computercraft/turtle_upgrades/diamond_hoe.json
+++ b/projects/forge/src/generated/resources/data/minecraft/computercraft/turtle_upgrades/diamond_hoe.json
@@ -1,1 +1,6 @@
-{"type": "computercraft:tool", "breakable": "computercraft:turtle_hoe_harvestable", "item": "minecraft:diamond_hoe"}
+{
+  "type": "computercraft:tool",
+  "breakable": "computercraft:turtle_hoe_harvestable",
+  "item": "minecraft:diamond_hoe",
+  "peripheralType": "hoe"
+}

--- a/projects/forge/src/generated/resources/data/minecraft/computercraft/turtle_upgrades/diamond_pickaxe.json
+++ b/projects/forge/src/generated/resources/data/minecraft/computercraft/turtle_upgrades/diamond_pickaxe.json
@@ -1,1 +1,1 @@
-{"type": "computercraft:tool", "item": "minecraft:diamond_pickaxe"}
+{"type": "computercraft:tool", "item": "minecraft:diamond_pickaxe", "peripheralType": "pickaxe"}

--- a/projects/forge/src/generated/resources/data/minecraft/computercraft/turtle_upgrades/diamond_shovel.json
+++ b/projects/forge/src/generated/resources/data/minecraft/computercraft/turtle_upgrades/diamond_shovel.json
@@ -1,5 +1,6 @@
 {
   "type": "computercraft:tool",
   "breakable": "computercraft:turtle_shovel_harvestable",
-  "item": "minecraft:diamond_shovel"
+  "item": "minecraft:diamond_shovel",
+  "peripheralType": "shovel"
 }

--- a/projects/forge/src/generated/resources/data/minecraft/computercraft/turtle_upgrades/diamond_sword.json
+++ b/projects/forge/src/generated/resources/data/minecraft/computercraft/turtle_upgrades/diamond_sword.json
@@ -2,5 +2,6 @@
   "type": "computercraft:tool",
   "breakable": "computercraft:turtle_sword_harvestable",
   "damageMultiplier": 9.0,
-  "item": "minecraft:diamond_sword"
+  "item": "minecraft:diamond_sword",
+  "peripheralType": "sword"
 }


### PR DESCRIPTION
This is an update to a previously closed pr I had to `mc-1.19.x`.

This fixes https://github.com/cc-tweaked/CC-Tweaked/issues/964 by making pickaxes (and all tools) peripherals in addition to tools. You can use peripheral.getType(side) and get the type of tool.

I haven't added any test cases for the new functionality like peripheral.call("left", "dig"), but I can do that if this seems like a reasonable approach.

Any comments or improvements are welcome!