### PR TITLE
set.lua universal coloring

### DIFF
--- a/projects/core/src/main/resources/data/computercraft/lua/rom/programs/set.lua
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/programs/set.lua
@@ -7,13 +7,9 @@ local pp = require "cc.pretty"
 local tArgs = { ... }
 if #tArgs == 0 then
     -- "set"
-    local _, y = term.getCursorPos()
-    local tSettings = {}
     for n, sName in ipairs(settings.getNames()) do
-        tSettings[n] = textutils.serialize(sName) .. " is " .. textutils.serialize(settings.get(sName))
+        pp.print(pp.text(sName, colors.cyan) .. " is " .. pp.pretty(settings.get(sName)))
     end
-    textutils.pagedPrint(table.concat(tSettings, "\n"), y - 3)
-
 elseif #tArgs == 1 then
     -- "set foo"
     local sName = tArgs[1]
@@ -24,7 +20,6 @@ elseif #tArgs == 1 then
     end
     pp.print(msg)
     if deets.description then print(deets.description) end
-
 else
     -- "set foo bar"
     local sName = tArgs[1]
@@ -45,12 +40,12 @@ else
     local option = settings.getDetails(sName)
     if value == nil then
         settings.unset(sName)
-        print(textutils.serialize(sName) .. " unset")
+        pp.print(pp.text(sName, colors.cyan) .. " unset")
     elseif option.type and option.type ~= type(value) then
         printError(("%s is not a valid %s."):format(textutils.serialize(sValue), option.type))
     else
         settings.set(sName, value)
-        print(textutils.serialize(sName) .. " set to " .. textutils.serialize(value))
+        pp.print(pp.text(sName, colors.cyan) .. " set to " .. pp.pretty(value))
     end
 
     if value ~= option.value then

--- a/projects/core/src/main/resources/data/computercraft/lua/rom/programs/set.lua
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/programs/set.lua
@@ -7,7 +7,7 @@ local pp = require "cc.pretty"
 local tArgs = { ... }
 if #tArgs == 0 then
     -- "set"
-    for n, sName in ipairs(settings.getNames()) do
+    for _, sName in ipairs(settings.getNames()) do
         pp.print(pp.text(sName, colors.cyan) .. " is " .. pp.pretty(settings.get(sName)))
     end
 elseif #tArgs == 1 then

--- a/projects/core/src/test/resources/test-rom/spec/programs/set_spec.lua
+++ b/projects/core/src/test/resources/test-rom/spec/programs/set_spec.lua
@@ -18,7 +18,7 @@ describe("The set program", function()
         setup()
 
         expect(capture("set"))
-            :matches { ok = true, output = '"test" is "Hello World!"\n"test.defined" is 456\n', error = "" }
+            :matches { ok = true, output = 'test is "Hello World!"\ntest.defined is 456\n', error = "" }
     end)
 
     it("displays a single setting", function()
@@ -47,7 +47,7 @@ describe("The set program", function()
         setup()
 
         expect(capture("set test Hello"))
-            :matches { ok = true, output = '"test" set to "Hello"\n', error = "" }
+            :matches { ok = true, output = 'test set to "Hello"\n', error = "" }
 
         expect(settings.get("test")):eq("Hello")
     end)
@@ -58,6 +58,6 @@ describe("The set program", function()
         expect(capture("set test.defined Hello"))
             :matches { ok = true, output = "", error = '"Hello" is not a valid number.\n' }
         expect(capture("set test.defined 456"))
-            :matches { ok = true, output = '"test.defined" set to 456\n', error = "" }
+            :matches { ok = true, output = 'test.defined set to 456\n', error = "" }
     end)
 end)


### PR DESCRIPTION
Makes the coloring in `set.lua` be universal, instead of colored in some commands.

Todo:
- [x] Add colors
- [x] Fix tests
- [x] Fix linting
- [ ] The old implementation of `set` used textutils, allowing for "Press any key to continue" scrolling.

I'm not sure how to go about adding back scrolling, help wanted