### PR TITLE
Update to Minecraft 1.21

### DIFF
--- a/buildSrc/src/main/kotlin/cc/tweaked/gradle/ForgeExtensions.kt
+++ b/buildSrc/src/main/kotlin/cc/tweaked/gradle/ForgeExtensions.kt
@@ -31,9 +31,9 @@ fun JavaExec.setRunConfig(config: Run) {
     environment(config.environmentVariables.get())
     systemProperties(config.systemProperties.get())
 
-    config.modSources.get().forEach { classpath(it.runtimeClasspath) }
+    config.modSources.all().get().values().forEach { classpath(it.runtimeClasspath) }
     classpath(config.classpath)
-    classpath(config.dependencies.get().configuration)
+    classpath(config.dependencies.get().runtimeConfiguration)
 
     (config as RunImpl).taskDependencies.forEach { dependsOn(it) }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,9 +8,11 @@ org.gradle.parallel=true
 kotlin.stdlib.default.dependency=false
 kotlin.jvm.target.validation.mode=error
 
+neogradle.subsystems.conventions.runs.enabled=false
+
 # Mod properties
 isUnstable=true
 modVersion=1.111.0
 
 # Minecraft properties: We want to configure this here so we can read it in settings.gradle
-mcVersion=1.20.6
+mcVersion=1.21

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,14 +7,14 @@
 # Minecraft
 # MC version is specified in gradle.properties, as we need that in settings.gradle.
 # Remember to update corresponding versions in fabric.mod.json/neoforge.mods.toml
-fabric-api = "0.98.0+1.20.6"
-fabric-loader = "0.15.10"
-neoForge = "20.6.48-beta"
+fabric-api = "0.100.1+1.21"
+fabric-loader = "0.15.11"
+neoForge = "21.0.21-beta"
 neoForgeSpi = "8.0.1"
 mixin = "0.8.5"
-parchment = "2024.05.01"
+parchment = "2024.06.16"
 parchmentMc = "1.20.6"
-yarn = "1.20.6+build.1"
+yarn = "1.21+build.1"
 
 # Core dependencies (these versions are tied to the version Minecraft uses)
 fastutil = "8.5.12"
@@ -36,14 +36,14 @@ kotlin-coroutines = "1.7.3"
 nightConfig = "3.6.7"
 
 # Minecraft mods
-emi = "1.1.5+1.20.6"
+emi = "1.1.7+1.21"
 fabricPermissions = "0.3.1"
 iris = "1.6.14+1.20.4"
-jei = "17.3.0.48"
-modmenu = "9.0.0"
+jei = "19.0.0.1"
+modmenu = "11.0.0-rc.4"
 moreRed = "4.0.0.4"
 oculus = "1.2.5"
-rei = "15.0.728"
+rei = "16.0.729"
 rubidium = "0.6.1"
 sodium = "mc1.20-0.4.10"
 mixinExtra = "0.3.5"
@@ -67,7 +67,7 @@ ideaExt = "1.1.7"
 illuaminate = "0.1.0-73-g43ee16c"
 lwjgl = "3.3.3"
 minotaur = "2.8.7"
-neoGradle = "7.0.116"
+neoGradle = "7.0.145"
 nullAway = "0.10.25"
 spotless = "6.23.3"
 taskTree = "2.1.1"
@@ -106,9 +106,9 @@ fabric-junit = { module = "net.fabricmc:fabric-loader-junit", version.ref = "fab
 fabricPermissions = { module = "me.lucko:fabric-permissions-api", version.ref = "fabricPermissions" }
 emi = { module = "dev.emi:emi-xplat-mojmap", version.ref = "emi" }
 iris = { module = "maven.modrinth:iris", version.ref = "iris" }
-jei-api = { module = "mezz.jei:jei-1.20.4-common-api", version.ref = "jei" }
-jei-fabric = { module = "mezz.jei:jei-1.20.4-fabric", version.ref = "jei" }
-jei-forge = { module = "mezz.jei:jei-1.20.4-forge", version.ref = "jei" }
+jei-api = { module = "mezz.jei:jei-1.21-common-api", version.ref = "jei" }
+jei-fabric = { module = "mezz.jei:jei-1.21-fabric", version.ref = "jei" }
+jei-forge = { module = "mezz.jei:jei-1.21-neoforge", version.ref = "jei" }
 mixin = { module = "org.spongepowered:mixin", version.ref = "mixin" }
 mixinExtra = { module = "io.github.llamalad7:mixinextras-common", version.ref = "mixinExtra" }
 modmenu = { module = "com.terraformersmc:modmenu", version.ref = "modmenu" }
@@ -181,7 +181,7 @@ externalMods-common = ["jei-api", "nightConfig-core", "nightConfig-toml"]
 externalMods-forge-compile = ["moreRed", "oculus", "jei-api"]
 externalMods-forge-runtime = []
 externalMods-fabric-compile = ["fabricPermissions", "iris", "jei-api", "rei-api", "rei-builtin"]
-externalMods-fabric-runtime = [] # ["jei-fabric", "modmenu"]
+externalMods-fabric-runtime = ["jei-fabric", "modmenu"]
 
 # Testing
 test = ["junit-jupiter-api", "junit-jupiter-params", "hamcrest", "jqwik-api"]

--- a/projects/common-api/src/client/java/dan200/computercraft/api/client/ModelLocation.java
+++ b/projects/common-api/src/client/java/dan200/computercraft/api/client/ModelLocation.java
@@ -1,0 +1,80 @@
+package dan200.computercraft.api.client;
+
+import dan200.computercraft.api.client.turtle.TurtleUpgradeModeller;
+import dan200.computercraft.impl.client.ClientPlatformHelper;
+import net.minecraft.client.resources.model.BakedModel;
+import net.minecraft.client.resources.model.ModelManager;
+import net.minecraft.client.resources.model.ModelResourceLocation;
+import net.minecraft.resources.ResourceLocation;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.stream.Stream;
+
+/**
+ * The location of a model to load. This may either be:
+ *
+ * <ul>
+ *     <li>A {@link ModelResourceLocation}, referencing an already baked model (such as {@code minecraft:dirt#inventory}).</li>
+ *     <li>
+ *         A {@link ResourceLocation}, referencing a path to a model resource (such as {@code minecraft:item/dirt}.
+ *         These models will be baked and stored in the {@link ModelManager} in a loader-specific way.
+ *     </li>
+ * </ul>
+ */
+public final class ModelLocation {
+    /**
+     * The location of the model.
+     * <p>
+     * When {@link #resourceLocation} is null, this is the location of the model to load. When {@link #resourceLocation}
+     * is non-null, this is the "standalone" variant of the model resource — this is used by Forge's implementation of
+     * {@link ClientPlatformHelper#getModel(ModelManager, ModelResourceLocation, ResourceLocation)} to fetch the model
+     * from the model manger. It is not used on Fabric.
+     */
+    private final ModelResourceLocation modelLocation;
+    private final @Nullable ResourceLocation resourceLocation;
+
+    private ModelLocation(ModelResourceLocation modelLocation, @Nullable ResourceLocation resourceLocation) {
+        this.modelLocation = modelLocation;
+        this.resourceLocation = resourceLocation;
+    }
+
+    /**
+     * Create a {@link ModelLocation} from model in the model manager.
+     *
+     * @param location The name of the model to load.
+     * @return The new {@link ModelLocation} instance.
+     */
+    public static ModelLocation model(ModelResourceLocation location) {
+        return new ModelLocation(location, null);
+    }
+
+    /**
+     * Create a {@link ModelLocation} from a resource.
+     *
+     * @param location The location of the model resource, such as {@code minecraft:item/dirt}.
+     * @return The new {@link ModelLocation} instance.
+     */
+    public static ModelLocation resource(ResourceLocation location) {
+        return new ModelLocation(new ModelResourceLocation(location, "standalone"), location);
+    }
+
+    /**
+     * Get this model from the provided model manager.
+     *
+     * @param manager The model manger.
+     * @return This model, or the missing model if it could not be found.
+     */
+    public BakedModel getModel(ModelManager manager) {
+        return ClientPlatformHelper.get().getModel(manager, modelLocation, resourceLocation);
+    }
+
+    /**
+     * Get the models this model location depends on.
+     *
+     * @return A list of models that this model location depends on.
+     * @see TurtleUpgradeModeller#getDependencies()
+     */
+    public Stream<ResourceLocation> getDependencies() {
+        return resourceLocation == null ? Stream.empty() : Stream.of(resourceLocation);
+    }
+}

--- a/projects/common-api/src/client/java/dan200/computercraft/api/client/TransformedModel.java
+++ b/projects/common-api/src/client/java/dan200/computercraft/api/client/TransformedModel.java
@@ -13,30 +13,47 @@ import net.minecraft.client.resources.model.ModelResourceLocation;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 
-import java.util.Objects;
-
 /**
  * A model to render, combined with a transformation matrix to apply.
+ *
+ * @param model  The model.
+ * @param matrix The transformation matrix.
  */
-public final class TransformedModel {
-    private final BakedModel model;
-    private final Transformation matrix;
-
-    public TransformedModel(BakedModel model, Transformation matrix) {
-        this.model = Objects.requireNonNull(model);
-        this.matrix = Objects.requireNonNull(matrix);
-    }
-
+public record TransformedModel(BakedModel model, Transformation matrix) {
     public TransformedModel(BakedModel model) {
-        this.model = Objects.requireNonNull(model);
-        matrix = Transformation.identity();
+        this(model, Transformation.identity());
     }
 
+    /**
+     * Look up a model in the model bakery and construct a {@link TransformedModel} with no transformation.
+     *
+     * @param location The location of the model to load.
+     * @return The new {@link TransformedModel} instance.
+     */
+    public static TransformedModel of(ModelLocation location) {
+        var modelManager = Minecraft.getInstance().getModelManager();
+        return new TransformedModel(location.getModel(modelManager));
+    }
+
+    /**
+     * Look up a model in the model bakery and construct a {@link TransformedModel} with no transformation.
+     *
+     * @param location The location of the model to load.
+     * @return The new {@link TransformedModel} instance.
+     * @see ModelLocation#model(ModelResourceLocation)
+     */
     public static TransformedModel of(ModelResourceLocation location) {
         var modelManager = Minecraft.getInstance().getModelManager();
         return new TransformedModel(modelManager.getModel(location));
     }
 
+    /**
+     * Look up a model in the model bakery and construct a {@link TransformedModel} with no transformation.
+     *
+     * @param location The location of the model to load.
+     * @return The new {@link TransformedModel} instance.
+     * @see ModelLocation#resource(ResourceLocation)
+     */
     public static TransformedModel of(ResourceLocation location) {
         var modelManager = Minecraft.getInstance().getModelManager();
         return new TransformedModel(ClientPlatformHelper.get().getModel(modelManager, location));
@@ -45,13 +62,5 @@ public final class TransformedModel {
     public static TransformedModel of(ItemStack item, Transformation transform) {
         var model = Minecraft.getInstance().getItemRenderer().getItemModelShaper().getItemModel(item);
         return new TransformedModel(model, transform);
-    }
-
-    public BakedModel getModel() {
-        return model;
-    }
-
-    public Transformation getMatrix() {
-        return matrix;
     }
 }

--- a/projects/common-api/src/client/java/dan200/computercraft/api/client/turtle/TurtleUpgradeModeller.java
+++ b/projects/common-api/src/client/java/dan200/computercraft/api/client/turtle/TurtleUpgradeModeller.java
@@ -4,6 +4,7 @@
 
 package dan200.computercraft.api.client.turtle;
 
+import dan200.computercraft.api.client.ModelLocation;
 import dan200.computercraft.api.client.TransformedModel;
 import dan200.computercraft.api.turtle.ITurtleAccess;
 import dan200.computercraft.api.turtle.ITurtleUpgrade;
@@ -77,6 +78,18 @@ public interface TurtleUpgradeModeller<T extends ITurtleUpgrade> {
      * @return The constructed modeller.
      */
     static <T extends ITurtleUpgrade> TurtleUpgradeModeller<T> sided(ResourceLocation left, ResourceLocation right) {
+        return sided(ModelLocation.resource(left), ModelLocation.resource(right));
+    }
+
+    /**
+     * Construct a {@link TurtleUpgradeModeller} which has a single model for the left and right side.
+     *
+     * @param left  The model to use on the left.
+     * @param right The model to use on the right.
+     * @param <T>   The type of the turtle upgrade.
+     * @return The constructed modeller.
+     */
+    static <T extends ITurtleUpgrade> TurtleUpgradeModeller<T> sided(ModelLocation left, ModelLocation right) {
         return new TurtleUpgradeModeller<>() {
             @Override
             public TransformedModel getModel(T upgrade, @Nullable ITurtleAccess turtle, TurtleSide side, DataComponentPatch data) {
@@ -85,7 +98,7 @@ public interface TurtleUpgradeModeller<T extends ITurtleUpgrade> {
 
             @Override
             public Stream<ResourceLocation> getDependencies() {
-                return Stream.of(left, right);
+                return Stream.of(left, right).flatMap(ModelLocation::getDependencies);
             }
         };
     }

--- a/projects/common-api/src/client/java/dan200/computercraft/impl/client/ClientPlatformHelper.java
+++ b/projects/common-api/src/client/java/dan200/computercraft/impl/client/ClientPlatformHelper.java
@@ -4,6 +4,7 @@
 
 package dan200.computercraft.impl.client;
 
+import dan200.computercraft.api.client.ModelLocation;
 import dan200.computercraft.impl.Services;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.resources.model.BakedModel;
@@ -17,13 +18,28 @@ import javax.annotation.Nullable;
 @ApiStatus.Internal
 public interface ClientPlatformHelper {
     /**
-     * Equivalent to {@link ModelManager#getModel(ModelResourceLocation)} but for arbitrary {@link ResourceLocation}s.
+     * Get a model from a resource.
      *
-     * @param manager  The model manager.
-     * @param location The model location.
+     * @param manager          The model manager.
+     * @param resourceLocation The model resourceLocation.
      * @return The baked model.
+     * @see ModelLocation
      */
-    BakedModel getModel(ModelManager manager, ResourceLocation location);
+    BakedModel getModel(ModelManager manager, ResourceLocation resourceLocation);
+
+    /**
+     * Set a model from a {@link ModelResourceLocation} or {@link ResourceLocation}.
+     * <p>
+     * This is largely equivalent to {@code resourceLocation == null ? manager.getModel(modelLocation) : getModel(manager, resourceLocation)},
+     * but allows pre-computing {@code modelLocation} (if needed).
+     *
+     * @param manager          The model manager.
+     * @param modelLocation    The location of the model to load.
+     * @param resourceLocation The location of the resource, if trying to load from a resource.
+     * @return The baked model.
+     * @see ModelLocation
+     */
+    BakedModel getModel(ModelManager manager, ModelResourceLocation modelLocation, @Nullable ResourceLocation resourceLocation);
 
     /**
      * Wrap this model in a version which renders a foil/enchantment glint.

--- a/projects/common-api/src/main/java/dan200/computercraft/api/ComputerCraftTags.java
+++ b/projects/common-api/src/main/java/dan200/computercraft/api/ComputerCraftTags.java
@@ -46,7 +46,7 @@ public class ComputerCraftTags {
         public static final TagKey<Item> DYEABLE = make("dyeable");
 
         private static TagKey<Item> make(String name) {
-            return TagKey.create(Registries.ITEM, new ResourceLocation(ComputerCraftAPI.MOD_ID, name));
+            return TagKey.create(Registries.ITEM, ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, name));
         }
     }
 
@@ -91,7 +91,7 @@ public class ComputerCraftTags {
         public static final TagKey<Block> TURTLE_CAN_USE = make("turtle_can_use");
 
         private static TagKey<Block> make(String name) {
-            return TagKey.create(Registries.BLOCK, new ResourceLocation(ComputerCraftAPI.MOD_ID, name));
+            return TagKey.create(Registries.BLOCK, ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, name));
         }
     }
 }

--- a/projects/common-api/src/main/java/dan200/computercraft/api/media/IMedia.java
+++ b/projects/common-api/src/main/java/dan200/computercraft/api/media/IMedia.java
@@ -7,11 +7,13 @@ package dan200.computercraft.api.media;
 import dan200.computercraft.api.ComputerCraftAPI;
 import dan200.computercraft.api.filesystem.Mount;
 import dan200.computercraft.api.filesystem.WritableMount;
+import net.minecraft.core.Holder;
+import net.minecraft.core.HolderLookup;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
-import net.minecraft.sounds.SoundEvent;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.JukeboxSong;
 
 import javax.annotation.Nullable;
 
@@ -25,11 +27,12 @@ public interface IMedia {
     /**
      * Get a string representing the label of this item. Will be called via {@code disk.getLabel()} in lua.
      *
-     * @param stack The {@link ItemStack} to inspect.
+     * @param registries The currently loaded registries.
+     * @param stack      The {@link ItemStack} to inspect.
      * @return The label. ie: "Dan's Programs".
      */
     @Nullable
-    String getLabel(ItemStack stack);
+    String getLabel(HolderLookup.Provider registries, ItemStack stack);
 
     /**
      * Set a string representing the label of this item. Will be called vi {@code disk.setLabel()} in lua.
@@ -43,26 +46,15 @@ public interface IMedia {
     }
 
     /**
-     * If this disk represents an item with audio (like a record), get the readable name of the audio track. ie:
-     * "Jonathan Coulton - Still Alive"
+     * If this disk represents an item with audio (like a record), get the corresponding {@link JukeboxSong}.
      *
-     * @param stack The {@link ItemStack} to modify.
-     * @return The name, or null if this item does not represent an item with audio.
+     * @param registries The currently loaded registries.
+     * @param stack      The {@link ItemStack} to query.
+     * @return The song, or null if this item does not represent an item with audio.
      */
     @Nullable
-    default String getAudioTitle(ItemStack stack) {
-        return null;
-    }
-
-    /**
-     * If this disk represents an item with audio (like a record), get the resource name of the audio track to play.
-     *
-     * @param stack The {@link ItemStack} to modify.
-     * @return The name, or null if this item does not represent an item with audio.
-     */
-    @Nullable
-    default SoundEvent getAudio(ItemStack stack) {
-        return null;
+    default Holder<JukeboxSong> getAudio(HolderLookup.Provider registries, ItemStack stack) {
+        return JukeboxSong.fromStack(registries, stack).orElse(null);
     }
 
     /**

--- a/projects/common-api/src/main/java/dan200/computercraft/api/pocket/IPocketUpgrade.java
+++ b/projects/common-api/src/main/java/dan200/computercraft/api/pocket/IPocketUpgrade.java
@@ -48,7 +48,7 @@ import javax.annotation.Nullable;
  * }
  */
 public interface IPocketUpgrade extends UpgradeBase {
-    ResourceKey<Registry<IPocketUpgrade>> REGISTRY = ResourceKey.createRegistryKey(new ResourceLocation(ComputerCraftAPI.MOD_ID, "pocket_upgrade"));
+    ResourceKey<Registry<IPocketUpgrade>> REGISTRY = ResourceKey.createRegistryKey(ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "pocket_upgrade"));
 
     /**
      * The registry key for pocket upgrade types.

--- a/projects/common-api/src/main/java/dan200/computercraft/api/turtle/ITurtleUpgrade.java
+++ b/projects/common-api/src/main/java/dan200/computercraft/api/turtle/ITurtleUpgrade.java
@@ -57,7 +57,7 @@ public interface ITurtleUpgrade extends UpgradeBase {
     /**
      * The registry in which turtle upgrades are stored.
      */
-    ResourceKey<Registry<ITurtleUpgrade>> REGISTRY = ResourceKey.createRegistryKey(new ResourceLocation(ComputerCraftAPI.MOD_ID, "turtle_upgrade"));
+    ResourceKey<Registry<ITurtleUpgrade>> REGISTRY = ResourceKey.createRegistryKey(ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "turtle_upgrade"));
 
     /**
      * Create a {@link ResourceKey} for a turtle upgrade given a {@link ResourceLocation}.

--- a/projects/common-api/src/main/java/dan200/computercraft/api/turtle/TurtleToolBuilder.java
+++ b/projects/common-api/src/main/java/dan200/computercraft/api/turtle/TurtleToolBuilder.java
@@ -35,7 +35,7 @@ import java.util.Optional;
  * import net.minecraft.world.item.Items;
  *
  * public void registerTool(BootstrapContext<ITurtleUpgrade> upgrades) {
- *   TurtleToolBuilder.tool(new ResourceLocation("my_mod", "wooden_pickaxe"), Items.WOODEN_PICKAXE).register(upgrades);
+ *   TurtleToolBuilder.tool(ResourceLocation.fromNamespaceAndPath("my_mod", "wooden_pickaxe"), Items.WOODEN_PICKAXE).register(upgrades);
  * }
  *}
  */

--- a/projects/common-api/src/main/java/dan200/computercraft/api/upgrades/UpgradeType.java
+++ b/projects/common-api/src/main/java/dan200/computercraft/api/upgrades/UpgradeType.java
@@ -55,7 +55,7 @@ import java.util.function.Function;
  * public void generate(DataGenerator.PackGenerator output, CompletableFuture<HolderLookup.Provider> registries) {
  *     var newRegistries = RegistryPatchGenerator.createLookup(registries, Util.make(new RegistrySetBuilder(), builder -> {
  *         builder.add(ITurtleUpgrade.REGISTRY, upgrades -> {
- *             upgrades.register(ITurtleUpgrade.createKey(new ResourceLocation("my_mod", "my_upgrade")), new MyUpgrade());
+ *             upgrades.register(ITurtleUpgrade.createKey(ResourceLocation.fromNamespaceAndPath("my_mod", "my_upgrade")), new MyUpgrade());
  *         });
  *     }));
  *     output.addProvider(o -> new DatapackBuiltinEntriesProvider(o, newRegistries, Set.of("my_mod")));

--- a/projects/common/src/client/java/dan200/computercraft/client/ClientRegistry.java
+++ b/projects/common/src/client/java/dan200/computercraft/client/ClientRegistry.java
@@ -118,12 +118,12 @@ public final class ClientRegistry {
 
     public static void registerTurtleModellers(RegisterTurtleUpgradeModeller register) {
         register.register(ModRegistry.TurtleUpgradeTypes.SPEAKER.get(), TurtleUpgradeModeller.sided(
-            new ResourceLocation(ComputerCraftAPI.MOD_ID, "block/turtle_speaker_left"),
-            new ResourceLocation(ComputerCraftAPI.MOD_ID, "block/turtle_speaker_right")
+            ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "block/turtle_speaker_left"),
+            ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "block/turtle_speaker_right")
         ));
         register.register(ModRegistry.TurtleUpgradeTypes.WORKBENCH.get(), TurtleUpgradeModeller.sided(
-            new ResourceLocation(ComputerCraftAPI.MOD_ID, "block/turtle_crafting_table_left"),
-            new ResourceLocation(ComputerCraftAPI.MOD_ID, "block/turtle_crafting_table_right")
+            ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "block/turtle_crafting_table_left"),
+            ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "block/turtle_crafting_table_right")
         ));
         register.register(ModRegistry.TurtleUpgradeTypes.WIRELESS_MODEM.get(), new TurtleModemModeller());
         register.register(ModRegistry.TurtleUpgradeTypes.TOOL.get(), TurtleUpgradeModeller.flatItem());
@@ -131,7 +131,7 @@ public final class ClientRegistry {
 
     @SafeVarargs
     private static void registerItemProperty(RegisterItemProperty itemProperties, String name, ClampedItemPropertyFunction getter, Supplier<? extends Item>... items) {
-        var id = new ResourceLocation(ComputerCraftAPI.MOD_ID, name);
+        var id = ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, name);
         for (var item : items) itemProperties.register(item.get(), id, getter);
     }
 
@@ -155,7 +155,7 @@ public final class ClientRegistry {
     };
 
     public static void registerExtraModels(Consumer<ResourceLocation> register) {
-        for (var model : EXTRA_MODELS) register.accept(new ResourceLocation(ComputerCraftAPI.MOD_ID, model));
+        for (var model : EXTRA_MODELS) register.accept(ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, model));
         TurtleUpgradeModellers.getDependencies().forEach(register);
     }
 

--- a/projects/common/src/client/java/dan200/computercraft/client/gui/DiskDriveScreen.java
+++ b/projects/common/src/client/java/dan200/computercraft/client/gui/DiskDriveScreen.java
@@ -15,7 +15,7 @@ import net.minecraft.world.entity.player.Inventory;
  * The GUI for disk drives.
  */
 public class DiskDriveScreen extends AbstractContainerScreen<DiskDriveMenu> {
-    private static final ResourceLocation BACKGROUND = new ResourceLocation("computercraft", "textures/gui/disk_drive.png");
+    private static final ResourceLocation BACKGROUND = ResourceLocation.fromNamespaceAndPath("computercraft", "textures/gui/disk_drive.png");
 
     public DiskDriveScreen(DiskDriveMenu container, Inventory player, Component title) {
         super(container, player, title);

--- a/projects/common/src/client/java/dan200/computercraft/client/gui/GuiSprites.java
+++ b/projects/common/src/client/java/dan200/computercraft/client/gui/GuiSprites.java
@@ -21,7 +21,7 @@ import java.util.stream.Stream;
  * Sprite sheet for all GUI texutres in the mod.
  */
 public final class GuiSprites extends TextureAtlasHolder {
-    public static final ResourceLocation SPRITE_SHEET = new ResourceLocation(ComputerCraftAPI.MOD_ID, "gui");
+    public static final ResourceLocation SPRITE_SHEET = ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "gui");
     public static final ResourceLocation TEXTURE = SPRITE_SHEET.withPath(x -> "textures/atlas/" + x + ".png");
 
     public static final ButtonTextures TURNED_OFF = button("turned_off");
@@ -35,16 +35,16 @@ public final class GuiSprites extends TextureAtlasHolder {
 
     private static ButtonTextures button(String name) {
         return new ButtonTextures(
-            new ResourceLocation(ComputerCraftAPI.MOD_ID, "gui/buttons/" + name),
-            new ResourceLocation(ComputerCraftAPI.MOD_ID, "gui/buttons/" + name + "_hover")
+            ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "gui/buttons/" + name),
+            ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "gui/buttons/" + name + "_hover")
         );
     }
 
     private static ComputerTextures computer(String name, boolean pocket, boolean sidebar) {
         return new ComputerTextures(
-            new ResourceLocation(ComputerCraftAPI.MOD_ID, "gui/border_" + name),
-            pocket ? new ResourceLocation(ComputerCraftAPI.MOD_ID, "gui/pocket_bottom_" + name) : null,
-            sidebar ? new ResourceLocation(ComputerCraftAPI.MOD_ID, "gui/sidebar_" + name) : null
+            ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "gui/border_" + name),
+            pocket ? ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "gui/pocket_bottom_" + name) : null,
+            sidebar ? ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "gui/sidebar_" + name) : null
         );
     }
 

--- a/projects/common/src/client/java/dan200/computercraft/client/gui/ItemToast.java
+++ b/projects/common/src/client/java/dan200/computercraft/client/gui/ItemToast.java
@@ -19,7 +19,7 @@ import java.util.List;
  * A {@link Toast} implementation which displays an arbitrary message along with an optional {@link ItemStack}.
  */
 public class ItemToast implements Toast {
-    private static final ResourceLocation TEXTURE = new ResourceLocation("toast/recipe");
+    private static final ResourceLocation TEXTURE = ResourceLocation.withDefaultNamespace("toast/recipe");
     public static final Object TRANSFER_NO_RESPONSE_TOKEN = new Object();
 
     private static final long DISPLAY_TIME = 7000L;

--- a/projects/common/src/client/java/dan200/computercraft/client/gui/OptionScreen.java
+++ b/projects/common/src/client/java/dan200/computercraft/client/gui/OptionScreen.java
@@ -24,7 +24,7 @@ import static dan200.computercraft.core.util.Nullability.assertNonNull;
  * When closed, it returns to the previous screen.
  */
 public final class OptionScreen extends Screen {
-    private static final ResourceLocation BACKGROUND = new ResourceLocation("computercraft", "textures/gui/blank_screen.png");
+    private static final ResourceLocation BACKGROUND = ResourceLocation.fromNamespaceAndPath("computercraft", "textures/gui/blank_screen.png");
 
     public static final int BUTTON_WIDTH = 100;
     public static final int BUTTON_HEIGHT = 20;

--- a/projects/common/src/client/java/dan200/computercraft/client/gui/PrinterScreen.java
+++ b/projects/common/src/client/java/dan200/computercraft/client/gui/PrinterScreen.java
@@ -15,7 +15,7 @@ import net.minecraft.world.entity.player.Inventory;
  * The GUI for printers.
  */
 public class PrinterScreen extends AbstractContainerScreen<PrinterMenu> {
-    private static final ResourceLocation BACKGROUND = new ResourceLocation("computercraft", "textures/gui/printer.png");
+    private static final ResourceLocation BACKGROUND = ResourceLocation.fromNamespaceAndPath("computercraft", "textures/gui/printer.png");
 
     public PrinterScreen(PrinterMenu container, Inventory player, Component title) {
         super(container, player, title);

--- a/projects/common/src/client/java/dan200/computercraft/client/gui/PrintoutScreen.java
+++ b/projects/common/src/client/java/dan200/computercraft/client/gui/PrintoutScreen.java
@@ -4,7 +4,6 @@
 
 package dan200.computercraft.client.gui;
 
-import com.mojang.blaze3d.vertex.Tesselator;
 import dan200.computercraft.core.terminal.TextBuffer;
 import dan200.computercraft.shared.ModRegistry;
 import dan200.computercraft.shared.common.HeldItemMenu;
@@ -12,7 +11,6 @@ import dan200.computercraft.shared.media.items.PrintoutData;
 import dan200.computercraft.shared.media.items.PrintoutItem;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
-import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.player.Inventory;
 import org.lwjgl.glfw.GLFW;
@@ -90,10 +88,8 @@ public class PrintoutScreen extends AbstractContainerScreen<HeldItemMenu> {
         graphics.pose().pushPose();
         graphics.pose().translate(0, 0, 1);
 
-        var renderer = MultiBufferSource.immediate(Tesselator.getInstance().getBuilder());
-        drawBorder(graphics.pose(), renderer, leftPos, topPos, 0, page, pages, book, FULL_BRIGHT_LIGHTMAP);
-        drawText(graphics.pose(), renderer, leftPos + X_TEXT_MARGIN, topPos + Y_TEXT_MARGIN, PrintoutData.LINES_PER_PAGE * page, FULL_BRIGHT_LIGHTMAP, text, colours);
-        renderer.endBatch();
+        drawBorder(graphics.pose(), graphics.bufferSource(), leftPos, topPos, 0, page, pages, book, FULL_BRIGHT_LIGHTMAP);
+        drawText(graphics.pose(), graphics.bufferSource(), leftPos + X_TEXT_MARGIN, topPos + Y_TEXT_MARGIN, PrintoutData.LINES_PER_PAGE * page, FULL_BRIGHT_LIGHTMAP, text, colours);
 
         graphics.pose().popPose();
     }

--- a/projects/common/src/client/java/dan200/computercraft/client/gui/TurtleScreen.java
+++ b/projects/common/src/client/java/dan200/computercraft/client/gui/TurtleScreen.java
@@ -23,8 +23,8 @@ import static dan200.computercraft.shared.turtle.inventory.TurtleMenu.*;
  * The GUI for turtles.
  */
 public class TurtleScreen extends AbstractComputerScreen<TurtleMenu> {
-    private static final ResourceLocation BACKGROUND_NORMAL = new ResourceLocation(ComputerCraftAPI.MOD_ID, "textures/gui/turtle_normal.png");
-    private static final ResourceLocation BACKGROUND_ADVANCED = new ResourceLocation(ComputerCraftAPI.MOD_ID, "textures/gui/turtle_advanced.png");
+    private static final ResourceLocation BACKGROUND_NORMAL = ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "textures/gui/turtle_normal.png");
+    private static final ResourceLocation BACKGROUND_ADVANCED = ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "textures/gui/turtle_advanced.png");
 
     private static final int TEX_WIDTH = 278;
     private static final int TEX_HEIGHT = 217;

--- a/projects/common/src/client/java/dan200/computercraft/client/gui/widgets/TerminalWidget.java
+++ b/projects/common/src/client/java/dan200/computercraft/client/gui/widgets/TerminalWidget.java
@@ -4,7 +4,6 @@
 
 package dan200.computercraft.client.gui.widgets;
 
-import com.mojang.blaze3d.vertex.Tesselator;
 import dan200.computercraft.client.render.RenderTypes;
 import dan200.computercraft.client.render.text.FixedWidthFontRenderer;
 import dan200.computercraft.core.terminal.Terminal;
@@ -16,7 +15,6 @@ import net.minecraft.client.gui.components.AbstractWidget;
 import net.minecraft.client.gui.narration.NarratedElementType;
 import net.minecraft.client.gui.narration.NarrationElementOutput;
 import net.minecraft.client.gui.screens.Screen;
-import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.network.chat.Component;
 import org.lwjgl.glfw.GLFW;
 
@@ -259,15 +257,12 @@ public class TerminalWidget extends AbstractWidget {
     public void renderWidget(GuiGraphics graphics, int mouseX, int mouseY, float partialTicks) {
         if (!visible) return;
 
-        var bufferSource = MultiBufferSource.immediate(Tesselator.getInstance().getBuilder());
-        var emitter = FixedWidthFontRenderer.toVertexConsumer(graphics.pose(), bufferSource.getBuffer(RenderTypes.TERMINAL));
+        var emitter = FixedWidthFontRenderer.toVertexConsumer(graphics.pose(), graphics.bufferSource().getBuffer(RenderTypes.TERMINAL));
 
         FixedWidthFontRenderer.drawTerminal(
             emitter,
             (float) innerX, (float) innerY, terminal, (float) MARGIN, (float) MARGIN, (float) MARGIN, (float) MARGIN
         );
-
-        bufferSource.endBatch();
     }
 
     @Override

--- a/projects/common/src/client/java/dan200/computercraft/client/model/turtle/ModelTransformer.java
+++ b/projects/common/src/client/java/dan200/computercraft/client/model/turtle/ModelTransformer.java
@@ -4,11 +4,9 @@
 
 package dan200.computercraft.client.model.turtle;
 
-import com.mojang.blaze3d.vertex.DefaultVertexFormat;
-import com.mojang.blaze3d.vertex.VertexFormat;
-import com.mojang.blaze3d.vertex.VertexFormatElement;
 import com.mojang.math.Transformation;
 import net.minecraft.client.renderer.block.model.BakedQuad;
+import net.minecraft.client.renderer.block.model.FaceBakery;
 import net.minecraft.client.resources.model.BakedModel;
 import net.minecraft.core.Direction;
 import org.joml.Matrix4f;
@@ -29,8 +27,8 @@ import java.util.List;
 public class ModelTransformer {
     private static final int[] INVERSE_ORDER = new int[]{ 3, 2, 1, 0 };
 
-    private static final int STRIDE = DefaultVertexFormat.BLOCK.getIntegerSize();
-    private static final int POS_OFFSET = findOffset(DefaultVertexFormat.BLOCK, DefaultVertexFormat.ELEMENT_POSITION);
+    private static final int STRIDE = FaceBakery.VERTEX_INT_SIZE;
+    private static final int POS_OFFSET = 0;
 
     protected final Matrix4f transformation;
     protected final boolean invert;
@@ -90,14 +88,5 @@ public class ModelTransformer {
     }
 
     private record TransformedQuads(List<BakedQuad> original, List<BakedQuad> transformed) {
-    }
-
-    private static int findOffset(VertexFormat format, VertexFormatElement element) {
-        var offset = 0;
-        for (var other : format.getElements()) {
-            if (other == element) return offset / Integer.BYTES;
-            offset += element.getByteSize();
-        }
-        throw new IllegalArgumentException("Cannot find " + element + " in " + format);
     }
 }

--- a/projects/common/src/client/java/dan200/computercraft/client/model/turtle/TurtleModelParts.java
+++ b/projects/common/src/client/java/dan200/computercraft/client/model/turtle/TurtleModelParts.java
@@ -85,7 +85,7 @@ public final class TurtleModelParts<T> {
     public TurtleModelParts(BakedModel familyModel, BakedModel colourModel, ModelTransformer transformer, Function<List<BakedModel>, T> combineModel) {
         this.familyModel = familyModel;
         this.colourModel = colourModel;
-        this.transformer = x -> transformer.transform(x.getModel(), x.getMatrix());
+        this.transformer = x -> transformer.transform(x.model(), x.matrix());
         buildModel = x -> combineModel.apply(buildModel(x));
     }
 
@@ -127,7 +127,7 @@ public final class TurtleModelParts<T> {
     private void addUpgrade(List<BakedModel> parts, Transformation transformation, TurtleSide side, @Nullable UpgradeData<ITurtleUpgrade> upgrade) {
         if (upgrade == null) return;
         var model = TurtleUpgradeModellers.getModel(upgrade.upgrade(), upgrade.data(), side);
-        parts.add(transform(model.getModel(), transformation.compose(model.getMatrix())));
+        parts.add(transform(model.model(), transformation.compose(model.matrix())));
     }
 
     private BakedModel transform(BakedModel model, Transformation transformation) {

--- a/projects/common/src/client/java/dan200/computercraft/client/platform/ClientNetworkContextImpl.java
+++ b/projects/common/src/client/java/dan200/computercraft/client/platform/ClientNetworkContextImpl.java
@@ -21,10 +21,11 @@ import dan200.computercraft.shared.peripheral.speaker.EncodedAudio;
 import dan200.computercraft.shared.peripheral.speaker.SpeakerPosition;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Holder;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.sounds.SoundEvent;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.JukeboxSong;
 import net.minecraft.world.level.Level;
 
 import javax.annotation.Nullable;
@@ -60,10 +61,12 @@ public final class ClientNetworkContextImpl implements ClientNetworkContext {
     }
 
     @Override
-    public void handlePlayRecord(BlockPos pos, @Nullable SoundEvent sound, @Nullable String name) {
-        var mc = Minecraft.getInstance();
-        ClientPlatformHelper.get().playStreamingMusic(pos, sound);
-        if (name != null) mc.gui.setNowPlaying(Component.literal(name));
+    public void handlePlayRecord(BlockPos pos, @Nullable Holder<JukeboxSong> song) {
+        if (song == null) {
+            Minecraft.getInstance().levelRenderer.stopJukeboxSongAndNotifyNearby(pos);
+        } else {
+            Minecraft.getInstance().levelRenderer.playJukeboxSong(song, pos);
+        }
     }
 
     @Override

--- a/projects/common/src/client/java/dan200/computercraft/client/platform/ClientPlatformHelper.java
+++ b/projects/common/src/client/java/dan200/computercraft/client/platform/ClientPlatformHelper.java
@@ -7,8 +7,6 @@ package dan200.computercraft.client.platform;
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.resources.model.BakedModel;
-import net.minecraft.core.BlockPos;
-import net.minecraft.sounds.SoundEvent;
 
 import javax.annotation.Nullable;
 
@@ -28,13 +26,4 @@ public interface ClientPlatformHelper extends dan200.computercraft.impl.client.C
      * @param tints         Block colour tints to apply to the model.
      */
     void renderBakedModel(PoseStack transform, MultiBufferSource buffers, BakedModel model, int lightmapCoord, int overlayLight, @Nullable int[] tints);
-
-    /**
-     * Play a record at a particular position.
-     *
-     * @param pos   The position to play this record.
-     * @param sound The record to play, or {@code null} to stop it.
-     * @see net.minecraft.client.renderer.LevelRenderer#playStreamingMusic(SoundEvent, BlockPos)
-     */
-    void playStreamingMusic(BlockPos pos, @Nullable SoundEvent sound);
 }

--- a/projects/common/src/client/java/dan200/computercraft/client/render/CableHighlightRenderer.java
+++ b/projects/common/src/client/java/dan200/computercraft/client/render/CableHighlightRenderer.java
@@ -62,15 +62,13 @@ public final class CableHighlightRenderer {
             zDelta = zDelta / len;
 
             buffer
-                .vertex(matrix4f, (float) (x1 + xOffset), (float) (y1 + yOffset), (float) (z1 + zOffset))
-                .color(0, 0, 0, 0.4f)
-                .normal(transform.last(), xDelta, yDelta, zDelta)
-                .endVertex();
+                .addVertex(matrix4f, (float) (x1 + xOffset), (float) (y1 + yOffset), (float) (z1 + zOffset))
+                .setColor(0, 0, 0, 0.4f)
+                .setNormal(transform.last(), xDelta, yDelta, zDelta);
             buffer
-                .vertex(matrix4f, (float) (x2 + xOffset), (float) (y2 + yOffset), (float) (z2 + zOffset))
-                .color(0, 0, 0, 0.4f)
-                .normal(transform.last(), xDelta, yDelta, zDelta)
-                .endVertex();
+                .addVertex(matrix4f, (float) (x2 + xOffset), (float) (y2 + yOffset), (float) (z2 + zOffset))
+                .setColor(0, 0, 0, 0.4f)
+                .setNormal(transform.last(), xDelta, yDelta, zDelta);
         });
 
         return true;

--- a/projects/common/src/client/java/dan200/computercraft/client/render/ModelRenderer.java
+++ b/projects/common/src/client/java/dan200/computercraft/client/render/ModelRenderer.java
@@ -50,28 +50,23 @@ public final class ModelRenderer {
                 if (idx >= 0 && idx < tints.length) tint = tints[bakedquad.getTintIndex()];
             }
 
-            var r = (float) (tint >> 16 & 255) / 255.0F;
-            var g = (float) (tint >> 8 & 255) / 255.0F;
-            var b = (float) (tint & 255) / 255.0F;
-            putBulkQuad(buffer, matrix, bakedquad, r, g, b, lightmapCoord, overlayLight, inverted);
+            putBulkQuad(buffer, matrix, bakedquad, tint, lightmapCoord, overlayLight, inverted);
         }
     }
 
     /**
-     * A version of {@link VertexConsumer#putBulkData(PoseStack.Pose, BakedQuad, float, float, float, int, int)} which
+     * A version of {@link VertexConsumer#putBulkData(PoseStack.Pose, BakedQuad, float, float, float, float, int, int)} which
      * will reverse vertex order when the matrix is inverted.
      *
      * @param buffer        The buffer to draw to.
      * @param pose          The current matrix stack.
      * @param quad          The quad to draw.
-     * @param red           The red tint of this quad.
-     * @param green         The  green tint of this quad.
-     * @param blue          The blue tint of this quad.
+     * @param colour        The tint for this quad.
      * @param lightmapCoord The lightmap coordinate
      * @param overlayLight  The overlay light.
      * @param invert        Whether to reverse the order of this quad.
      */
-    private static void putBulkQuad(VertexConsumer buffer, PoseStack.Pose pose, BakedQuad quad, float red, float green, float blue, int lightmapCoord, int overlayLight, boolean invert) {
+    private static void putBulkQuad(VertexConsumer buffer, PoseStack.Pose pose, BakedQuad quad, int colour, int lightmapCoord, int overlayLight, boolean invert) {
         var matrix = pose.pose();
         // It's a little dubious to transform using this matrix rather than the normal matrix. This mirrors the logic in
         // Direction.rotate (so not out of nowhere!), but is a little suspicious.
@@ -93,9 +88,9 @@ public final class ModelRenderer {
 
             var u = Float.intBitsToFloat(vertices[i + 4]);
             var v = Float.intBitsToFloat(vertices[i + 5]);
-            buffer.vertex(
+            buffer.addVertex(
                 vector.x(), vector.y(), vector.z(),
-                red, green, blue, 1.0F, u, v, overlayLight, lightmapCoord,
+                colour, u, v, overlayLight, lightmapCoord,
                 normalX, normalY, normalZ
             );
         }

--- a/projects/common/src/client/java/dan200/computercraft/client/render/PrintoutRenderer.java
+++ b/projects/common/src/client/java/dan200/computercraft/client/render/PrintoutRenderer.java
@@ -158,7 +158,7 @@ public final class PrintoutRenderer {
     }
 
     private static void vertex(VertexConsumer buffer, Matrix4f matrix, float x, float y, float z, float u, float v, int light) {
-        buffer.vertex(matrix, x, y, z).color(255, 255, 255, 255).uv(u, v).uv2(light).endVertex();
+        buffer.addVertex(matrix, x, y, z).setColor(255, 255, 255, 255).setUv(u, v).setLight(light);
     }
 
     public static float offsetAt(int page) {

--- a/projects/common/src/client/java/dan200/computercraft/client/render/RenderTypes.java
+++ b/projects/common/src/client/java/dan200/computercraft/client/render/RenderTypes.java
@@ -52,7 +52,7 @@ public class RenderTypes {
      * Printout's background texture. {@link RenderType#text(ResourceLocation)} is a <em>little</em> questionable, but
      * it is what maps use, so should behave the same as vanilla in both item frames and in-hand.
      */
-    public static final RenderType PRINTOUT_BACKGROUND = RenderType.text(new ResourceLocation("computercraft", "textures/gui/printout.png"));
+    public static final RenderType PRINTOUT_BACKGROUND = RenderType.text(ResourceLocation.fromNamespaceAndPath("computercraft", "textures/gui/printout.png"));
 
     /**
      * Render type for {@linkplain GuiSprites GUI sprites}.

--- a/projects/common/src/client/java/dan200/computercraft/client/render/SpriteRenderer.java
+++ b/projects/common/src/client/java/dan200/computercraft/client/render/SpriteRenderer.java
@@ -118,10 +118,10 @@ public class SpriteRenderer {
      */
     public void blit(
         int x, int y, int width, int height, float u0, float v0, float u1, float v1) {
-        builder.vertex(transform, x, y + height, z).color(r, g, b, 255).uv(u0, v1).uv2(light).endVertex();
-        builder.vertex(transform, x + width, y + height, z).color(r, g, b, 255).uv(u1, v1).uv2(light).endVertex();
-        builder.vertex(transform, x + width, y, z).color(r, g, b, 255).uv(u1, v0).uv2(light).endVertex();
-        builder.vertex(transform, x, y, z).color(r, g, b, 255).uv(u0, v0).uv2(light).endVertex();
+        builder.addVertex(transform, x, y + height, z).setColor(r, g, b, 255).setUv(u0, v1).setLight(light);
+        builder.addVertex(transform, x + width, y + height, z).setColor(r, g, b, 255).setUv(u1, v1).setLight(light);
+        builder.addVertex(transform, x + width, y, z).setColor(r, g, b, 255).setUv(u1, v0).setLight(light);
+        builder.addVertex(transform, x, y, z).setColor(r, g, b, 255).setUv(u0, v0).setLight(light);
     }
 
     public static float u(TextureAtlasSprite sprite, int x, int width) {

--- a/projects/common/src/client/java/dan200/computercraft/client/render/TurtleBlockEntityRenderer.java
+++ b/projects/common/src/client/java/dan200/computercraft/client/render/TurtleBlockEntityRenderer.java
@@ -27,8 +27,8 @@ import net.minecraft.world.phys.HitResult;
 import javax.annotation.Nullable;
 
 public class TurtleBlockEntityRenderer implements BlockEntityRenderer<TurtleBlockEntity> {
-    private static final ResourceLocation COLOUR_TURTLE_MODEL = new ResourceLocation(ComputerCraftAPI.MOD_ID, "block/turtle_colour");
-    private static final ResourceLocation ELF_OVERLAY_MODEL = new ResourceLocation(ComputerCraftAPI.MOD_ID, "block/turtle_elf_overlay");
+    private static final ResourceLocation COLOUR_TURTLE_MODEL = ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "block/turtle_colour");
+    private static final ResourceLocation ELF_OVERLAY_MODEL = ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "block/turtle_elf_overlay");
 
     private final BlockEntityRenderDispatcher renderer;
     private final Font font;
@@ -121,8 +121,8 @@ public class TurtleBlockEntityRenderer implements BlockEntityRenderer<TurtleBloc
         transform.translate(0.0f, -0.5f, -0.5f);
 
         var model = TurtleUpgradeModellers.getModel(upgrade, turtle.getAccess(), side);
-        applyTransformation(transform, model.getMatrix());
-        renderModel(transform, buffers, lightmapCoord, overlayLight, model.getModel(), null);
+        applyTransformation(transform, model.matrix());
+        renderModel(transform, buffers, lightmapCoord, overlayLight, model.model(), null);
 
         transform.popPose();
     }

--- a/projects/common/src/client/java/dan200/computercraft/client/render/monitor/MonitorHighlightRenderer.java
+++ b/projects/common/src/client/java/dan200/computercraft/client/render/monitor/MonitorHighlightRenderer.java
@@ -72,18 +72,16 @@ public final class MonitorHighlightRenderer {
 
     private static void line(VertexConsumer buffer, Matrix4f transform, PoseStack.Pose normal, float x, float y, float z, Direction direction) {
         buffer
-            .vertex(transform, x, y, z)
-            .color(0, 0, 0, 0.4f)
-            .normal(normal, direction.getStepX(), direction.getStepY(), direction.getStepZ())
-            .endVertex();
+            .addVertex(transform, x, y, z)
+            .setColor(0, 0, 0, 0.4f)
+            .setNormal(normal, direction.getStepX(), direction.getStepY(), direction.getStepZ());
         buffer
-            .vertex(transform,
+            .addVertex(transform,
                 x + direction.getStepX(),
                 y + direction.getStepY(),
                 z + direction.getStepZ()
             )
-            .color(0, 0, 0, 0.4f)
-            .normal(normal, direction.getStepX(), direction.getStepY(), direction.getStepZ())
-            .endVertex();
+            .setColor(0, 0, 0, 0.4f)
+            .setNormal(normal, direction.getStepX(), direction.getStepY(), direction.getStepZ());
     }
 }

--- a/projects/common/src/client/java/dan200/computercraft/client/render/text/DirectFixedWidthFontRenderer.java
+++ b/projects/common/src/client/java/dan200/computercraft/client/render/text/DirectFixedWidthFontRenderer.java
@@ -4,7 +4,6 @@
 
 package dan200.computercraft.client.render.text;
 
-import com.mojang.blaze3d.platform.MemoryTracker;
 import com.mojang.blaze3d.vertex.DefaultVertexFormat;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 import com.mojang.blaze3d.vertex.VertexFormat;
@@ -28,7 +27,7 @@ import static org.lwjgl.system.MemoryUtil.*;
  * <ul>
  *   <li>No transformation matrix (not needed for VBOs).</li>
  *   <li>Only works with {@link DefaultVertexFormat#POSITION_COLOR_TEX_LIGHTMAP}.</li>
- *   <li>The buffer <strong>MUST</strong> be allocated with {@link MemoryTracker}, and not through any other means.</li>
+ *   <li>The buffer <strong>MUST</strong> be allocated with {@link MemoryUtil}, and not through any other means.</li>
  * </ul>
  * <p>
  * Note this is almost an exact copy of {@link FixedWidthFontRenderer}. While the code duplication is unfortunate,

--- a/projects/common/src/client/java/dan200/computercraft/client/render/text/FixedWidthFontRenderer.java
+++ b/projects/common/src/client/java/dan200/computercraft/client/render/text/FixedWidthFontRenderer.java
@@ -32,7 +32,7 @@ import static dan200.computercraft.client.render.RenderTypes.FULL_BRIGHT_LIGHTMA
  * {@link DirectFixedWidthFontRenderer}.
  */
 public final class FixedWidthFontRenderer {
-    public static final ResourceLocation FONT = new ResourceLocation("computercraft", "textures/gui/term_font.png");
+    public static final ResourceLocation FONT = ResourceLocation.fromNamespaceAndPath("computercraft", "textures/gui/term_font.png");
 
     public static final int FONT_HEIGHT = 9;
     public static final int FONT_WIDTH = 6;
@@ -221,9 +221,9 @@ public final class FixedWidthFontRenderer {
         var consumer = c.consumer();
         byte r = rgba[0], g = rgba[1], b = rgba[2], a = rgba[3];
 
-        consumer.vertex(poseMatrix, x1, y1, z).color(r, g, b, a).uv(u1, v1).uv2(light).endVertex();
-        consumer.vertex(poseMatrix, x1, y2, z).color(r, g, b, a).uv(u1, v2).uv2(light).endVertex();
-        consumer.vertex(poseMatrix, x2, y2, z).color(r, g, b, a).uv(u2, v2).uv2(light).endVertex();
-        consumer.vertex(poseMatrix, x2, y1, z).color(r, g, b, a).uv(u2, v1).uv2(light).endVertex();
+        consumer.addVertex(poseMatrix, x1, y1, z).setColor(r, g, b, a).setUv(u1, v1).setLight(light);
+        consumer.addVertex(poseMatrix, x1, y2, z).setColor(r, g, b, a).setUv(u1, v2).setLight(light);
+        consumer.addVertex(poseMatrix, x2, y2, z).setColor(r, g, b, a).setUv(u2, v2).setLight(light);
+        consumer.addVertex(poseMatrix, x2, y1, z).setColor(r, g, b, a).setUv(u2, v1).setLight(light);
     }
 }

--- a/projects/common/src/client/java/dan200/computercraft/client/sound/SpeakerInstance.java
+++ b/projects/common/src/client/java/dan200/computercraft/client/sound/SpeakerInstance.java
@@ -17,7 +17,7 @@ import javax.annotation.Nullable;
  * An instance of a speaker, which is either playing a {@link DfpwmStream} stream or a normal sound.
  */
 public class SpeakerInstance {
-    public static final ResourceLocation DFPWM_STREAM = new ResourceLocation(ComputerCraftAPI.MOD_ID, "speaker.dfpwm_fake_audio_should_not_be_played");
+    public static final ResourceLocation DFPWM_STREAM = ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "speaker.dfpwm_fake_audio_should_not_be_played");
 
     private @Nullable DfpwmStream currentStream;
     private @Nullable SpeakerSound sound;

--- a/projects/common/src/client/java/dan200/computercraft/client/turtle/TurtleModemModeller.java
+++ b/projects/common/src/client/java/dan200/computercraft/client/turtle/TurtleModemModeller.java
@@ -5,6 +5,7 @@
 package dan200.computercraft.client.turtle;
 
 import dan200.computercraft.api.ComputerCraftAPI;
+import dan200.computercraft.api.client.ModelLocation;
 import dan200.computercraft.api.client.TransformedModel;
 import dan200.computercraft.api.client.turtle.TurtleUpgradeModeller;
 import dan200.computercraft.api.turtle.ITurtleAccess;
@@ -38,23 +39,23 @@ public class TurtleModemModeller implements TurtleUpgradeModeller<TurtleModem> {
     }
 
     private record ModemModels(
-        ResourceLocation leftOffModel, ResourceLocation rightOffModel,
-        ResourceLocation leftOnModel, ResourceLocation rightOnModel
+        ModelLocation leftOffModel, ModelLocation rightOffModel,
+        ModelLocation leftOnModel, ModelLocation rightOnModel
     ) {
         private static final ModemModels NORMAL = create("normal");
         private static final ModemModels ADVANCED = create("advanced");
 
         public static ModemModels create(String type) {
             return new ModemModels(
-                new ResourceLocation(ComputerCraftAPI.MOD_ID, "block/turtle_modem_" + type + "_off_left"),
-                new ResourceLocation(ComputerCraftAPI.MOD_ID, "block/turtle_modem_" + type + "_off_right"),
-                new ResourceLocation(ComputerCraftAPI.MOD_ID, "block/turtle_modem_" + type + "_on_left"),
-                new ResourceLocation(ComputerCraftAPI.MOD_ID, "block/turtle_modem_" + type + "_on_right")
+                ModelLocation.resource(ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "block/turtle_modem_" + type + "_off_left")),
+                ModelLocation.resource(ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "block/turtle_modem_" + type + "_off_right")),
+                ModelLocation.resource(ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "block/turtle_modem_" + type + "_on_left")),
+                ModelLocation.resource(ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "block/turtle_modem_" + type + "_on_right"))
             );
         }
 
         public Stream<ResourceLocation> getDependencies() {
-            return Stream.of(leftOffModel, rightOffModel, leftOnModel, rightOnModel);
+            return Stream.of(leftOffModel, rightOffModel, leftOnModel, rightOnModel).flatMap(ModelLocation::getDependencies);
         }
     }
 }

--- a/projects/common/src/client/java/dan200/computercraft/data/client/ClientDataProviders.java
+++ b/projects/common/src/client/java/dan200/computercraft/data/client/ClientDataProviders.java
@@ -28,7 +28,7 @@ public final class ClientDataProviders {
 
     public static void add(DataProviders.GeneratorSink generator) {
         generator.addFromCodec("Block atlases", PackType.CLIENT_RESOURCES, "atlases", SpriteSources.FILE_CODEC, out -> {
-            out.accept(new ResourceLocation("blocks"), List.of(
+            out.accept(ResourceLocation.withDefaultNamespace("blocks"), List.of(
                 new SingleFile(UpgradeSlot.LEFT_UPGRADE, Optional.empty()),
                 new SingleFile(UpgradeSlot.RIGHT_UPGRADE, Optional.empty())
             ));

--- a/projects/common/src/main/java/dan200/computercraft/data/BlockModelProvider.java
+++ b/projects/common/src/main/java/dan200/computercraft/data/BlockModelProvider.java
@@ -43,33 +43,33 @@ class BlockModelProvider {
     private static final TextureSlot BACKPACK = TextureSlot.create("backpack");
 
     private static final ModelTemplate COMPUTER_ON = new ModelTemplate(
-        Optional.of(new ResourceLocation(ComputerCraftAPI.MOD_ID, "block/computer_on")),
+        Optional.of(ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "block/computer_on")),
         Optional.empty(),
         TextureSlot.FRONT, TextureSlot.SIDE, TextureSlot.TOP, CURSOR
     );
 
     private static final ModelTemplate MONITOR_BASE = new ModelTemplate(
-        Optional.of(new ResourceLocation(ComputerCraftAPI.MOD_ID, "block/monitor_base")),
+        Optional.of(ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "block/monitor_base")),
         Optional.empty(),
         TextureSlot.FRONT, TextureSlot.SIDE, TextureSlot.TOP, TextureSlot.BACK
     );
     private static final ModelTemplate MODEM = new ModelTemplate(
-        Optional.of(new ResourceLocation(ComputerCraftAPI.MOD_ID, "block/modem")),
+        Optional.of(ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "block/modem")),
         Optional.empty(),
         TextureSlot.FRONT, TextureSlot.BACK
     );
     private static final ModelTemplate TURTLE = new ModelTemplate(
-        Optional.of(new ResourceLocation(ComputerCraftAPI.MOD_ID, "block/turtle_base")),
+        Optional.of(ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "block/turtle_base")),
         Optional.empty(),
         TextureSlot.FRONT, TextureSlot.BACK, TextureSlot.TOP, TextureSlot.BOTTOM, LEFT, RIGHT, BACKPACK
     );
     private static final ModelTemplate TURTLE_UPGRADE_LEFT = new ModelTemplate(
-        Optional.of(new ResourceLocation(ComputerCraftAPI.MOD_ID, "block/turtle_upgrade_base_left")),
+        Optional.of(ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "block/turtle_upgrade_base_left")),
         Optional.of("_left"),
         TextureSlot.TEXTURE
     );
     private static final ModelTemplate TURTLE_UPGRADE_RIGHT = new ModelTemplate(
-        Optional.of(new ResourceLocation(ComputerCraftAPI.MOD_ID, "block/turtle_upgrade_base_right")),
+        Optional.of(ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "block/turtle_upgrade_base_right")),
         Optional.of("_left"),
         TextureSlot.TEXTURE
     );
@@ -161,7 +161,7 @@ class BlockModelProvider {
                 );
                 case ON, BLINKING -> COMPUTER_ON.createWithSuffix(
                     block, "_" + state.getSerializedName(),
-                    TextureMapping.orientableCube(block).put(CURSOR, new ResourceLocation(ComputerCraftAPI.MOD_ID, "block/computer" + state.getTexture())),
+                    TextureMapping.orientableCube(block).put(CURSOR, ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "block/computer" + state.getTexture())),
                     generators.modelOutput
                 );
             }))
@@ -207,10 +207,10 @@ class BlockModelProvider {
         generators.blockStateOutput.accept(MultiVariantGenerator.multiVariant(fullBlock)
             .with(createModelDispatch(WiredModemFullBlock.MODEM_ON, WiredModemFullBlock.PERIPHERAL_ON, (on, peripheral) -> {
                 var suffix = (on ? "_on" : "_off") + (peripheral ? "_peripheral" : "");
-                var faceTexture = new ResourceLocation(ComputerCraftAPI.MOD_ID, "block/wired_modem_face" + (peripheral ? "_peripheral" : "") + (on ? "_on" : ""));
+                var faceTexture = ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "block/wired_modem_face" + (peripheral ? "_peripheral" : "") + (on ? "_on" : ""));
 
                 // TODO: Do this somewhere more elegant!
-                modemModel(generators, new ResourceLocation(ComputerCraftAPI.MOD_ID, "block/wired_modem" + suffix), faceTexture);
+                modemModel(generators, ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "block/wired_modem" + suffix), faceTexture);
 
                 return ModelTemplates.CUBE_ALL.create(
                     getModelLocation(fullBlock, suffix),
@@ -220,7 +220,7 @@ class BlockModelProvider {
             })));
 
         generators.delegateItemModel(fullBlock, getModelLocation(fullBlock, "_off"));
-        generators.delegateItemModel(ModRegistry.Items.WIRED_MODEM.get(), new ResourceLocation(ComputerCraftAPI.MOD_ID, "block/wired_modem_off"));
+        generators.delegateItemModel(ModRegistry.Items.WIRED_MODEM.get(), ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "block/wired_modem_off"));
     }
 
     private static ResourceLocation modemModel(BlockModelGenerators generators, ResourceLocation name, ResourceLocation texture) {
@@ -228,7 +228,7 @@ class BlockModelProvider {
             name,
             new TextureMapping()
                 .put(TextureSlot.FRONT, texture)
-                .put(TextureSlot.BACK, new ResourceLocation(ComputerCraftAPI.MOD_ID, "block/modem_back")),
+                .put(TextureSlot.BACK, ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "block/modem_back")),
             generators.modelOutput
         );
     }
@@ -275,7 +275,7 @@ class BlockModelProvider {
         var generator = MultiPartGenerator.multiPart(ModRegistry.Blocks.CABLE.get());
 
         // When a cable only has a neighbour in a single direction, we redirect the core to face that direction.
-        var coreFacing = new ResourceLocation(ComputerCraftAPI.MOD_ID, "block/cable_core_facing");
+        var coreFacing = ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "block/cable_core_facing");
         // Up/Down
         generator.with(
             Condition.or(
@@ -305,7 +305,7 @@ class BlockModelProvider {
         );
 
         // Find all other possibilities and emit a "solid" core which doesn't have a facing direction.
-        var core = new ResourceLocation(ComputerCraftAPI.MOD_ID, "block/cable_core_any");
+        var core = ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "block/cable_core_any");
         List<Condition.TerminalCondition> rightAngles = new ArrayList<>();
         for (var i = 0; i < DirectionUtil.FACINGS.length; i++) {
             for (var j = i; j < DirectionUtil.FACINGS.length; j++) {
@@ -319,7 +319,7 @@ class BlockModelProvider {
         generator.with(Condition.or(rightAngles.toArray(new Condition[0])), Variant.variant().with(VariantProperties.MODEL, core));
 
         // Then emit the actual cable arms
-        var arm = new ResourceLocation(ComputerCraftAPI.MOD_ID, "block/cable_arm");
+        var arm = ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "block/cable_arm");
         for (var direction : DirectionUtil.FACINGS) {
             generator.with(
                 new Condition.TerminalCondition().term(CABLE_DIRECTIONS[direction.ordinal()], true),
@@ -338,7 +338,7 @@ class BlockModelProvider {
                     generator.with(
                         new Condition.TerminalCondition().term(CableBlock.MODEM, CableModemVariant.from(direction, on, peripheral)),
                         Variant.variant()
-                            .with(VariantProperties.MODEL, new ResourceLocation(ComputerCraftAPI.MOD_ID, "block/wired_modem" + suffix))
+                            .with(VariantProperties.MODEL, ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "block/wired_modem" + suffix))
                             .with(VariantProperties.X_ROT, toXAngle(direction))
                             .with(VariantProperties.Y_ROT, toYAngle(direction))
                     );
@@ -360,13 +360,13 @@ class BlockModelProvider {
 
     private static void registerTurtleUpgrade(BlockModelGenerators generators, String name, String texture) {
         TURTLE_UPGRADE_LEFT.create(
-            new ResourceLocation(ComputerCraftAPI.MOD_ID, name + "_left"),
-            TextureMapping.defaultTexture(new ResourceLocation(ComputerCraftAPI.MOD_ID, texture)),
+            ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, name + "_left"),
+            TextureMapping.defaultTexture(ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, texture)),
             generators.modelOutput
         );
         TURTLE_UPGRADE_RIGHT.create(
-            new ResourceLocation(ComputerCraftAPI.MOD_ID, name + "_right"),
-            TextureMapping.defaultTexture(new ResourceLocation(ComputerCraftAPI.MOD_ID, texture)),
+            ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, name + "_right"),
+            TextureMapping.defaultTexture(ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, texture)),
             generators.modelOutput
         );
     }

--- a/projects/common/src/main/java/dan200/computercraft/data/ItemModelProvider.java
+++ b/projects/common/src/main/java/dan200/computercraft/data/ItemModelProvider.java
@@ -28,7 +28,7 @@ public final class ItemModelProvider {
 
         registerPocketComputer(generators, getModelLocation(ModRegistry.Items.POCKET_COMPUTER_NORMAL.get()), false);
         registerPocketComputer(generators, getModelLocation(ModRegistry.Items.POCKET_COMPUTER_ADVANCED.get()), false);
-        registerPocketComputer(generators, new ResourceLocation(ComputerCraftAPI.MOD_ID, "item/pocket_computer_colour"), true);
+        registerPocketComputer(generators, ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "item/pocket_computer_colour"), true);
 
         generators.generateFlatItem(ModRegistry.Items.PRINTED_BOOK.get(), ModelTemplates.FLAT_ITEM);
         generators.generateFlatItem(ModRegistry.Items.PRINTED_PAGE.get(), ModelTemplates.FLAT_ITEM);
@@ -37,21 +37,21 @@ public final class ItemModelProvider {
 
     private static void registerPocketComputer(ItemModelGenerators generators, ResourceLocation id, boolean off) {
         createFlatItem(generators, id.withSuffix("_blinking"),
-            new ResourceLocation(ComputerCraftAPI.MOD_ID, "item/pocket_computer_blink"),
+            ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "item/pocket_computer_blink"),
             id,
-            new ResourceLocation(ComputerCraftAPI.MOD_ID, "item/pocket_computer_light")
+            ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "item/pocket_computer_light")
         );
 
         createFlatItem(generators, id.withSuffix("_on"),
-            new ResourceLocation(ComputerCraftAPI.MOD_ID, "item/pocket_computer_on"),
+            ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "item/pocket_computer_on"),
             id,
-            new ResourceLocation(ComputerCraftAPI.MOD_ID, "item/pocket_computer_light")
+            ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "item/pocket_computer_light")
         );
 
         // Don't emit the default/off state for advanced/normal pocket computers, as they have item overrides.
         if (off) {
             createFlatItem(generators, id,
-                new ResourceLocation(ComputerCraftAPI.MOD_ID, "item/pocket_computer_frame"),
+                ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "item/pocket_computer_frame"),
                 id
             );
         }
@@ -59,8 +59,8 @@ public final class ItemModelProvider {
 
     private static void registerDisk(ItemModelGenerators generators, Item item) {
         createFlatItem(generators, item,
-            new ResourceLocation(ComputerCraftAPI.MOD_ID, "item/disk_frame"),
-            new ResourceLocation(ComputerCraftAPI.MOD_ID, "item/disk_colour")
+            ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "item/disk_frame"),
+            ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "item/disk_colour")
         );
     }
 
@@ -91,7 +91,7 @@ public final class ItemModelProvider {
             mapping.put(slot, textures[i]);
         }
 
-        new ModelTemplate(Optional.of(new ResourceLocation("item/generated")), Optional.empty(), slots)
+        new ModelTemplate(Optional.of(ResourceLocation.withDefaultNamespace("item/generated")), Optional.empty(), slots)
             .create(model, mapping, generators.output);
     }
 }

--- a/projects/common/src/main/java/dan200/computercraft/data/LootTableProvider.java
+++ b/projects/common/src/main/java/dan200/computercraft/data/LootTableProvider.java
@@ -12,7 +12,6 @@ import dan200.computercraft.shared.data.PlayerCreativeLootCondition;
 import dan200.computercraft.shared.peripheral.modem.wired.CableBlock;
 import dan200.computercraft.shared.peripheral.modem.wired.CableModemVariant;
 import net.minecraft.advancements.critereon.StatePropertiesPredicate;
-import net.minecraft.core.HolderLookup;
 import net.minecraft.data.loot.LootTableProvider.SubProviderEntry;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.level.block.Block;
@@ -36,12 +35,12 @@ import java.util.function.Supplier;
 class LootTableProvider {
     public static List<SubProviderEntry> getTables() {
         return List.of(
-            new SubProviderEntry(() -> LootTableProvider::registerBlocks, LootContextParamSets.BLOCK),
-            new SubProviderEntry(() -> LootTableProvider::registerGeneric, LootContextParamSets.ALL_PARAMS)
+            new SubProviderEntry(r -> LootTableProvider::registerBlocks, LootContextParamSets.BLOCK),
+            new SubProviderEntry(r -> LootTableProvider::registerGeneric, LootContextParamSets.ALL_PARAMS)
         );
     }
 
-    private static void registerBlocks(HolderLookup.Provider registries, BiConsumer<ResourceKey<LootTable>, LootTable.Builder> add) {
+    private static void registerBlocks(BiConsumer<ResourceKey<LootTable>, LootTable.Builder> add) {
         namedBlockDrop(add, ModRegistry.Blocks.DISK_DRIVE);
         selfDrop(add, ModRegistry.Blocks.MONITOR_NORMAL);
         selfDrop(add, ModRegistry.Blocks.MONITOR_ADVANCED);
@@ -78,7 +77,7 @@ class LootTableProvider {
             ));
     }
 
-    private static void registerGeneric(HolderLookup.Provider registries, BiConsumer<ResourceKey<LootTable>, LootTable.Builder> add) {
+    private static void registerGeneric(BiConsumer<ResourceKey<LootTable>, LootTable.Builder> add) {
         add.accept(CommonHooks.TREASURE_DISK_LOOT, LootTable.lootTable());
     }
 

--- a/projects/common/src/main/java/dan200/computercraft/data/PocketUpgradeProvider.java
+++ b/projects/common/src/main/java/dan200/computercraft/data/PocketUpgradeProvider.java
@@ -23,6 +23,6 @@ class PocketUpgradeProvider {
     }
 
     private static ResourceKey<IPocketUpgrade> id(String id) {
-        return ResourceKey.create(IPocketUpgrade.REGISTRY, new ResourceLocation(ComputerCraftAPI.MOD_ID, id));
+        return ResourceKey.create(IPocketUpgrade.REGISTRY, ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, id));
     }
 }

--- a/projects/common/src/main/java/dan200/computercraft/data/RecipeProvider.java
+++ b/projects/common/src/main/java/dan200/computercraft/data/RecipeProvider.java
@@ -14,7 +14,6 @@ import dan200.computercraft.api.upgrades.UpgradeData;
 import dan200.computercraft.core.util.Colour;
 import dan200.computercraft.data.recipe.ShapedSpecBuilder;
 import dan200.computercraft.data.recipe.ShapelessSpecBuilder;
-import dan200.computercraft.shared.util.RegistryHelper;
 import dan200.computercraft.shared.ModRegistry;
 import dan200.computercraft.shared.common.ClearColourRecipe;
 import dan200.computercraft.shared.common.ColourableRecipe;
@@ -33,6 +32,7 @@ import dan200.computercraft.shared.turtle.items.TurtleItem;
 import dan200.computercraft.shared.turtle.recipes.TurtleUpgradeRecipe;
 import dan200.computercraft.shared.util.ColourUtils;
 import dan200.computercraft.shared.util.DataComponentUtil;
+import dan200.computercraft.shared.util.RegistryHelper;
 import net.minecraft.advancements.Criterion;
 import net.minecraft.advancements.critereon.InventoryChangeTrigger;
 import net.minecraft.advancements.critereon.ItemPredicate;
@@ -120,7 +120,7 @@ final class RecipeProvider extends net.minecraft.data.recipes.RecipeProvider {
                 .group("computercraft:disk")
                 .unlockedBy("has_drive", inventoryChange(ModRegistry.Items.DISK_DRIVE.get()))
                 .build(ImpostorShapelessRecipe::new)
-                .save(output, new ResourceLocation(ComputerCraftAPI.MOD_ID, "disk_" + (colour.ordinal() + 1)));
+                .save(output, ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "disk_" + (colour.ordinal() + 1)));
         }
     }
 
@@ -211,7 +211,7 @@ final class RecipeProvider extends net.minecraft.data.recipes.RecipeProvider {
     }
 
     private void turtleOverlay(RecipeOutput add, String overlay, Consumer<ShapelessSpecBuilder> build) {
-        var overlayId = new ResourceLocation(ComputerCraftAPI.MOD_ID, "block/" + overlay);
+        var overlayId = ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "block/" + overlay);
 
         for (var turtleItem : turtleItems()) {
             var name = RegistryHelper.getKeyOrThrow(BuiltInRegistries.ITEM, turtleItem);
@@ -274,7 +274,7 @@ final class RecipeProvider extends net.minecraft.data.recipes.RecipeProvider {
             .define('C', ModRegistry.Items.COMPUTER_NORMAL.get())
             .unlockedBy("has_components", inventoryChange(itemPredicate(ModRegistry.Items.COMPUTER_NORMAL.get()), itemPredicate(ingredients.goldIngot())))
             .build(x -> new TransformShapedRecipe(x, List.of(new CopyComponents(ModRegistry.Items.COMPUTER_NORMAL.get()))))
-            .save(add, new ResourceLocation(ComputerCraftAPI.MOD_ID, "computer_advanced_upgrade"));
+            .save(add, ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "computer_advanced_upgrade"));
 
         ShapedRecipeBuilder
             .shaped(RecipeCategory.REDSTONE, ModRegistry.Items.COMPUTER_COMMAND.get())
@@ -321,7 +321,7 @@ final class RecipeProvider extends net.minecraft.data.recipes.RecipeProvider {
             .define('B', ingredients.goldBlock())
             .unlockedBy("has_components", inventoryChange(itemPredicate(ModRegistry.Items.TURTLE_NORMAL.get()), itemPredicate(ingredients.goldIngot())))
             .build(x -> new TransformShapedRecipe(x, List.of(new CopyComponents(ModRegistry.Items.TURTLE_NORMAL.get()))))
-            .save(add, new ResourceLocation(ComputerCraftAPI.MOD_ID, "turtle_advanced_upgrade"));
+            .save(add, ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "turtle_advanced_upgrade"));
 
         ShapedRecipeBuilder
             .shaped(RecipeCategory.REDSTONE, ModRegistry.Items.DISK_DRIVE.get())
@@ -386,7 +386,7 @@ final class RecipeProvider extends net.minecraft.data.recipes.RecipeProvider {
             .define('C', ModRegistry.Items.POCKET_COMPUTER_NORMAL.get())
             .unlockedBy("has_components", inventoryChange(itemPredicate(ModRegistry.Items.POCKET_COMPUTER_NORMAL.get()), itemPredicate(ingredients.goldIngot())))
             .build(x -> new TransformShapedRecipe(x, List.of(new CopyComponents(ModRegistry.Items.POCKET_COMPUTER_NORMAL.get()))))
-            .save(add, new ResourceLocation(ComputerCraftAPI.MOD_ID, "pocket_computer_advanced_upgrade"));
+            .save(add, ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "pocket_computer_advanced_upgrade"));
 
         ShapedRecipeBuilder
             .shaped(RecipeCategory.REDSTONE, ModRegistry.Items.PRINTER.get())
@@ -425,12 +425,12 @@ final class RecipeProvider extends net.minecraft.data.recipes.RecipeProvider {
             .shapeless(RecipeCategory.REDSTONE, ModRegistry.Items.WIRED_MODEM_FULL.get())
             .requires(ModRegistry.Items.WIRED_MODEM.get())
             .unlockedBy("has_modem", inventoryChange(WIRED_MODEM))
-            .save(add, new ResourceLocation(ComputerCraftAPI.MOD_ID, "wired_modem_full_from"));
+            .save(add, ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "wired_modem_full_from"));
         ShapelessRecipeBuilder
             .shapeless(RecipeCategory.REDSTONE, ModRegistry.Items.WIRED_MODEM.get())
             .requires(ModRegistry.Items.WIRED_MODEM_FULL.get())
             .unlockedBy("has_modem", inventoryChange(WIRED_MODEM))
-            .save(add, new ResourceLocation(ComputerCraftAPI.MOD_ID, "wired_modem_full_to"));
+            .save(add, ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "wired_modem_full_to"));
 
         ShapedRecipeBuilder
             .shaped(RecipeCategory.REDSTONE, ModRegistry.Items.WIRELESS_MODEM_NORMAL.get())
@@ -459,7 +459,7 @@ final class RecipeProvider extends net.minecraft.data.recipes.RecipeProvider {
             .requires(ModRegistry.Items.MONITOR_NORMAL.get())
             .unlockedBy("has_monitor", inventoryChange(ModRegistry.Items.MONITOR_NORMAL.get()))
             .build()
-            .save(add, new ResourceLocation(ComputerCraftAPI.MOD_ID, "skull_cloudy"));
+            .save(add, ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "skull_cloudy"));
 
         ShapelessSpecBuilder
             .shapeless(RecipeCategory.DECORATIONS, playerHead("dan200", "f3c8d69b-0776-4512-8434-d1b2165909eb"))
@@ -467,7 +467,7 @@ final class RecipeProvider extends net.minecraft.data.recipes.RecipeProvider {
             .requires(ModRegistry.Items.COMPUTER_ADVANCED.get())
             .unlockedBy("has_computer", inventoryChange(ModRegistry.Items.COMPUTER_ADVANCED.get()))
             .build()
-            .save(add, new ResourceLocation(ComputerCraftAPI.MOD_ID, "skull_dan200"));
+            .save(add, ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "skull_dan200"));
 
         var pages = Ingredient.of(
             ModRegistry.Items.PRINTED_PAGE.get(),
@@ -523,7 +523,7 @@ final class RecipeProvider extends net.minecraft.data.recipes.RecipeProvider {
             var item = ItemStack.SIMPLE_ITEM_CODEC.parse(JsonOps.INSTANCE, object).getOrThrow();
             return itemPredicate(item.getItem());
         } else if (object.has("tag")) {
-            return itemPredicate(TagKey.create(Registries.ITEM, new ResourceLocation(GsonHelper.getAsString(object, "tag"))));
+            return itemPredicate(TagKey.create(Registries.ITEM, ResourceLocation.parse(GsonHelper.getAsString(object, "tag"))));
         } else {
             throw new IllegalArgumentException("Unknown ingredient " + json);
         }

--- a/projects/common/src/main/java/dan200/computercraft/data/TurtleUpgradeProvider.java
+++ b/projects/common/src/main/java/dan200/computercraft/data/TurtleUpgradeProvider.java
@@ -34,11 +34,11 @@ class TurtleUpgradeProvider {
     }
 
     private static ResourceKey<ITurtleUpgrade> id(String id) {
-        return ITurtleUpgrade.createKey(new ResourceLocation(ComputerCraftAPI.MOD_ID, id));
+        return ITurtleUpgrade.createKey(ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, id));
     }
 
     private static ResourceKey<ITurtleUpgrade> vanilla(String id) {
         // Naughty, please don't do this. Mostly here for some semblance of backwards compatibility.
-        return ITurtleUpgrade.createKey(new ResourceLocation("minecraft", id));
+        return ITurtleUpgrade.createKey(ResourceLocation.fromNamespaceAndPath("minecraft", id));
     }
 }

--- a/projects/common/src/main/java/dan200/computercraft/impl/AbstractComputerCraftAPI.java
+++ b/projects/common/src/main/java/dan200/computercraft/impl/AbstractComputerCraftAPI.java
@@ -48,12 +48,12 @@ public abstract class AbstractComputerCraftAPI implements ComputerCraftAPIServic
     private final DetailRegistry<ItemStack> itemStackDetails = new DetailRegistryImpl<>(ItemDetails::fillBasic);
     private final DetailRegistry<BlockReference> blockDetails = new DetailRegistryImpl<>(BlockDetails::fillBasic);
 
-    protected static final ResourceKey<Registry<UpgradeType<? extends ITurtleUpgrade>>> turtleUpgradeRegistryId = ResourceKey.createRegistryKey(new ResourceLocation(ComputerCraftAPI.MOD_ID, "turtle_upgrade_type"));
-    protected static final ResourceKey<Registry<UpgradeType<? extends IPocketUpgrade>>> pocketUpgradeRegistryId = ResourceKey.createRegistryKey(new ResourceLocation(ComputerCraftAPI.MOD_ID, "pocket_upgrade_type"));
+    protected static final ResourceKey<Registry<UpgradeType<? extends ITurtleUpgrade>>> turtleUpgradeRegistryId = ResourceKey.createRegistryKey(ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "turtle_upgrade_type"));
+    protected static final ResourceKey<Registry<UpgradeType<? extends IPocketUpgrade>>> pocketUpgradeRegistryId = ResourceKey.createRegistryKey(ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "pocket_upgrade_type"));
 
     public static @Nullable InputStream getResourceFile(MinecraftServer server, String domain, String subPath) {
         var manager = server.getResourceManager();
-        var resource = manager.getResource(new ResourceLocation(domain, subPath)).orElse(null);
+        var resource = manager.getResource(ResourceLocation.fromNamespaceAndPath(domain, subPath)).orElse(null);
         if (resource == null) return null;
         try {
             return resource.open();

--- a/projects/common/src/main/java/dan200/computercraft/shared/CommonHooks.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/CommonHooks.java
@@ -92,7 +92,7 @@ public final class CommonHooks {
         TickScheduler.onChunkTicketChanged(level, chunkPos, oldLevel, newLevel);
     }
 
-    public static final ResourceKey<LootTable> TREASURE_DISK_LOOT = ResourceKey.create(Registries.LOOT_TABLE, new ResourceLocation(ComputerCraftAPI.MOD_ID, "treasure_disk"));
+    public static final ResourceKey<LootTable> TREASURE_DISK_LOOT = ResourceKey.create(Registries.LOOT_TABLE, ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "treasure_disk"));
 
     private static final Set<ResourceKey<LootTable>> TREASURE_DISK_LOOT_TABLES = Set.of(
         BuiltInLootTables.SIMPLE_DUNGEON,

--- a/projects/common/src/main/java/dan200/computercraft/shared/ModRegistry.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/ModRegistry.java
@@ -100,7 +100,10 @@ import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.flag.FeatureFlags;
 import net.minecraft.world.inventory.MenuType;
-import net.minecraft.world.item.*;
+import net.minecraft.world.item.BlockItem;
+import net.minecraft.world.item.CreativeModeTab;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.component.DyedItemColor;
 import net.minecraft.world.item.crafting.CustomRecipe;
 import net.minecraft.world.item.crafting.Recipe;
@@ -580,9 +583,8 @@ public final class ModRegistry {
         ComputerCraftAPI.registerBundledRedstoneProvider(new DefaultBundledRedstoneProvider());
         ComputerCraftAPI.registerRefuelHandler(new FurnaceRefuelHandler());
         ComputerCraftAPI.registerMediaProvider(stack -> {
-            var item = stack.getItem();
-            if (item instanceof IMedia media) return media;
-            if (item instanceof RecordItem) return RecordMedia.INSTANCE;
+            if (stack.getItem() instanceof IMedia media) return media;
+            if (stack.has(net.minecraft.core.component.DataComponents.JUKEBOX_PLAYABLE)) return RecordMedia.INSTANCE;
             return null;
         });
 

--- a/projects/common/src/main/java/dan200/computercraft/shared/common/ClearColourRecipe.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/common/ClearColourRecipe.java
@@ -10,10 +10,10 @@ import dan200.computercraft.shared.util.DataComponentUtil;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.NonNullList;
 import net.minecraft.core.component.DataComponents;
-import net.minecraft.world.inventory.CraftingContainer;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.crafting.CraftingBookCategory;
+import net.minecraft.world.item.crafting.CraftingInput;
 import net.minecraft.world.item.crafting.CustomRecipe;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.level.Level;
@@ -27,10 +27,10 @@ public final class ClearColourRecipe extends CustomRecipe {
     }
 
     @Override
-    public boolean matches(CraftingContainer inv, Level world) {
+    public boolean matches(CraftingInput inv, Level world) {
         var hasColourable = false;
         var hasSponge = false;
-        for (var i = 0; i < inv.getContainerSize(); i++) {
+        for (var i = 0; i < inv.size(); i++) {
             var stack = inv.getItem(i);
             if (stack.isEmpty()) continue;
 
@@ -50,10 +50,10 @@ public final class ClearColourRecipe extends CustomRecipe {
     }
 
     @Override
-    public ItemStack assemble(CraftingContainer inv, HolderLookup.Provider registryAccess) {
+    public ItemStack assemble(CraftingInput inv, HolderLookup.Provider registryAccess) {
         var colourable = ItemStack.EMPTY;
 
-        for (var i = 0; i < inv.getContainerSize(); i++) {
+        for (var i = 0; i < inv.size(); i++) {
             var stack = inv.getItem(i);
             if (stack.is(ComputerCraftTags.Items.DYEABLE)) colourable = stack;
         }
@@ -64,8 +64,8 @@ public final class ClearColourRecipe extends CustomRecipe {
     }
 
     @Override
-    public NonNullList<ItemStack> getRemainingItems(CraftingContainer container) {
-        var remaining = NonNullList.withSize(container.getContainerSize(), ItemStack.EMPTY);
+    public NonNullList<ItemStack> getRemainingItems(CraftingInput container) {
+        var remaining = NonNullList.withSize(container.size(), ItemStack.EMPTY);
         for (var i = 0; i < remaining.size(); i++) {
             if (container.getItem(i).getItem() == Items.WET_SPONGE) remaining.set(i, new ItemStack(Items.WET_SPONGE));
         }

--- a/projects/common/src/main/java/dan200/computercraft/shared/common/ColourableRecipe.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/common/ColourableRecipe.java
@@ -11,10 +11,10 @@ import dan200.computercraft.shared.util.ColourUtils;
 import dan200.computercraft.shared.util.DataComponentUtil;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.component.DataComponents;
-import net.minecraft.world.inventory.CraftingContainer;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.component.DyedItemColor;
 import net.minecraft.world.item.crafting.CraftingBookCategory;
+import net.minecraft.world.item.crafting.CraftingInput;
 import net.minecraft.world.item.crafting.CustomRecipe;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.level.Level;
@@ -25,10 +25,10 @@ public final class ColourableRecipe extends CustomRecipe {
     }
 
     @Override
-    public boolean matches(CraftingContainer inv, Level world) {
+    public boolean matches(CraftingInput inv, Level world) {
         var hasColourable = false;
         var hasDye = false;
-        for (var i = 0; i < inv.getContainerSize(); i++) {
+        for (var i = 0; i < inv.size(); i++) {
             var stack = inv.getItem(i);
             if (stack.isEmpty()) continue;
 
@@ -46,12 +46,12 @@ public final class ColourableRecipe extends CustomRecipe {
     }
 
     @Override
-    public ItemStack assemble(CraftingContainer inv, HolderLookup.Provider registryAccess) {
+    public ItemStack assemble(CraftingInput inv, HolderLookup.Provider registryAccess) {
         var colourable = ItemStack.EMPTY;
 
         var tracker = new ColourTracker();
 
-        for (var i = 0; i < inv.getContainerSize(); i++) {
+        for (var i = 0; i < inv.size(); i++) {
             var stack = inv.getItem(i);
 
             if (stack.isEmpty()) continue;

--- a/projects/common/src/main/java/dan200/computercraft/shared/common/HorizontalContainerBlock.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/common/HorizontalContainerBlock.java
@@ -62,13 +62,7 @@ public abstract class HorizontalContainerBlock extends BaseEntityBlock {
 
     @Override
     protected final void onRemove(BlockState state, Level level, BlockPos pos, BlockState newState, boolean isMoving) {
-        if (state.is(newState.getBlock())) return;
-
-        if (level.getBlockEntity(pos) instanceof BaseContainerBlockEntity container) {
-            Containers.dropContents(level, pos, container);
-            level.updateNeighbourForOutputSignal(pos, this);
-        }
-
+        Containers.dropContentsOnDestroy(state, newState, level, pos);
         super.onRemove(state, level, pos, newState, isMoving);
     }
 

--- a/projects/common/src/main/java/dan200/computercraft/shared/computer/core/ResourceMount.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/computer/core/ResourceMount.java
@@ -41,7 +41,7 @@ public final class ResourceMount extends ArchiveMount<ResourceMount.FileEntry> {
     private ResourceManager manager;
 
     public static ResourceMount get(String namespace, String subPath, ResourceManager manager) {
-        var path = new ResourceLocation(namespace, subPath);
+        var path = ResourceLocation.fromNamespaceAndPath(namespace, subPath);
         synchronized (MOUNT_CACHE) {
             var mount = MOUNT_CACHE.get(path);
             if (mount == null) MOUNT_CACHE.put(path, mount = new ResourceMount(namespace, subPath, manager));
@@ -60,7 +60,7 @@ public final class ResourceMount extends ArchiveMount<ResourceMount.FileEntry> {
         var hasAny = false;
         String existingNamespace = null;
 
-        var newRoot = new FileEntry(new ResourceLocation(namespace, subPath));
+        var newRoot = new FileEntry(ResourceLocation.fromNamespaceAndPath(namespace, subPath));
         for (var file : manager.listResources(subPath, s -> true).keySet()) {
             existingNamespace = file.getNamespace();
 
@@ -88,7 +88,7 @@ public final class ResourceMount extends ArchiveMount<ResourceMount.FileEntry> {
     }
 
     private FileEntry createEntry(String path) {
-        return new FileEntry(new ResourceLocation(namespace, subPath + "/" + path));
+        return new FileEntry(ResourceLocation.fromNamespaceAndPath(namespace, subPath + "/" + path));
     }
 
     @Override

--- a/projects/common/src/main/java/dan200/computercraft/shared/computer/items/AbstractComputerItem.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/computer/items/AbstractComputerItem.java
@@ -12,6 +12,7 @@ import dan200.computercraft.shared.computer.blocks.AbstractComputerBlock;
 import dan200.computercraft.shared.config.Config;
 import dan200.computercraft.shared.util.DataComponentUtil;
 import net.minecraft.ChatFormatting;
+import net.minecraft.core.HolderLookup;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerLevel;
@@ -39,7 +40,7 @@ public class AbstractComputerItem extends BlockItem implements IMedia {
     }
 
     @Override
-    public @Nullable String getLabel(ItemStack stack) {
+    public @Nullable String getLabel(HolderLookup.Provider registries, ItemStack stack) {
         return DataComponentUtil.getCustomName(stack);
     }
 

--- a/projects/common/src/main/java/dan200/computercraft/shared/container/BasicContainer.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/container/BasicContainer.java
@@ -4,16 +4,17 @@
 
 package dan200.computercraft.shared.container;
 
-import net.minecraft.core.NonNullList;
 import net.minecraft.world.Container;
 import net.minecraft.world.ContainerHelper;
 import net.minecraft.world.item.ItemStack;
+
+import java.util.List;
 
 /**
  * A basic implementation of {@link Container} which operates on a {@linkplain #getItems() list of stacks}.
  */
 public interface BasicContainer extends Container {
-    NonNullList<ItemStack> getItems();
+    List<ItemStack> getItems();
 
     @Override
     default int getContainerSize() {
@@ -55,7 +56,7 @@ public interface BasicContainer extends Container {
         getItems().clear();
     }
 
-    static void defaultSetItems(NonNullList<ItemStack> inventory, NonNullList<ItemStack> items) {
+    static void defaultSetItems(List<ItemStack> inventory, List<ItemStack> items) {
         var i = 0;
         for (; i < items.size(); i++) inventory.set(i, items.get(i));
         for (; i < inventory.size(); i++) inventory.set(i, ItemStack.EMPTY);

--- a/projects/common/src/main/java/dan200/computercraft/shared/container/ListContainer.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/container/ListContainer.java
@@ -1,0 +1,27 @@
+package dan200.computercraft.shared.container;
+
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+
+import java.util.List;
+
+/**
+ * A container backed by a simple list.
+ *
+ * @param items The items backing this list.
+ */
+public record ListContainer(List<ItemStack> items) implements BasicContainer {
+    @Override
+    public List<ItemStack> getItems() {
+        return items;
+    }
+
+    @Override
+    public void setChanged() {
+    }
+
+    @Override
+    public boolean stillValid(Player player) {
+        return true;
+    }
+}

--- a/projects/common/src/main/java/dan200/computercraft/shared/details/ItemDetails.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/details/ItemDetails.java
@@ -13,6 +13,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.CreativeModeTabs;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.item.enchantment.EnchantmentHelper;
 import net.minecraft.world.item.enchantment.ItemEnchantments;
 
@@ -112,9 +113,9 @@ public class ItemDetails {
             var enchantment = entry.getKey();
             var level = entry.getIntValue();
             var enchant = new HashMap<String, Object>(3);
-            enchant.put("name", DetailHelpers.getId(BuiltInRegistries.ENCHANTMENT, enchantment.value()));
+            enchant.put("name", enchantment.getRegisteredName());
             enchant.put("level", level);
-            enchant.put("displayName", enchantment.value().getFullname(level).getString());
+            enchant.put("displayName", Enchantment.getFullname(enchantment, level).getString());
             enchants.add(enchant);
         }
     }

--- a/projects/common/src/main/java/dan200/computercraft/shared/integration/ExternalModTags.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/integration/ExternalModTags.java
@@ -31,7 +31,7 @@ public final class ExternalModTags {
         public static final TagKey<Block> CREATE_BRITTLE = make("create", "brittle");
 
         private static TagKey<Block> make(String mod, String name) {
-            return TagKey.create(Registries.BLOCK, new ResourceLocation(mod, name));
+            return TagKey.create(Registries.BLOCK, ResourceLocation.fromNamespaceAndPath(mod, name));
         }
     }
 }

--- a/projects/common/src/main/java/dan200/computercraft/shared/integration/jei/JEIComputerCraft.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/integration/jei/JEIComputerCraft.java
@@ -28,7 +28,7 @@ import java.util.List;
 public class JEIComputerCraft implements IModPlugin {
     @Override
     public ResourceLocation getPluginUid() {
-        return new ResourceLocation(ComputerCraftAPI.MOD_ID, "jei");
+        return ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "jei");
     }
 
     @Override

--- a/projects/common/src/main/java/dan200/computercraft/shared/integration/jei/RecipeResolver.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/integration/jei/RecipeResolver.java
@@ -22,7 +22,7 @@ import net.minecraft.world.item.crafting.RecipeHolder;
 import java.util.List;
 
 class RecipeResolver implements IRecipeManagerPlugin {
-    private static final ResourceLocation RECIPE_ID = new ResourceLocation(ComputerCraftAPI.MOD_ID, "upgrade");
+    private static final ResourceLocation RECIPE_ID = ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "upgrade");
     private final UpgradeRecipeGenerator<RecipeHolder<CraftingRecipe>> resolver = new UpgradeRecipeGenerator<>(x -> new RecipeHolder<>(RECIPE_ID, x), RecipeModHelpers.getEmptyRegistryAccess());
 
     @Override

--- a/projects/common/src/main/java/dan200/computercraft/shared/media/items/DiskItem.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/media/items/DiskItem.java
@@ -14,6 +14,7 @@ import dan200.computercraft.shared.config.Config;
 import dan200.computercraft.shared.util.NonNegativeId;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.HolderLookup;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerLevel;
@@ -49,7 +50,7 @@ public class DiskItem extends Item implements IMedia {
     }
 
     @Override
-    public @Nullable String getLabel(ItemStack stack) {
+    public @Nullable String getLabel(HolderLookup.Provider registries, ItemStack stack) {
         var label = stack.get(DataComponents.CUSTOM_NAME);
         return label != null ? label.getString() : null;
     }

--- a/projects/common/src/main/java/dan200/computercraft/shared/media/items/RecordMedia.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/media/items/RecordMedia.java
@@ -5,14 +5,14 @@
 package dan200.computercraft.shared.media.items;
 
 import dan200.computercraft.api.media.IMedia;
-import net.minecraft.sounds.SoundEvent;
+import net.minecraft.core.HolderLookup;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.RecordItem;
+import net.minecraft.world.item.JukeboxSong;
 
 import javax.annotation.Nullable;
 
 /**
- * An implementation of {@link IMedia} for {@link RecordItem}.
+ * An implementation of {@link IMedia} for items with a {@link JukeboxSong}.
  */
 public final class RecordMedia implements IMedia {
     public static final RecordMedia INSTANCE = new RecordMedia();
@@ -21,19 +21,8 @@ public final class RecordMedia implements IMedia {
     }
 
     @Override
-    public @Nullable String getLabel(ItemStack stack) {
-        return getAudioTitle(stack);
-    }
-
-    @Override
-    public @Nullable String getAudioTitle(ItemStack stack) {
-        var item = stack.getItem();
-        return item instanceof RecordItem record ? record.getDisplayName().getString() : null;
-    }
-
-    @Override
-    public @Nullable SoundEvent getAudio(ItemStack stack) {
-        var item = stack.getItem();
-        return item instanceof RecordItem record ? record.getSound() : null;
+    public @Nullable String getLabel(HolderLookup.Provider registries, ItemStack stack) {
+        var song = getAudio(registries, stack);
+        return song == null ? null : song.value().description().getString();
     }
 }

--- a/projects/common/src/main/java/dan200/computercraft/shared/media/items/TreasureDiskItem.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/media/items/TreasureDiskItem.java
@@ -11,6 +11,7 @@ import dan200.computercraft.api.media.IMedia;
 import dan200.computercraft.core.filesystem.SubMount;
 import dan200.computercraft.shared.ModRegistry;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.HolderLookup;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.player.Player;
@@ -39,7 +40,7 @@ public class TreasureDiskItem extends Item implements IMedia {
     }
 
     @Override
-    public String getLabel(ItemStack stack) {
+    public String getLabel(HolderLookup.Provider registries, ItemStack stack) {
         return TreasureDisk.getTitle(stack);
     }
 

--- a/projects/common/src/main/java/dan200/computercraft/shared/media/recipes/DiskRecipe.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/media/recipes/DiskRecipe.java
@@ -12,14 +12,10 @@ import dan200.computercraft.shared.util.ColourUtils;
 import dan200.computercraft.shared.util.DataComponentUtil;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.component.DataComponents;
-import net.minecraft.world.inventory.CraftingContainer;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.component.DyedItemColor;
-import net.minecraft.world.item.crafting.CraftingBookCategory;
-import net.minecraft.world.item.crafting.CustomRecipe;
-import net.minecraft.world.item.crafting.Ingredient;
-import net.minecraft.world.item.crafting.RecipeSerializer;
+import net.minecraft.world.item.crafting.*;
 import net.minecraft.world.level.Level;
 
 public class DiskRecipe extends CustomRecipe {
@@ -31,11 +27,11 @@ public class DiskRecipe extends CustomRecipe {
     }
 
     @Override
-    public boolean matches(CraftingContainer inv, Level world) {
+    public boolean matches(CraftingInput inv, Level world) {
         var paperFound = false;
         var redstoneFound = false;
 
-        for (var i = 0; i < inv.getContainerSize(); i++) {
+        for (var i = 0; i < inv.size(); i++) {
             var stack = inv.getItem(i);
 
             if (!stack.isEmpty()) {
@@ -55,10 +51,10 @@ public class DiskRecipe extends CustomRecipe {
     }
 
     @Override
-    public ItemStack assemble(CraftingContainer inv, HolderLookup.Provider registryAccess) {
+    public ItemStack assemble(CraftingInput inv, HolderLookup.Provider registryAccess) {
         var tracker = new ColourTracker();
 
-        for (var i = 0; i < inv.getContainerSize(); i++) {
+        for (var i = 0; i < inv.size(); i++) {
             var stack = inv.getItem(i);
 
             if (stack.isEmpty()) continue;

--- a/projects/common/src/main/java/dan200/computercraft/shared/media/recipes/PrintoutRecipe.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/media/recipes/PrintoutRecipe.java
@@ -18,8 +18,8 @@ import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.util.ExtraCodecs;
 import net.minecraft.world.entity.player.StackedContents;
-import net.minecraft.world.inventory.CraftingContainer;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.CraftingInput;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.item.crafting.ShapelessRecipe;
@@ -93,7 +93,7 @@ public final class PrintoutRecipe extends ShapelessRecipe {
     }
 
     @Override
-    public boolean matches(CraftingContainer inv, Level world) {
+    public boolean matches(CraftingInput inv, Level world) {
         var stackedContents = new StackedContents();
 
         var inputs = 0;
@@ -101,7 +101,7 @@ public final class PrintoutRecipe extends ShapelessRecipe {
         var pages = 0;
         var hasPrintout = false;
 
-        for (var j = 0; j < inv.getContainerSize(); ++j) {
+        for (var j = 0; j < inv.size(); ++j) {
             var stack = inv.getItem(j);
             if (stack.isEmpty()) continue;
             if (printout.test(stack)) {
@@ -125,9 +125,9 @@ public final class PrintoutRecipe extends ShapelessRecipe {
     }
 
     @Override
-    public ItemStack assemble(CraftingContainer inv, HolderLookup.Provider registries) {
+    public ItemStack assemble(CraftingInput inv, HolderLookup.Provider registries) {
         List<PrintoutData> data = new ArrayList<>();
-        for (var j = 0; j < inv.getContainerSize(); ++j) {
+        for (var j = 0; j < inv.size(); ++j) {
             var stack = inv.getItem(j);
             if (!stack.isEmpty() && printout.test(stack)) data.add(PrintoutData.getOrEmpty(stack));
         }

--- a/projects/common/src/main/java/dan200/computercraft/shared/network/NetworkMessages.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/network/NetworkMessages.java
@@ -51,7 +51,7 @@ public final class NetworkMessages {
         String channel, StreamCodec<RegistryFriendlyByteBuf, T> codec
     ) {
         if (!seenChannel.add(channel)) throw new IllegalArgumentException("Duplicate channel " + channel);
-        var type = new CustomPacketPayload.Type<T>(new ResourceLocation(ComputerCraftAPI.MOD_ID, channel));
+        var type = new CustomPacketPayload.Type<T>(ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, channel));
         messages.add(new CustomPacketPayload.TypeAndCodec<>(type, codec));
         return type;
     }

--- a/projects/common/src/main/java/dan200/computercraft/shared/network/client/ClientNetworkContext.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/network/client/ClientNetworkContext.java
@@ -11,9 +11,10 @@ import dan200.computercraft.shared.computer.upload.UploadResult;
 import dan200.computercraft.shared.peripheral.speaker.EncodedAudio;
 import dan200.computercraft.shared.peripheral.speaker.SpeakerPosition;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Holder;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.sounds.SoundEvent;
+import net.minecraft.world.item.JukeboxSong;
 
 import javax.annotation.Nullable;
 import java.util.UUID;
@@ -28,7 +29,7 @@ public interface ClientNetworkContext {
 
     void handleMonitorData(BlockPos pos, @Nullable TerminalState terminal);
 
-    void handlePlayRecord(BlockPos pos, @Nullable SoundEvent sound, @Nullable String name);
+    void handlePlayRecord(BlockPos pos, @Nullable Holder<JukeboxSong> sound);
 
     void handlePocketComputerData(UUID instanceId, ComputerState state, int lightState, @Nullable TerminalState terminal);
 

--- a/projects/common/src/main/java/dan200/computercraft/shared/network/client/PlayRecordClientMessage.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/network/client/PlayRecordClientMessage.java
@@ -13,37 +13,36 @@ import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
-import net.minecraft.sounds.SoundEvent;
+import net.minecraft.world.item.JukeboxSong;
 
 import java.util.Optional;
 
 /**
- * Starts or stops a record on the client, depending on if {@link #soundEvent} is {@code null}.
+ * Starts or stops a record on the client, depending on if {@link #song} is {@code null}.
  * <p>
  * Used by disk drives to play record items.
  *
- * @param pos        The position of the speaker, where we should play this sound.
- * @param soundEvent The sound to play, or {@link Optional#empty()} if we should stop playing.
- * @param name       The title of the audio to play.
+ * @param pos  The position of the speaker, where we should play this sound.
+ * @param song The sound to play, or {@link Optional#empty()} if we should stop playing.
+ * @param name The title of the audio to play.
  * @see DiskDriveBlockEntity
  */
 public record PlayRecordClientMessage(
-    BlockPos pos, Optional<Holder<SoundEvent>> soundEvent, Optional<String> name
+    BlockPos pos, Optional<Holder<JukeboxSong>> song
 ) implements NetworkMessage<ClientNetworkContext> {
     public static final StreamCodec<RegistryFriendlyByteBuf, PlayRecordClientMessage> STREAM_CODEC = StreamCodec.composite(
         BlockPos.STREAM_CODEC, PlayRecordClientMessage::pos,
-        ByteBufCodecs.optional(SoundEvent.STREAM_CODEC), PlayRecordClientMessage::soundEvent,
-        ByteBufCodecs.optional(ByteBufCodecs.STRING_UTF8), PlayRecordClientMessage::name,
+        ByteBufCodecs.optional(JukeboxSong.STREAM_CODEC), PlayRecordClientMessage::song,
         PlayRecordClientMessage::new
     );
 
     public PlayRecordClientMessage(BlockPos pos) {
-        this(pos, Optional.empty(), Optional.empty());
+        this(pos, Optional.empty());
     }
 
     @Override
     public void handle(ClientNetworkContext context) {
-        context.handlePlayRecord(pos, soundEvent.map(Holder::value).orElse(null), name.orElse(null));
+        context.handlePlayRecord(pos, song.orElse(null));
     }
 
     @Override

--- a/projects/common/src/main/java/dan200/computercraft/shared/network/codec/MoreStreamCodecs.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/network/codec/MoreStreamCodecs.java
@@ -48,7 +48,7 @@ public class MoreStreamCodecs {
 
             @Override
             public void encode(B buffer, NonNullList<C> list) {
-                var count = buffer.writeVarInt(list.size());
+                buffer.writeVarInt(list.size());
                 for (var entry : list) codec.encode(buffer, entry);
             }
         };

--- a/projects/common/src/main/java/dan200/computercraft/shared/peripheral/diskdrive/DiskDriveBlockEntity.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/peripheral/diskdrive/DiskDriveBlockEntity.java
@@ -15,7 +15,10 @@ import dan200.computercraft.shared.container.BasicContainer;
 import dan200.computercraft.shared.network.client.PlayRecordClientMessage;
 import dan200.computercraft.shared.network.server.ServerNetworking;
 import dan200.computercraft.shared.util.WorldUtil;
-import net.minecraft.core.*;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.core.NonNullList;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.player.Inventory;
@@ -131,11 +134,10 @@ public final class DiskDriveBlockEntity extends AbstractContainerBlockEntity imp
             switch (recordQueued) {
                 case PLAY -> {
                     var media = getMedia();
-                    var record = media.getAudio();
+                    var record = media.getAudio(getLevel().registryAccess());
                     if (record != null) {
                         recordPlaying = true;
-                        var title = media.getAudioTitle();
-                        sendMessage(new PlayRecordClientMessage(getBlockPos(), Optional.of(Holder.direct(record)), Optional.ofNullable(title)));
+                        sendMessage(new PlayRecordClientMessage(getBlockPos(), Optional.of(record)));
                     }
                 }
                 case STOP -> {

--- a/projects/common/src/main/java/dan200/computercraft/shared/peripheral/diskdrive/DiskDrivePeripheral.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/peripheral/diskdrive/DiskDrivePeripheral.java
@@ -64,7 +64,7 @@ public class DiskDrivePeripheral implements IPeripheral {
     @LuaFunction
     public final Object[] getDiskLabel() {
         var media = diskDrive.getMedia();
-        return media.media() == null ? null : new Object[]{ media.media().getLabel(media.stack()) };
+        return media.media() == null ? null : new Object[]{ media.media().getLabel(diskDrive.getLevel().registryAccess(), media.stack()) };
     }
 
     /**
@@ -117,7 +117,7 @@ public class DiskDrivePeripheral implements IPeripheral {
      */
     @LuaFunction
     public final boolean hasAudio() {
-        return diskDrive.getMedia().getAudio() != null;
+        return diskDrive.getMedia().getAudio(diskDrive.getLevel().registryAccess()) != null;
     }
 
     /**
@@ -130,7 +130,10 @@ public class DiskDrivePeripheral implements IPeripheral {
     @Nullable
     public final Object getAudioTitle() {
         var stack = diskDrive.getMedia();
-        return stack.media() != null ? stack.getAudioTitle() : false;
+        if (stack.media() == null) return false;
+
+        var audio = stack.getAudio(diskDrive.getLevel().registryAccess());
+        return audio == null ? null : audio.value().description().getString();
     }
 
     /**

--- a/projects/common/src/main/java/dan200/computercraft/shared/peripheral/diskdrive/MediaStack.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/peripheral/diskdrive/MediaStack.java
@@ -6,8 +6,10 @@ package dan200.computercraft.shared.peripheral.diskdrive;
 
 import dan200.computercraft.api.media.IMedia;
 import dan200.computercraft.impl.MediaProviders;
-import net.minecraft.sounds.SoundEvent;
+import net.minecraft.core.Holder;
+import net.minecraft.core.HolderLookup;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.JukeboxSong;
 
 import javax.annotation.Nullable;
 
@@ -28,12 +30,7 @@ record MediaStack(ItemStack stack, @Nullable IMedia media) {
     }
 
     @Nullable
-    SoundEvent getAudio() {
-        return media != null ? media.getAudio(stack) : null;
-    }
-
-    @Nullable
-    String getAudioTitle() {
-        return media != null ? media.getAudioTitle(stack) : null;
+    Holder<JukeboxSong> getAudio(HolderLookup.Provider registries) {
+        return media != null ? media.getAudio(registries, stack) : null;
     }
 }

--- a/projects/common/src/main/java/dan200/computercraft/shared/platform/PlatformHelper.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/platform/PlatformHelper.java
@@ -28,12 +28,12 @@ import net.minecraft.world.*;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
-import net.minecraft.world.inventory.CraftingContainer;
 import net.minecraft.world.inventory.MenuType;
 import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.CraftingInput;
 import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
@@ -217,7 +217,7 @@ public interface PlatformHelper {
      * @param container The crafting container.
      * @return A list of items to return to the player after crafting.
      */
-    List<ItemStack> getRecipeRemainingItems(ServerPlayer player, Recipe<CraftingContainer> recipe, CraftingContainer container);
+    List<ItemStack> getRecipeRemainingItems(ServerPlayer player, Recipe<CraftingInput> recipe, CraftingInput container);
 
     /**
      * Fire an event after crafting has occurred.
@@ -226,7 +226,7 @@ public interface PlatformHelper {
      * @param container The current crafting container.
      * @param stack     The resulting stack from crafting.
      */
-    void onItemCrafted(ServerPlayer player, CraftingContainer container, ItemStack stack);
+    void onItemCrafted(ServerPlayer player, CraftingInput container, ItemStack stack);
 
     /**
      * Check whether we should notify neighbours in a particular direction.

--- a/projects/common/src/main/java/dan200/computercraft/shared/pocket/items/PocketComputerItem.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/pocket/items/PocketComputerItem.java
@@ -25,6 +25,7 @@ import dan200.computercraft.shared.util.DataComponentUtil;
 import dan200.computercraft.shared.util.IDAssigner;
 import dan200.computercraft.shared.util.NonNegativeId;
 import net.minecraft.ChatFormatting;
+import net.minecraft.core.HolderLookup;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
@@ -189,9 +190,13 @@ public class PocketComputerItem extends Item implements IMedia {
 
     // IMedia
 
-    @Override
-    public @Nullable String getLabel(ItemStack stack) {
+    private @Nullable String getLabel(ItemStack stack) {
         return DataComponentUtil.getCustomName(stack);
+    }
+
+    @Override
+    public @Nullable String getLabel(HolderLookup.Provider registries, ItemStack stack) {
+        return getLabel(stack);
     }
 
     @Override

--- a/projects/common/src/main/java/dan200/computercraft/shared/pocket/recipes/PocketComputerUpgradeRecipe.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/pocket/recipes/PocketComputerUpgradeRecipe.java
@@ -10,9 +10,9 @@ import dan200.computercraft.impl.PocketUpgrades;
 import dan200.computercraft.shared.ModRegistry;
 import dan200.computercraft.shared.pocket.items.PocketComputerItem;
 import net.minecraft.core.HolderLookup;
-import net.minecraft.world.inventory.CraftingContainer;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.CraftingBookCategory;
+import net.minecraft.world.item.crafting.CraftingInput;
 import net.minecraft.world.item.crafting.CustomRecipe;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.level.Level;
@@ -33,20 +33,20 @@ public final class PocketComputerUpgradeRecipe extends CustomRecipe {
     }
 
     @Override
-    public boolean matches(CraftingContainer inventory, Level world) {
+    public boolean matches(CraftingInput inventory, Level world) {
         return !assemble(inventory, world.registryAccess()).isEmpty();
     }
 
     @Override
-    public ItemStack assemble(CraftingContainer inventory, HolderLookup.Provider registryAccess) {
+    public ItemStack assemble(CraftingInput inventory, HolderLookup.Provider registryAccess) {
         // Scan the grid for a pocket computer
         var computer = ItemStack.EMPTY;
         var computerX = -1;
         var computerY = -1;
         computer:
-        for (var y = 0; y < inventory.getHeight(); y++) {
-            for (var x = 0; x < inventory.getWidth(); x++) {
-                var item = inventory.getItem(x + y * inventory.getWidth());
+        for (var y = 0; y < inventory.height(); y++) {
+            for (var x = 0; x < inventory.width(); x++) {
+                var item = inventory.getItem(x, y);
                 if (!item.isEmpty() && item.getItem() instanceof PocketComputerItem) {
                     computer = item;
                     computerX = x;
@@ -58,14 +58,13 @@ public final class PocketComputerUpgradeRecipe extends CustomRecipe {
 
         if (computer.isEmpty()) return ItemStack.EMPTY;
 
-        var itemComputer = (PocketComputerItem) computer.getItem();
         if (PocketComputerItem.getUpgradeWithData(computer) != null) return ItemStack.EMPTY;
 
         // Check for upgrades around the item
         UpgradeData<IPocketUpgrade> upgrade = null;
-        for (var y = 0; y < inventory.getHeight(); y++) {
-            for (var x = 0; x < inventory.getWidth(); x++) {
-                var item = inventory.getItem(x + y * inventory.getWidth());
+        for (var y = 0; y < inventory.height(); y++) {
+            for (var x = 0; x < inventory.width(); x++) {
+                var item = inventory.getItem(x, y);
                 if (x == computerX && y == computerY) continue;
 
                 if (x == computerX && y == computerY - 1) {

--- a/projects/common/src/main/java/dan200/computercraft/shared/recipe/ImpostorShapedRecipe.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/recipe/ImpostorShapedRecipe.java
@@ -6,8 +6,8 @@ package dan200.computercraft.shared.recipe;
 
 import dan200.computercraft.shared.ModRegistry;
 import net.minecraft.core.HolderLookup;
-import net.minecraft.world.inventory.CraftingContainer;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.CraftingInput;
 import net.minecraft.world.item.crafting.CustomRecipe;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.item.crafting.ShapedRecipe;
@@ -24,12 +24,12 @@ public final class ImpostorShapedRecipe extends CustomShapedRecipe {
     }
 
     @Override
-    public boolean matches(CraftingContainer inv, Level world) {
+    public boolean matches(CraftingInput inv, Level world) {
         return false;
     }
 
     @Override
-    public ItemStack assemble(CraftingContainer inventory, HolderLookup.Provider registryAccess) {
+    public ItemStack assemble(CraftingInput inventory, HolderLookup.Provider registryAccess) {
         return ItemStack.EMPTY;
     }
 

--- a/projects/common/src/main/java/dan200/computercraft/shared/recipe/ImpostorShapelessRecipe.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/recipe/ImpostorShapelessRecipe.java
@@ -6,8 +6,8 @@ package dan200.computercraft.shared.recipe;
 
 import dan200.computercraft.shared.ModRegistry;
 import net.minecraft.core.HolderLookup;
-import net.minecraft.world.inventory.CraftingContainer;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.CraftingInput;
 import net.minecraft.world.item.crafting.CustomRecipe;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.item.crafting.ShapelessRecipe;
@@ -24,12 +24,12 @@ public final class ImpostorShapelessRecipe extends CustomShapelessRecipe {
     }
 
     @Override
-    public boolean matches(CraftingContainer inv, Level world) {
+    public boolean matches(CraftingInput inv, Level world) {
         return false;
     }
 
     @Override
-    public ItemStack assemble(CraftingContainer inventory, HolderLookup.Provider access) {
+    public ItemStack assemble(CraftingInput inventory, HolderLookup.Provider access) {
         return ItemStack.EMPTY;
     }
 

--- a/projects/common/src/main/java/dan200/computercraft/shared/recipe/TransformShapedRecipe.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/recipe/TransformShapedRecipe.java
@@ -11,8 +11,8 @@ import dan200.computercraft.shared.recipe.function.RecipeFunction;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
-import net.minecraft.world.inventory.CraftingContainer;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.CraftingInput;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.item.crafting.ShapedRecipe;
 
@@ -42,7 +42,7 @@ public final class TransformShapedRecipe extends CustomShapedRecipe {
     }
 
     @Override
-    public ItemStack assemble(CraftingContainer inventory, HolderLookup.Provider registryAccess) {
+    public ItemStack assemble(CraftingInput inventory, HolderLookup.Provider registryAccess) {
         var result = super.assemble(inventory, registryAccess);
         for (var function : functions) result = function.apply(inventory, result);
         return result;

--- a/projects/common/src/main/java/dan200/computercraft/shared/recipe/TransformShapelessRecipe.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/recipe/TransformShapelessRecipe.java
@@ -11,8 +11,8 @@ import dan200.computercraft.shared.recipe.function.RecipeFunction;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
-import net.minecraft.world.inventory.CraftingContainer;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.CraftingInput;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.item.crafting.ShapelessRecipe;
 
@@ -41,7 +41,7 @@ public class TransformShapelessRecipe extends CustomShapelessRecipe {
     }
 
     @Override
-    public ItemStack assemble(CraftingContainer inventory, HolderLookup.Provider registryAccess) {
+    public ItemStack assemble(CraftingInput inventory, HolderLookup.Provider registryAccess) {
         var result = super.assemble(inventory, registryAccess);
         for (var function : functions) result = function.apply(inventory, result);
         return result;

--- a/projects/common/src/main/java/dan200/computercraft/shared/recipe/function/CopyComponents.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/recipe/function/CopyComponents.java
@@ -12,8 +12,8 @@ import net.minecraft.core.component.DataComponentType;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
-import net.minecraft.world.inventory.CraftingContainer;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.CraftingInput;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.level.ItemLike;
 import net.minecraft.world.level.storage.loot.functions.CopyComponentsFunction;
@@ -83,8 +83,8 @@ public final class CopyComponents implements RecipeFunction {
     }
 
     @Override
-    public ItemStack apply(CraftingContainer container, ItemStack result) {
-        for (var item : container.getItems()) {
+    public ItemStack apply(CraftingInput container, ItemStack result) {
+        for (var item : container.items()) {
             if (from.test(item)) {
                 applyPatch(item.getComponentsPatch(), result);
                 break;

--- a/projects/common/src/main/java/dan200/computercraft/shared/recipe/function/RecipeFunction.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/recipe/function/RecipeFunction.java
@@ -16,8 +16,8 @@ import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.inventory.CraftingContainer;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.CraftingInput;
 import net.minecraft.world.level.storage.loot.functions.LootItemFunction;
 
 import java.util.List;
@@ -39,7 +39,7 @@ public interface RecipeFunction {
     /**
      * The registry where {@link RecipeFunction}s are registered.
      */
-    ResourceKey<Registry<Type<?>>> REGISTRY = ResourceKey.createRegistryKey(new ResourceLocation(ComputerCraftAPI.MOD_ID, "recipe_function"));
+    ResourceKey<Registry<Type<?>>> REGISTRY = ResourceKey.createRegistryKey(ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "recipe_function"));
 
     /**
      * The codec to read and write {@link RecipeFunction}s with.
@@ -75,7 +75,7 @@ public interface RecipeFunction {
      * @param result    The result item to modify. This may be mutated in place.
      * @return The new result item. This may be {@code result}.
      */
-    ItemStack apply(CraftingContainer container, ItemStack result);
+    ItemStack apply(CraftingInput container, ItemStack result);
 
     /**
      * Properties about a type of {@link RecipeFunction}. These are stored in {@linkplain #REGISTRY a Minecraft

--- a/projects/common/src/main/java/dan200/computercraft/shared/turtle/core/TurtleBrain.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/turtle/core/TurtleBrain.java
@@ -134,7 +134,7 @@ public class TurtleBrain implements TurtleAccessInternal {
         // Read fields
         colourHex = nbt.contains(NBT_COLOUR) ? nbt.getInt(NBT_COLOUR) : -1;
         fuelLevel = nbt.contains(NBT_FUEL) ? nbt.getInt(NBT_FUEL) : 0;
-        overlay = nbt.contains(NBT_OVERLAY) ? new ResourceLocation(nbt.getString(NBT_OVERLAY)) : null;
+        overlay = nbt.contains(NBT_OVERLAY) ? ResourceLocation.parse(nbt.getString(NBT_OVERLAY)) : null;
 
         // Read upgrades
         setUpgradeDirect(TurtleSide.LEFT, NBTUtil.decodeFrom(TurtleUpgrades.instance().upgradeDataCodec(), registries, nbt, NBT_LEFT_UPGRADE));

--- a/projects/common/src/main/java/dan200/computercraft/shared/turtle/core/TurtleCraftCommand.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/turtle/core/TurtleCraftCommand.java
@@ -21,8 +21,7 @@ public class TurtleCraftCommand implements TurtleCommand {
     @Override
     public TurtleCommandResult execute(ITurtleAccess turtle) {
         // Craft the item
-        var crafting = new TurtleInventoryCrafting(turtle);
-        var results = crafting.doCrafting(turtle.getLevel(), limit);
+        var results = TurtleInventoryCrafting.craft(turtle, limit);
         if (results == null) return TurtleCommandResult.failure("No matching recipes");
 
         // Store or drop any remainders

--- a/projects/common/src/main/java/dan200/computercraft/shared/turtle/inventory/UpgradeSlot.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/turtle/inventory/UpgradeSlot.java
@@ -23,8 +23,8 @@ import javax.annotation.Nullable;
  * @see TurtleMenu
  */
 public class UpgradeSlot extends Slot {
-    public static final ResourceLocation LEFT_UPGRADE = new ResourceLocation(ComputerCraftAPI.MOD_ID, "gui/turtle_upgrade_left");
-    public static final ResourceLocation RIGHT_UPGRADE = new ResourceLocation(ComputerCraftAPI.MOD_ID, "gui/turtle_upgrade_right");
+    public static final ResourceLocation LEFT_UPGRADE = ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "gui/turtle_upgrade_left");
+    public static final ResourceLocation RIGHT_UPGRADE = ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "gui/turtle_upgrade_right");
 
     private final HolderLookup.Provider registries;
     private final TurtleSide side;

--- a/projects/common/src/main/java/dan200/computercraft/shared/turtle/recipes/TurtleUpgradeRecipe.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/turtle/recipes/TurtleUpgradeRecipe.java
@@ -11,9 +11,9 @@ import dan200.computercraft.impl.TurtleUpgrades;
 import dan200.computercraft.shared.ModRegistry;
 import dan200.computercraft.shared.turtle.items.TurtleItem;
 import net.minecraft.core.HolderLookup;
-import net.minecraft.world.inventory.CraftingContainer;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.CraftingBookCategory;
+import net.minecraft.world.item.crafting.CraftingInput;
 import net.minecraft.world.item.crafting.CustomRecipe;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.level.Level;
@@ -34,23 +34,23 @@ public final class TurtleUpgradeRecipe extends CustomRecipe {
     }
 
     @Override
-    public boolean matches(CraftingContainer inventory, Level world) {
+    public boolean matches(CraftingInput inventory, Level world) {
         return !assemble(inventory, world.registryAccess()).isEmpty();
     }
 
     @Override
-    public ItemStack assemble(CraftingContainer inventory, HolderLookup.Provider registryAccess) {
+    public ItemStack assemble(CraftingInput inventory, HolderLookup.Provider registryAccess) {
         // Scan the grid for a row containing a turtle and 1 or 2 items
         var leftItem = ItemStack.EMPTY;
         var turtle = ItemStack.EMPTY;
         var rightItem = ItemStack.EMPTY;
 
-        for (var y = 0; y < inventory.getHeight(); y++) {
+        for (var y = 0; y < inventory.height(); y++) {
             if (turtle.isEmpty()) {
                 // Search this row for potential turtles
                 var finishedRow = false;
-                for (var x = 0; x < inventory.getWidth(); x++) {
-                    var item = inventory.getItem(x + y * inventory.getWidth());
+                for (var x = 0; x < inventory.width(); x++) {
+                    var item = inventory.getItem(x, y);
                     if (!item.isEmpty()) {
                         if (finishedRow) {
                             return ItemStack.EMPTY;
@@ -87,8 +87,8 @@ public final class TurtleUpgradeRecipe extends CustomRecipe {
                 }
             } else {
                 // Turtle is already found, just check this row is empty
-                for (var x = 0; x < inventory.getWidth(); x++) {
-                    var item = inventory.getItem(x + y * inventory.getWidth());
+                for (var x = 0; x < inventory.width(); x++) {
+                    var item = inventory.getItem(x, y);
                     if (!item.isEmpty()) {
                         return ItemStack.EMPTY;
                     }

--- a/projects/common/src/main/java/dan200/computercraft/shared/turtle/upgrades/TurtleTool.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/turtle/upgrades/TurtleTool.java
@@ -27,12 +27,8 @@ import net.minecraft.tags.TagKey;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.LivingEntity;
-import net.minecraft.world.entity.ai.attributes.Attributes;
-import net.minecraft.world.entity.decoration.ArmorStand;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.enchantment.EnchantmentHelper;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
@@ -206,6 +202,7 @@ public class TurtleTool extends AbstractTurtleUpgrade {
      * @see Player#attack(Entity)
      */
     private boolean attack(ServerPlayer player, Direction direction, Entity entity) {
+        /*
         var baseDamage = (float) player.getAttributeValue(Attributes.ATTACK_DAMAGE) * spec.damageMultiplier();
         var bonusDamage = EnchantmentHelper.getDamageBonus(player.getItemInHand(InteractionHand.MAIN_HAND), entity.getType());
         var damage = baseDamage + bonusDamage;
@@ -242,20 +239,20 @@ public class TurtleTool extends AbstractTurtleUpgrade {
         }
 
         // Apply remaining enchantments
-        if (entity instanceof LivingEntity target) EnchantmentHelper.doPostHurtEffects(target, player);
-        EnchantmentHelper.doPostDamageEffects(player, entity);
+        boolean doPostHurt = false;
+        if (entity instanceof LivingEntity target) {
+            doPostHurt = player.getItemInHand(InteractionHand.MAIN_HAND).hurtEnemy(target, player);
+        }
+
+        EnchantmentHelper.doPostAttackEffects(player.serverLevel(), entity, source);
 
         // Damage the original item stack.
-        if (entity instanceof LivingEntity target) {
-            player.getItemInHand(InteractionHand.MAIN_HAND).hurtEnemy(target, player);
+        if (entity instanceof LivingEntity target && doPostHurt) {
+            player.getItemInHand(InteractionHand.MAIN_HAND).postHurtEnemy(target, player);
         }
 
-        // Apply fire aspect
-        if (entity instanceof LivingEntity target && fireAspect > 0 && !target.isOnFire()) {
-            target.igniteForSeconds(4 * fireAspect);
-        }
-
-        return true;
+        return true;*/
+        return false;
     }
 
     private TurtleCommandResult dig(ITurtleAccess turtle, TurtleSide side, Direction direction) {

--- a/projects/common/src/main/java/dan200/computercraft/shared/util/ArgumentHelpers.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/util/ArgumentHelpers.java
@@ -22,7 +22,7 @@ public final class ArgumentHelpers {
     public static <T> T getRegistryEntry(String name, String typeName, Registry<T> registry) throws LuaException {
         ResourceLocation id;
         try {
-            id = new ResourceLocation(name);
+            id = ResourceLocation.parse(name);
         } catch (ResourceLocationException e) {
             id = null;
         }

--- a/projects/common/src/test/java/dan200/computercraft/TestPlatformHelper.java
+++ b/projects/common/src/test/java/dan200/computercraft/TestPlatformHelper.java
@@ -30,11 +30,11 @@ import net.minecraft.world.MenuProvider;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
-import net.minecraft.world.inventory.CraftingContainer;
 import net.minecraft.world.inventory.MenuType;
 import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.CraftingInput;
 import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
@@ -156,12 +156,12 @@ public class TestPlatformHelper extends AbstractComputerCraftAPI implements Plat
     }
 
     @Override
-    public List<ItemStack> getRecipeRemainingItems(ServerPlayer player, Recipe<CraftingContainer> recipe, CraftingContainer container) {
+    public List<ItemStack> getRecipeRemainingItems(ServerPlayer player, Recipe<CraftingInput> recipe, CraftingInput container) {
         throw new UnsupportedOperationException("Cannot query recipes inside tests");
     }
 
     @Override
-    public void onItemCrafted(ServerPlayer player, CraftingContainer container, ItemStack stack) {
+    public void onItemCrafted(ServerPlayer player, CraftingInput container, ItemStack stack) {
         throw new UnsupportedOperationException("Cannot interact with the world inside tests");
     }
 

--- a/projects/common/src/testMod/kotlin/dan200/computercraft/gametest/Recipe_Test.kt
+++ b/projects/common/src/testMod/kotlin/dan200/computercraft/gametest/Recipe_Test.kt
@@ -8,18 +8,16 @@ import com.mojang.authlib.GameProfile
 import dan200.computercraft.gametest.api.Structures
 import dan200.computercraft.gametest.api.sequence
 import dan200.computercraft.shared.ModRegistry
+import net.minecraft.core.NonNullList
 import net.minecraft.core.component.DataComponentPatch
 import net.minecraft.core.component.DataComponents
 import net.minecraft.gametest.framework.GameTest
 import net.minecraft.gametest.framework.GameTestAssertException
 import net.minecraft.gametest.framework.GameTestHelper
-import net.minecraft.world.entity.player.Player
-import net.minecraft.world.inventory.AbstractContainerMenu
-import net.minecraft.world.inventory.MenuType
-import net.minecraft.world.inventory.TransientCraftingContainer
 import net.minecraft.world.item.ItemStack
 import net.minecraft.world.item.Items
 import net.minecraft.world.item.component.ResolvableProfile
+import net.minecraft.world.item.crafting.CraftingInput
 import net.minecraft.world.item.crafting.RecipeType
 import org.junit.jupiter.api.Assertions.assertEquals
 import java.util.*
@@ -33,9 +31,10 @@ class Recipe_Test {
     @GameTest(template = Structures.DEFAULT)
     fun Craft_result_has_nbt(context: GameTestHelper) = context.sequence {
         thenExecute {
-            val container = TransientCraftingContainer(DummyMenu, 3, 3)
-            container.setItem(0, ItemStack(Items.SKELETON_SKULL))
-            container.setItem(1, ItemStack(ModRegistry.Items.COMPUTER_ADVANCED.get()))
+            val items = NonNullList.withSize(3 * 3, ItemStack.EMPTY)
+            items[0] = ItemStack(Items.SKELETON_SKULL)
+            items[1] = ItemStack(ModRegistry.Items.COMPUTER_ADVANCED.get())
+            val container = CraftingInput.of(3, 3, items)
 
             val recipe = context.level.server.recipeManager
                 .getRecipeFor(RecipeType.CRAFTING, container, context.level)
@@ -48,10 +47,5 @@ class Recipe_Test {
             val tag = DataComponentPatch.builder().set(DataComponents.PROFILE, ResolvableProfile(profile)).build()
             assertEquals(tag, result.componentsPatch, "Expected NBT tags to be the same")
         }
-    }
-
-    object DummyMenu : AbstractContainerMenu(MenuType.GENERIC_9x1, 0) {
-        override fun quickMoveStack(player: Player, slot: Int): ItemStack = ItemStack.EMPTY
-        override fun stillValid(p0: Player): Boolean = true
     }
 }

--- a/projects/common/src/testMod/kotlin/dan200/computercraft/gametest/Speaker_Test.kt
+++ b/projects/common/src/testMod/kotlin/dan200/computercraft/gametest/Speaker_Test.kt
@@ -36,7 +36,7 @@ class Speaker_Test {
     @GameTest
     fun Will_not_play_record(helper: GameTestHelper) = helper.sequence {
         thenOnComputer {
-            callPeripheral("right", "playSound", SoundEvents.MUSIC_DISC_PIGSTEP.location.toString())
+            callPeripheral("right", "playSound", SoundEvents.MUSIC_DISC_PIGSTEP.key().location().toString())
                 .assertArrayEquals(false)
         }
     }

--- a/projects/common/src/testMod/kotlin/dan200/computercraft/gametest/Turtle_Test.kt
+++ b/projects/common/src/testMod/kotlin/dan200/computercraft/gametest/Turtle_Test.kt
@@ -27,6 +27,7 @@ import dan200.computercraft.test.core.assertArrayEquals
 import dan200.computercraft.test.core.computer.LuaTaskContext
 import dan200.computercraft.test.core.computer.getApi
 import net.minecraft.core.BlockPos
+import net.minecraft.core.registries.Registries
 import net.minecraft.gametest.framework.GameTest
 import net.minecraft.gametest.framework.GameTestHelper
 import net.minecraft.resources.ResourceLocation
@@ -234,7 +235,7 @@ class Turtle_Test {
             val upgrade = turtle.getUpgrade(TurtleSide.LEFT)
             assertEquals(
                 helper.level.registryAccess().registryOrThrow(ITurtleUpgrade.REGISTRY)
-                    .get(ResourceLocation("cctest", "wooden_pickaxe")),
+                    .get(ResourceLocation.fromNamespaceAndPath("cctest", "wooden_pickaxe")),
                 upgrade,
                 "Upgrade is a wooden pickaxe",
             )
@@ -263,7 +264,7 @@ class Turtle_Test {
                 ItemStack(Items.WOODEN_PICKAXE),
                 UpgradeData.ofDefault(
                     helper.level.registryAccess().registryOrThrow(ITurtleUpgrade.REGISTRY)
-                        .getHolder(ResourceLocation("cctest", "wooden_pickaxe")).orElseThrow(),
+                        .getHolder(ResourceLocation.fromNamespaceAndPath("cctest", "wooden_pickaxe")).orElseThrow(),
                 ),
             )
         }
@@ -284,14 +285,18 @@ class Turtle_Test {
             val upgrade = turtle.getUpgrade(TurtleSide.LEFT)
             assertEquals(
                 helper.level.registryAccess().registryOrThrow(ITurtleUpgrade.REGISTRY)
-                    .get(ResourceLocation("cctest", "netherite_pickaxe")),
+                    .get(ResourceLocation.fromNamespaceAndPath("cctest", "netherite_pickaxe")),
                 upgrade,
                 "Upgrade is a netherite pickaxe",
             )
 
             val item = ItemStack(Items.NETHERITE_PICKAXE)
             item.damageValue = 1
-            item.enchant(Enchantments.SILK_TOUCH, 1)
+            item.enchant(
+                helper.level.registryAccess().registryOrThrow(Registries.ENCHANTMENT)
+                    .getHolderOrThrow(Enchantments.SILK_TOUCH),
+                1,
+            )
 
             helper.assertUpgradeItem(item, turtle.getUpgradeWithData(TurtleSide.LEFT)!!)
         }

--- a/projects/common/src/testMod/kotlin/dan200/computercraft/gametest/api/TestExtensions.kt
+++ b/projects/common/src/testMod/kotlin/dan200/computercraft/gametest/api/TestExtensions.kt
@@ -177,7 +177,7 @@ fun <T : Comparable<T>> GameTestHelper.assertBlockHas(pos: BlockPos, property: P
  * Get a [Container] at a given position.
  */
 fun GameTestHelper.getContainerAt(pos: BlockPos): Container =
-    when (val container = getBlockEntity(pos)) {
+    when (val container: BlockEntity = getBlockEntity(pos)) {
         is Container -> container
         null -> failVerbose("Expected a container at $pos, found nothing", pos)
         else -> failVerbose("Expected a container at $pos, found ${getName(container.type)}", pos)
@@ -226,7 +226,7 @@ private fun GameTestHelper.assertContainerExactlyImpl(pos: BlockPos, container: 
  */
 private fun GameTestHelper.getPeripheralAt(pos: BlockPos, direction: Direction): IPeripheral? {
     val be = BarrelBlockEntity(absolutePos(pos).relative(direction), Blocks.BARREL.defaultBlockState())
-    be.level = level
+    be.setLevel(level)
     return PlatformHelper.get().createPeripheralAccess(be) { }.get(direction.opposite)
 }
 
@@ -260,10 +260,9 @@ private fun getName(type: BlockEntityType<*>): ResourceLocation =
  * Get a [BlockEntity] of a specific type.
  */
 fun <T : BlockEntity> GameTestHelper.getBlockEntity(pos: BlockPos, type: BlockEntityType<T>): T {
-    val tile = getBlockEntity(pos)
+    val tile: BlockEntity = getBlockEntity(pos)
     @Suppress("UNCHECKED_CAST")
     return when {
-        tile == null -> failVerbose("Expected ${getName(type)}, but no tile was there", pos)
         tile.type != type -> failVerbose("Expected ${getName(type)} but got ${getName(tile.type)}", pos)
         else -> tile as T
     }

--- a/projects/common/src/testMod/kotlin/dan200/computercraft/gametest/core/ClientTestHooks.kt
+++ b/projects/common/src/testMod/kotlin/dan200/computercraft/gametest/core/ClientTestHooks.kt
@@ -125,7 +125,7 @@ object ClientTestHooks {
                     GameTestBatchFactory.fromTestFunction(GameTestRegistry.getAllTestFunctions(), server.overworld()),
                     server.overworld(),
                 )
-                    .newStructureSpawner(StructureGridSpawner(TestHooks.getTestOrigin(server), 8))
+                    .newStructureSpawner(StructureGridSpawner(TestHooks.getTestOrigin(server), 8, false))
                     .build()
 
                 val testTracker = MultipleTestTracker(tests.testInfos)

--- a/projects/fabric-api/src/main/java/dan200/computercraft/api/network/wired/WiredElementLookup.java
+++ b/projects/fabric-api/src/main/java/dan200/computercraft/api/network/wired/WiredElementLookup.java
@@ -14,7 +14,7 @@ import net.minecraft.resources.ResourceLocation;
  * from a block.
  */
 public final class WiredElementLookup {
-    public static final ResourceLocation ID = new ResourceLocation(ComputerCraftAPI.MOD_ID, "wired_node");
+    public static final ResourceLocation ID = ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "wired_node");
 
     private static final BlockApiLookup<WiredElement, Direction> lookup = BlockApiLookup.get(ID, WiredElement.class, Direction.class);
 

--- a/projects/fabric-api/src/main/java/dan200/computercraft/api/peripheral/PeripheralLookup.java
+++ b/projects/fabric-api/src/main/java/dan200/computercraft/api/peripheral/PeripheralLookup.java
@@ -14,7 +14,7 @@ import net.minecraft.resources.ResourceLocation;
  * for a block. It should <em>NOT</em> be used to query peripherals.
  */
 public final class PeripheralLookup {
-    public static final ResourceLocation ID = new ResourceLocation(ComputerCraftAPI.MOD_ID, "peripheral");
+    public static final ResourceLocation ID = ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "peripheral");
 
     private static final BlockApiLookup<IPeripheral, Direction> lookup = BlockApiLookup.get(ID, IPeripheral.class, Direction.class);
 

--- a/projects/fabric/src/client/java/dan200/computercraft/client/model/CustomModelLoader.java
+++ b/projects/fabric/src/client/java/dan200/computercraft/client/model/CustomModelLoader.java
@@ -106,10 +106,11 @@ public final class CustomModelLoader {
      * @return The wrapped model.
      */
     public BakedModel wrapModel(ModelModifier.AfterBake.Context ctx, BakedModel baked) {
-        if (!ctx.id().getNamespace().equals(ComputerCraftAPI.MOD_ID)) return baked;
+        var id = ctx.resourceId();
+        if (id == null || !id.getNamespace().equals(ComputerCraftAPI.MOD_ID)) return baked;
         if (!(ctx.sourceModel() instanceof BlockModel model)) return baked;
 
-        var emissive = getEmissive(ctx.id(), model);
+        var emissive = getEmissive(id, model);
         return emissive == null ? baked : EmissiveBakedModel.wrap(baked, ctx.textureGetter().apply(model.getMaterial(emissive)));
     }
 

--- a/projects/fabric/src/client/java/dan200/computercraft/client/model/turtle/UnbakedTurtleModel.java
+++ b/projects/fabric/src/client/java/dan200/computercraft/client/model/turtle/UnbakedTurtleModel.java
@@ -22,7 +22,7 @@ import java.util.function.Function;
  * {@link TurtleModel}.
  */
 public final class UnbakedTurtleModel implements UnbakedModel {
-    private static final ResourceLocation COLOUR_TURTLE_MODEL = new ResourceLocation(ComputerCraftAPI.MOD_ID, "block/turtle_colour");
+    private static final ResourceLocation COLOUR_TURTLE_MODEL = ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "block/turtle_colour");
 
     private final ResourceLocation model;
 
@@ -31,7 +31,7 @@ public final class UnbakedTurtleModel implements UnbakedModel {
     }
 
     public static UnbakedModel parse(JsonObject json) {
-        var model = new ResourceLocation(GsonHelper.getAsString(json, "model"));
+        var model = ResourceLocation.parse(GsonHelper.getAsString(json, "model"));
         return new UnbakedTurtleModel(model);
     }
 
@@ -47,7 +47,7 @@ public final class UnbakedTurtleModel implements UnbakedModel {
     }
 
     @Override
-    public BakedModel bake(ModelBaker bakery, Function<Material, TextureAtlasSprite> spriteGetter, ModelState transform, ResourceLocation location) {
+    public BakedModel bake(ModelBaker bakery, Function<Material, TextureAtlasSprite> spriteGetter, ModelState transform) {
         var mainModel = bakery.bake(model, transform);
         if (mainModel == null) throw new NullPointerException(model + " failed to bake");
 

--- a/projects/fabric/src/client/java/dan200/computercraft/client/platform/ClientPlatformHelperImpl.java
+++ b/projects/fabric/src/client/java/dan200/computercraft/client/platform/ClientPlatformHelperImpl.java
@@ -9,15 +9,13 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import dan200.computercraft.client.model.FoiledModel;
 import dan200.computercraft.client.render.ModelRenderer;
 import net.fabricmc.fabric.api.renderer.v1.model.ModelHelper;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.Sheets;
 import net.minecraft.client.renderer.entity.ItemRenderer;
 import net.minecraft.client.resources.model.BakedModel;
 import net.minecraft.client.resources.model.ModelManager;
-import net.minecraft.core.BlockPos;
+import net.minecraft.client.resources.model.ModelResourceLocation;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.sounds.SoundEvent;
 import net.minecraft.util.RandomSource;
 
 import javax.annotation.Nullable;
@@ -27,9 +25,14 @@ public class ClientPlatformHelperImpl implements ClientPlatformHelper {
     private static final RandomSource random = RandomSource.create(0);
 
     @Override
-    public BakedModel getModel(ModelManager manager, ResourceLocation location) {
-        var model = manager.getModel(location);
+    public BakedModel getModel(ModelManager manager, ResourceLocation resourceLocation) {
+        var model = manager.getModel(resourceLocation);
         return model == null ? manager.getMissingModel() : model;
+    }
+
+    @Override
+    public BakedModel getModel(ModelManager manager, ModelResourceLocation modelLocation, @Nullable ResourceLocation resourceLocation) {
+        return resourceLocation == null ? manager.getModel(modelLocation) : getModel(manager, resourceLocation);
     }
 
     @Override
@@ -48,10 +51,5 @@ public class ClientPlatformHelperImpl implements ClientPlatformHelper {
             random.setSeed(42);
             ModelRenderer.renderQuads(transform, buffer, model.getQuads(null, face, random), lightmapCoord, overlayLight, tints);
         }
-    }
-
-    @Override
-    public void playStreamingMusic(BlockPos pos, @Nullable SoundEvent sound) {
-        Minecraft.getInstance().levelRenderer.playStreamingMusic(sound, pos);
     }
 }

--- a/projects/fabric/src/main/java/dan200/computercraft/shared/ComputerCraft.java
+++ b/projects/fabric/src/main/java/dan200/computercraft/shared/ComputerCraft.java
@@ -148,7 +148,7 @@ public class ComputerCraft {
 
         @Override
         public ResourceLocation getFabricId() {
-            return new ResourceLocation(ComputerCraftAPI.MOD_ID, name);
+            return ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, name);
         }
 
         @Override

--- a/projects/fabric/src/main/java/dan200/computercraft/shared/platform/PlatformHelperImpl.java
+++ b/projects/fabric/src/main/java/dan200/computercraft/shared/platform/PlatformHelperImpl.java
@@ -51,10 +51,10 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
-import net.minecraft.world.inventory.CraftingContainer;
 import net.minecraft.world.inventory.MenuType;
 import net.minecraft.world.item.*;
 import net.minecraft.world.item.context.UseOnContext;
+import net.minecraft.world.item.crafting.CraftingInput;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.level.Level;
@@ -192,12 +192,12 @@ public class PlatformHelperImpl implements PlatformHelper {
     }
 
     @Override
-    public List<ItemStack> getRecipeRemainingItems(ServerPlayer player, Recipe<CraftingContainer> recipe, CraftingContainer container) {
+    public List<ItemStack> getRecipeRemainingItems(ServerPlayer player, Recipe<CraftingInput> recipe, CraftingInput container) {
         return recipe.getRemainingItems(container);
     }
 
     @Override
-    public void onItemCrafted(ServerPlayer player, CraftingContainer container, ItemStack stack) {
+    public void onItemCrafted(ServerPlayer player, CraftingInput container, ItemStack stack) {
     }
 
     @Override
@@ -256,7 +256,7 @@ public class PlatformHelperImpl implements PlatformHelper {
 
         @Override
         public <U extends T> RegistryEntry<U> register(String name, Supplier<U> create) {
-            var entry = new RegistryEntryImpl<>(new ResourceLocation(ComputerCraftAPI.MOD_ID, name), create);
+            var entry = new RegistryEntryImpl<>(ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, name), create);
             entries.add(entry);
             return entry;
         }

--- a/projects/fabric/src/main/resources/fabric.mod.json
+++ b/projects/fabric/src/main/resources/fabric.mod.json
@@ -46,8 +46,8 @@
     ],
     "depends": {
         "fabricloader": ">=0.15.10",
-        "fabric-api": ">=0.97.3",
-        "minecraft": "=1.20.6"
+        "fabric-api": ">=0.100.1",
+        "minecraft": "=1.21"
     },
     "accessWidener": "computercraft.accesswidener"
 }

--- a/projects/fabric/src/testMod/java/dan200/computercraft/gametest/core/TestMod.java
+++ b/projects/fabric/src/testMod/java/dan200/computercraft/gametest/core/TestMod.java
@@ -22,7 +22,7 @@ public class TestMod implements ModInitializer, ClientModInitializer {
     public void onInitialize() {
         TestHooks.init();
 
-        var phase = new ResourceLocation(ComputerCraftAPI.MOD_ID, "test_mod");
+        var phase = ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "test_mod");
         ServerLifecycleEvents.SERVER_STARTED.addPhaseOrdering(Event.DEFAULT_PHASE, phase);
         ServerLifecycleEvents.SERVER_STARTED.register(phase, TestHooks::onServerStarted);
         CommandRegistrationCallback.EVENT.register((dispatcher, registryAccess, environment) -> CCTestCommand.register(dispatcher));

--- a/projects/forge-api/src/main/java/dan200/computercraft/api/network/wired/WiredElementCapability.java
+++ b/projects/forge-api/src/main/java/dan200/computercraft/api/network/wired/WiredElementCapability.java
@@ -14,7 +14,7 @@ import net.neoforged.neoforge.capabilities.BlockCapability;
  * from a block.
  */
 public final class WiredElementCapability {
-    public static final ResourceLocation ID = new ResourceLocation(ComputerCraftAPI.MOD_ID, "wired_node");
+    public static final ResourceLocation ID = ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "wired_node");
 
     private static final BlockCapability<WiredElement, Direction> capability = BlockCapability.create(ID, WiredElement.class, Direction.class);
 

--- a/projects/forge-api/src/main/java/dan200/computercraft/api/peripheral/PeripheralCapability.java
+++ b/projects/forge-api/src/main/java/dan200/computercraft/api/peripheral/PeripheralCapability.java
@@ -14,7 +14,7 @@ import net.neoforged.neoforge.capabilities.BlockCapability;
  * for a block. It should <em>NOT</em> be used to query peripherals.
  */
 public final class PeripheralCapability {
-    public static final ResourceLocation ID = new ResourceLocation(ComputerCraftAPI.MOD_ID, "peripheral");
+    public static final ResourceLocation ID = ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "peripheral");
 
     private static final BlockCapability<IPeripheral, Direction> capability = BlockCapability.create(ID, IPeripheral.class, Direction.class);
 

--- a/projects/forge/src/client/java/dan200/computercraft/client/ForgeClientRegistry.java
+++ b/projects/forge/src/client/java/dan200/computercraft/client/ForgeClientRegistry.java
@@ -10,6 +10,7 @@ import dan200.computercraft.client.model.turtle.TurtleModelLoader;
 import dan200.computercraft.client.turtle.TurtleUpgradeModellers;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.item.ItemProperties;
+import net.minecraft.client.resources.model.ModelResourceLocation;
 import net.minecraft.resources.ResourceLocation;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.SubscribeEvent;
@@ -33,7 +34,7 @@ public final class ForgeClientRegistry {
 
     @SubscribeEvent
     public static void registerModelLoaders(ModelEvent.RegisterGeometryLoaders event) {
-        event.register(new ResourceLocation(ComputerCraftAPI.MOD_ID, "turtle"), TurtleModelLoader.INSTANCE);
+        event.register(ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "turtle"), TurtleModelLoader.INSTANCE);
     }
 
     /**
@@ -56,7 +57,7 @@ public final class ForgeClientRegistry {
     @SubscribeEvent
     public static void registerModels(ModelEvent.RegisterAdditional event) {
         gatherModellers();
-        ClientRegistry.registerExtraModels(event::register);
+        ClientRegistry.registerExtraModels(x -> event.register(ModelResourceLocation.standalone(x)));
     }
 
     @SubscribeEvent

--- a/projects/forge/src/client/java/dan200/computercraft/client/model/FoiledModel.java
+++ b/projects/forge/src/client/java/dan200/computercraft/client/model/FoiledModel.java
@@ -35,7 +35,7 @@ public final class FoiledModel extends BakedModelWrapper<BakedModel> {
 
     @Override
     public List<RenderType> getRenderTypes(ItemStack itemStack, boolean fabulous) {
-        return new ConsList<>(fabulous ? RenderType.glintDirect() : RenderType.glint(), super.getRenderTypes(itemStack, fabulous));
+        return new ConsList<>(fabulous ? RenderType.glintTranslucent() : RenderType.glint(), super.getRenderTypes(itemStack, fabulous));
     }
 
     @Override

--- a/projects/forge/src/client/java/dan200/computercraft/client/model/turtle/TurtleModelLoader.java
+++ b/projects/forge/src/client/java/dan200/computercraft/client/model/turtle/TurtleModelLoader.java
@@ -28,7 +28,7 @@ import java.util.function.Function;
  * {@link TurtleModel}.
  */
 public final class TurtleModelLoader implements IGeometryLoader<TurtleModelLoader.Unbaked> {
-    private static final ResourceLocation COLOUR_TURTLE_MODEL = new ResourceLocation(ComputerCraftAPI.MOD_ID, "block/turtle_colour");
+    private static final ResourceLocation COLOUR_TURTLE_MODEL = ResourceLocation.fromNamespaceAndPath(ComputerCraftAPI.MOD_ID, "block/turtle_colour");
 
     public static final TurtleModelLoader INSTANCE = new TurtleModelLoader();
 
@@ -37,7 +37,7 @@ public final class TurtleModelLoader implements IGeometryLoader<TurtleModelLoade
 
     @Override
     public Unbaked read(JsonObject modelContents, JsonDeserializationContext deserializationContext) {
-        var model = new ResourceLocation(GsonHelper.getAsString(modelContents, "model"));
+        var model = ResourceLocation.parse(GsonHelper.getAsString(modelContents, "model"));
         return new Unbaked(model);
     }
 
@@ -49,7 +49,7 @@ public final class TurtleModelLoader implements IGeometryLoader<TurtleModelLoade
         }
 
         @Override
-        public BakedModel bake(IGeometryBakingContext owner, ModelBaker bakery, Function<Material, TextureAtlasSprite> spriteGetter, ModelState transform, ItemOverrides overrides, ResourceLocation modelLocation) {
+        public BakedModel bake(IGeometryBakingContext owner, ModelBaker bakery, Function<Material, TextureAtlasSprite> spriteGetter, ModelState transform, ItemOverrides overrides) {
             var mainModel = bakery.bake(family, transform, spriteGetter);
             if (mainModel == null) throw new NullPointerException(family + " failed to bake");
 

--- a/projects/forge/src/client/java/dan200/computercraft/client/platform/ClientPlatformHelperImpl.java
+++ b/projects/forge/src/client/java/dan200/computercraft/client/platform/ClientPlatformHelperImpl.java
@@ -8,14 +8,12 @@ import com.google.auto.service.AutoService;
 import com.mojang.blaze3d.vertex.PoseStack;
 import dan200.computercraft.client.model.FoiledModel;
 import dan200.computercraft.client.render.ModelRenderer;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.resources.model.BakedModel;
 import net.minecraft.client.resources.model.ModelManager;
-import net.minecraft.core.BlockPos;
+import net.minecraft.client.resources.model.ModelResourceLocation;
 import net.minecraft.core.Direction;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.sounds.SoundEvent;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.item.ItemStack;
 import net.neoforged.neoforge.client.model.data.ModelData;
@@ -29,8 +27,13 @@ public class ClientPlatformHelperImpl implements ClientPlatformHelper {
     private static final Direction[] directions = Arrays.copyOf(Direction.values(), 7);
 
     @Override
-    public BakedModel getModel(ModelManager manager, ResourceLocation location) {
-        return manager.getModel(location);
+    public BakedModel getModel(ModelManager manager, ResourceLocation resourceLocation) {
+        return manager.getModel(ModelResourceLocation.standalone(resourceLocation));
+    }
+
+    @Override
+    public BakedModel getModel(ModelManager manager, ModelResourceLocation modelLocation, @Nullable ResourceLocation resourceLocation) {
+        return manager.getModel(modelLocation);
     }
 
     @Override
@@ -48,10 +51,5 @@ public class ClientPlatformHelperImpl implements ClientPlatformHelper {
                 ModelRenderer.renderQuads(transform, buffer, quads, lightmapCoord, overlayLight, tints);
             }
         }
-    }
-
-    @Override
-    public void playStreamingMusic(BlockPos pos, @Nullable SoundEvent sound) {
-        Minecraft.getInstance().levelRenderer.playStreamingMusic(sound, pos, null);
     }
 }


### PR DESCRIPTION
I forgot about the breeze, so instead there's a much more boring screenshot:

![A screenshot of a CC terminal in a superflat Minecraft world. `_HOST` as been entered in the Lua REPL, showing it is running in MC 1.21.](https://github.com/cc-tweaked/CC-Tweaked/assets/4346137/c014ce7e-8b4e-4fbf-a448-2d8aeb9e325d)

## Still to do:
 - [ ] NeoForge support. I think this should be pretty straightforward, but I want to tear out NeoGradle first, and replace it with an alternative Gradle plugin, which might require a bit more work.
 - [ ] `turtle.attack`. This whole code is commented out right now, and not sure quite how to handle this without just copying `Player.attack` again :/.
 - [ ] Testing. Especially around rendering and `turtle.craft` — the changes there are pretty simple, but easy to get wrong.

## API changes
 - `IMedia.getAudioTitle`/`IMedia.getAudio` were merged into a single method returning a `Holder<JukeboxSong>`.