### PR TITLE
Add setting bios.shell_path

### DIFF
--- a/projects/core/src/main/resources/data/computercraft/lua/bios.lua
+++ b/projects/core/src/main/resources/data/computercraft/lua/bios.lua
@@ -708,7 +708,7 @@ end
 settings.define("bios.shell_path", {
     default = sShell,
     description = "The path the bios executes as the shell. This program is responsible for implementing the shell and multishell API, handling user input, and program execution.",
-    type = "string"
+    type = "string",
 })
 
 if _CC_DEFAULT_SETTINGS then


### PR DESCRIPTION
Allows the user to directly set the path the bios uses to launch the shell. Setting `bios.shell_path` takes precedent over `bios.use_multishell`. Essentially a custom shell may choose to implement `shell` and `multishell` APIs, independent of whether use_multishell is set. This is loosely reflected in the description of the setting. Also some additional status checking has been implemented to allow for shell errors to be easily read before computer shutdown. 

My justification for adding this is that while [unbios](https://gist.github.com/MCJack123/42bc69d3757226c966da752df80437dc) exists, it is the logical extreme of what I imagine most players want. This PR is the spirit of unbios in a way that makes sense for CC, that advanced players can take advantage of (if I'm not mistaken mbs could benefit from this too, no?) Also servers presumably would ever so slightly benefit from computers that don't *need* a whole shell having the ability to start without one.