### PR TITLE
Transfer item data when adding upgrade to pocket computer by crafting (i.e. enchantments)

### DIFF
--- a/projects/common/src/main/java/dan200/computercraft/shared/pocket/recipes/PocketComputerUpgradeRecipe.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/pocket/recipes/PocketComputerUpgradeRecipe.java
@@ -84,7 +84,9 @@ public final class PocketComputerUpgradeRecipe extends CustomRecipe {
         var computerID = itemComputer.getComputerID(computer);
         var label = itemComputer.getLabel(computer);
         var colour = itemComputer.getColour(computer);
-        return itemComputer.create(computerID, label, colour, upgrade);
+        var newItemComputer = itemComputer.create(computerID, label, colour, upgrade);
+        newItemComputer.addTagElement("Enchantments", computer.getEnchantmentTags());
+        return newItemComputer;
     }
 
     @Override

--- a/projects/common/src/main/java/dan200/computercraft/shared/pocket/recipes/PocketComputerUpgradeRecipe.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/pocket/recipes/PocketComputerUpgradeRecipe.java
@@ -81,12 +81,9 @@ public final class PocketComputerUpgradeRecipe extends CustomRecipe {
         if (upgrade == null) return ItemStack.EMPTY;
 
         // Construct the new stack
-        var computerID = itemComputer.getComputerID(computer);
-        var label = itemComputer.getLabel(computer);
-        var colour = itemComputer.getColour(computer);
-        var newItemComputer = itemComputer.create(computerID, label, colour, upgrade);
-        newItemComputer.addTagElement("Enchantments", computer.getEnchantmentTags());
-        return newItemComputer;
+        var newStack = computer.copyWithCount(1);
+        PocketComputerItem.setUpgrade(newStack, upgrade);
+        return newStack;
     }
 
     @Override

--- a/projects/common/src/main/java/dan200/computercraft/shared/pocket/recipes/PocketComputerUpgradeRecipe.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/pocket/recipes/PocketComputerUpgradeRecipe.java
@@ -59,7 +59,6 @@ public final class PocketComputerUpgradeRecipe extends CustomRecipe {
 
         if (computer.isEmpty()) return ItemStack.EMPTY;
 
-        var itemComputer = (PocketComputerItem) computer.getItem();
         if (PocketComputerItem.getUpgrade(computer) != null) return ItemStack.EMPTY;
 
         // Check for upgrades around the item


### PR DESCRIPTION
## About
This PR now makes `PocketComputerUpgradeRecipe` transfer item data to crafted pocket computer by cloning `ItemStack` and adding upgrade to it.

## Why
There is an issue that removes enchantments from pocket computers when upgrade is attached through crafting.
Pocket API also have functions that equip and unequip upgrades that doesn't remove enchantments.

### How pocket computer can be enchanted
- Pocket computer can be enchanted with custom enchantment that can apply on any item. 
- Any enchantment to pocket computer can also be applied with anvil while being in creative mod
- Commands like `/give`

## Image
![image](https://github.com/cc-tweaked/CC-Tweaked/assets/56765288/08332d75-36b6-48da-af71-be48507f2acc)
