### PR TITLE
Fix cc.image.nft.draw signature

### DIFF
--- a/projects/core/src/main/resources/data/computercraft/lua/rom/modules/main/cc/image/nft.lua
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/modules/main/cc/image/nft.lua
@@ -89,7 +89,7 @@ end
 --
 -- @tparam table image An image, as returned from [`load`] or [`parse`].
 -- @tparam number xPos The x position to start drawing at.
--- @tparam number xPos The y position to start drawing at.
+-- @tparam number yPos The y position to start drawing at.
 -- @tparam[opt] term.Redirect target The terminal redirect to draw to. Defaults to the
 -- current terminal.
 local function draw(image, xPos, yPos, target)


### PR DESCRIPTION
This corrects duplicate `xPos` parameters in the documentation for the `draw` function in `cc.image.nft`.