### PR TITLE
update lang.zh_cn.item.computercraft.printed_pages

### DIFF
--- a/projects/common/src/main/resources/assets/computercraft/lang/zh_cn.json
+++ b/projects/common/src/main/resources/assets/computercraft/lang/zh_cn.json
@@ -102,7 +102,7 @@
     "item.computercraft.pocket_computer_normal.upgraded": "%s手提计算机",
     "item.computercraft.printed_book": "打印书",
     "item.computercraft.printed_page": "打印纸",
-    "item.computercraft.printed_pages": "打印纸",
+    "item.computercraft.printed_pages": "打印纸簇",
     "item.computercraft.treasure_disk": "软盘",
     "itemGroup.computercraft": "ComputerCraft",
     "tracking_field.computercraft.fs.name": "文件系统操作",


### PR DESCRIPTION
Since in Chinese `Print Page` and `Print Pages` will translate into same thing (`打印纸`), which is difficult to identify each other. I update the translate of `Print Pages` to `打印纸簇` (means `Print Pages Bundle` in English), and it will help us to not mix them up.