### PR TITLE
Computer components for custom APIs

### DIFF
--- a/projects/common-api/src/main/java/dan200/computercraft/api/ComputerCraftAPI.java
+++ b/projects/common-api/src/main/java/dan200/computercraft/api/ComputerCraftAPI.java
@@ -177,7 +177,7 @@ public final class ComputerCraftAPI {
      * ComputerCraftAPI.registerAPIFactory(computer -> {
      *   // Read the turtle component.
      *   var turtle = computer.getComponent(ComputerComponents.TURTLE);
-     *
+     *   // If present then add our API.
      *   return turtle == null ? null : new MyCustomTurtleApi(turtle);
      * });
      * }</pre>

--- a/projects/common-api/src/main/java/dan200/computercraft/api/ComputerCraftAPI.java
+++ b/projects/common-api/src/main/java/dan200/computercraft/api/ComputerCraftAPI.java
@@ -4,9 +4,11 @@
 
 package dan200.computercraft.api;
 
+import dan200.computercraft.api.component.ComputerComponent;
 import dan200.computercraft.api.filesystem.Mount;
 import dan200.computercraft.api.filesystem.WritableMount;
 import dan200.computercraft.api.lua.GenericSource;
+import dan200.computercraft.api.lua.IComputerSystem;
 import dan200.computercraft.api.lua.ILuaAPI;
 import dan200.computercraft.api.lua.ILuaAPIFactory;
 import dan200.computercraft.api.media.IMedia;
@@ -165,7 +167,20 @@ public final class ComputerCraftAPI {
      * Register a custom {@link ILuaAPI}, which may be added onto all computers without requiring a peripheral.
      * <p>
      * Before implementing this interface, consider alternative methods of providing methods. It is generally preferred
-     * to use peripherals to provide functionality to users.
+     * to use peripherals to provide functionality to users. If an API is <em>required</em>, you may want to consider
+     * using {@link ILuaAPI#getModuleName()} to expose this library as a module instead of as a global.
+     * <p>
+     * This may be used with {@link IComputerSystem#getComponent(ComputerComponent)} to only attach APIs to specific
+     * computers. For example, one can add an additional API just to turtles with the following code:
+     *
+     * <pre>{@code
+     * ComputerCraftAPI.registerAPIFactory(computer -> {
+     *   // Read the turtle component.
+     *   var turtle = computer.getComponent(ComputerComponents.TURTLE);
+     *
+     *   return turtle == null ? null : new MyCustomTurtleApi(turtle);
+     * });
+     * }</pre>
      *
      * @param factory The factory for your API subclass.
      * @see ILuaAPIFactory

--- a/projects/common-api/src/main/java/dan200/computercraft/api/component/AdminComputer.java
+++ b/projects/common-api/src/main/java/dan200/computercraft/api/component/AdminComputer.java
@@ -8,7 +8,7 @@ import net.minecraft.commands.CommandSourceStack;
 import org.jetbrains.annotations.ApiStatus;
 
 /**
- * A computer which has permission to perform administrative/op commands, such as CC's command computer.
+ * A computer which has permission to perform administrative/op commands, such as the command computer.
  */
 @ApiStatus.NonExtendable
 public interface AdminComputer {

--- a/projects/common-api/src/main/java/dan200/computercraft/api/component/AdminComputer.java
+++ b/projects/common-api/src/main/java/dan200/computercraft/api/component/AdminComputer.java
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2024 The CC: Tweaked Developers
+//
+// SPDX-License-Identifier: MPL-2.0
+
+package dan200.computercraft.api.component;
+
+import net.minecraft.commands.CommandSourceStack;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * A computer which has permission to perform administrative/op commands, such as CC's command computer.
+ */
+@ApiStatus.NonExtendable
+public interface AdminComputer {
+    /**
+     * The permission level that this computer can operate at.
+     *
+     * @return The permission level for this computer.
+     * @see CommandSourceStack#hasPermission(int)
+     */
+    default int permissionLevel() {
+        return 2;
+    }
+}

--- a/projects/common-api/src/main/java/dan200/computercraft/api/component/ComputerComponent.java
+++ b/projects/common-api/src/main/java/dan200/computercraft/api/component/ComputerComponent.java
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2024 The CC: Tweaked Developers
+//
+// SPDX-License-Identifier: MPL-2.0
+
+package dan200.computercraft.api.component;
+
+import dan200.computercraft.api.lua.IComputerSystem;
+import dan200.computercraft.api.lua.ILuaAPIFactory;
+
+/**
+ * An additional component attached to a computer.
+ * <p>
+ * Components provide a mechanism to attach additional data to a computer, that can then be queried with
+ * {@link IComputerSystem#getComponent(ComputerComponent)}.
+ * <p>
+ * This is largely designed for {@linkplain ILuaAPIFactory custom APIs}, allowing APIs to read additional properties
+ * of the computer, such as its position.
+ *
+ * @param <T> The type of this component.
+ * @see ComputerComponents The built-in components.
+ */
+@SuppressWarnings("UnusedTypeParameter")
+public final class ComputerComponent<T> {
+    private final String id;
+
+    private ComputerComponent(String id) {
+        this.id = id;
+    }
+
+    /**
+     * Create a new computer component.
+     * <p>
+     * Mods typically will not need to create their own components.
+     *
+     * @param namespace The namespace of this component. This should be the mod id.
+     * @param id        The unique id of this component.
+     * @param <T>       The component
+     * @return The newly created component.
+     */
+    public static <T> ComputerComponent<T> create(String namespace, String id) {
+        return new ComputerComponent<>(namespace + ":" + id);
+    }
+
+    @Override
+    public String toString() {
+        return "ComputerComponent(" + id + ")";
+    }
+}

--- a/projects/common-api/src/main/java/dan200/computercraft/api/component/ComputerComponent.java
+++ b/projects/common-api/src/main/java/dan200/computercraft/api/component/ComputerComponent.java
@@ -8,7 +8,7 @@ import dan200.computercraft.api.lua.IComputerSystem;
 import dan200.computercraft.api.lua.ILuaAPIFactory;
 
 /**
- * An additional component attached to a computer.
+ * A component attached to a computer.
  * <p>
  * Components provide a mechanism to attach additional data to a computer, that can then be queried with
  * {@link IComputerSystem#getComponent(ComputerComponent)}.

--- a/projects/common-api/src/main/java/dan200/computercraft/api/component/ComputerComponents.java
+++ b/projects/common-api/src/main/java/dan200/computercraft/api/component/ComputerComponents.java
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2024 The CC: Tweaked Developers
+//
+// SPDX-License-Identifier: MPL-2.0
+
+package dan200.computercraft.api.component;
+
+import dan200.computercraft.api.ComputerCraftAPI;
+import dan200.computercraft.api.pocket.IPocketAccess;
+import dan200.computercraft.api.turtle.ITurtleAccess;
+
+/**
+ * The {@link ComputerComponent}s provided by ComputerCraft.
+ */
+public class ComputerComponents {
+    /**
+     * The {@link ITurtleAccess} associated with a turtle.
+     */
+    public static final ComputerComponent<ITurtleAccess> TURTLE = ComputerComponent.create(ComputerCraftAPI.MOD_ID, "turtle");
+
+    /**
+     * The {@link IPocketAccess} associated with a pocket computer.
+     */
+    public static final ComputerComponent<IPocketAccess> POCKET = ComputerComponent.create(ComputerCraftAPI.MOD_ID, "pocket");
+
+    /**
+     * This component is only present on "command computers", and other computers with admin capabilities.
+     */
+    public static final ComputerComponent<AdminComputer> ADMIN_COMPUTER = ComputerComponent.create(ComputerCraftAPI.MOD_ID, "admin_computer");
+}

--- a/projects/common-api/src/main/java/dan200/computercraft/api/lua/IComputerSystem.java
+++ b/projects/common-api/src/main/java/dan200/computercraft/api/lua/IComputerSystem.java
@@ -21,7 +21,7 @@ public interface IComputerSystem extends IComputerAccess {
     /**
      * Get the level this computer is currently in.
      * <p>
-     * This method is not guaranteed to remain the same (even for stationary computers), so should not be cached.
+     * This method is not guaranteed to remain the same (even for stationary computers).
      *
      * @return The computer's current level.
      */
@@ -30,7 +30,7 @@ public interface IComputerSystem extends IComputerAccess {
     /**
      * Get the position this computer is currently at.
      * <p>
-     * This method is not guaranteed to remain the same (even for stationary computers), so should not be cached.
+     * This method is not guaranteed to remain the same (even for stationary computers).
      *
      * @return The computer's current position.
      */

--- a/projects/common-api/src/main/java/dan200/computercraft/api/lua/IComputerSystem.java
+++ b/projects/common-api/src/main/java/dan200/computercraft/api/lua/IComputerSystem.java
@@ -4,7 +4,10 @@
 
 package dan200.computercraft.api.lua;
 
+import dan200.computercraft.api.component.ComputerComponent;
 import dan200.computercraft.api.peripheral.IComputerAccess;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
 import org.jetbrains.annotations.ApiStatus;
 
 import javax.annotation.Nullable;
@@ -16,10 +19,41 @@ import javax.annotation.Nullable;
 @ApiStatus.NonExtendable
 public interface IComputerSystem extends IComputerAccess {
     /**
+     * Get the level this computer is currently in.
+     * <p>
+     * This method is not guaranteed to remain the same (even for stationary computers), so should not be cached.
+     *
+     * @return The computer's current level.
+     */
+    ServerLevel getLevel();
+
+    /**
+     * Get the position this computer is currently at.
+     * <p>
+     * This method is not guaranteed to remain the same (even for stationary computers), so should not be cached.
+     *
+     * @return The computer's current position.
+     */
+    BlockPos getPosition();
+
+    /**
      * Get the label for this computer.
      *
      * @return This computer's label, or {@code null} if it is not set.
      */
     @Nullable
     String getLabel();
+
+    /**
+     * Get a component attached to this computer.
+     * <p>
+     * No component is guaranteed to be on a computer, and so this method should always be guarded with a null check.
+     * <p>
+     * This method will always return the same value for a given component, and so may be cached.
+     *
+     * @param component The component to query.
+     * @param <T>       The type of the component.
+     * @return The component, if present.
+     */
+    <T> @Nullable T getComponent(ComputerComponent<T> component);
 }

--- a/projects/common/src/main/java/dan200/computercraft/impl/ApiFactories.java
+++ b/projects/common/src/main/java/dan200/computercraft/impl/ApiFactories.java
@@ -14,7 +14,6 @@ import java.util.Objects;
 /**
  * The global factory for {@link ILuaAPIFactory}s.
  *
- * @see dan200.computercraft.core.ComputerContext.Builder#apiFactories(Collection)
  * @see dan200.computercraft.api.ComputerCraftAPI#registerAPIFactory(ILuaAPIFactory)
  */
 public final class ApiFactories {

--- a/projects/common/src/main/java/dan200/computercraft/shared/ModRegistry.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/ModRegistry.java
@@ -6,6 +6,7 @@ package dan200.computercraft.shared;
 
 import com.mojang.brigadier.arguments.ArgumentType;
 import dan200.computercraft.api.ComputerCraftAPI;
+import dan200.computercraft.api.component.ComputerComponents;
 import dan200.computercraft.api.detail.DetailProvider;
 import dan200.computercraft.api.detail.VanillaDetailRegistries;
 import dan200.computercraft.api.media.IMedia;
@@ -23,6 +24,7 @@ import dan200.computercraft.shared.common.ClearColourRecipe;
 import dan200.computercraft.shared.common.ColourableRecipe;
 import dan200.computercraft.shared.common.DefaultBundledRedstoneProvider;
 import dan200.computercraft.shared.common.HeldItemMenu;
+import dan200.computercraft.shared.computer.apis.CommandAPI;
 import dan200.computercraft.shared.computer.blocks.CommandComputerBlock;
 import dan200.computercraft.shared.computer.blocks.ComputerBlock;
 import dan200.computercraft.shared.computer.blocks.ComputerBlockEntity;
@@ -64,6 +66,7 @@ import dan200.computercraft.shared.peripheral.speaker.SpeakerBlockEntity;
 import dan200.computercraft.shared.platform.PlatformHelper;
 import dan200.computercraft.shared.platform.RegistrationHelper;
 import dan200.computercraft.shared.platform.RegistryEntry;
+import dan200.computercraft.shared.pocket.apis.PocketAPI;
 import dan200.computercraft.shared.pocket.items.PocketComputerItem;
 import dan200.computercraft.shared.pocket.peripherals.PocketModem;
 import dan200.computercraft.shared.pocket.peripherals.PocketSpeaker;
@@ -73,14 +76,17 @@ import dan200.computercraft.shared.recipe.CustomShapelessRecipe;
 import dan200.computercraft.shared.recipe.ImpostorShapedRecipe;
 import dan200.computercraft.shared.recipe.ImpostorShapelessRecipe;
 import dan200.computercraft.shared.turtle.FurnaceRefuelHandler;
+import dan200.computercraft.shared.turtle.apis.TurtleAPI;
 import dan200.computercraft.shared.turtle.blocks.TurtleBlock;
 import dan200.computercraft.shared.turtle.blocks.TurtleBlockEntity;
+import dan200.computercraft.shared.turtle.core.TurtleAccessInternal;
 import dan200.computercraft.shared.turtle.inventory.TurtleMenu;
 import dan200.computercraft.shared.turtle.items.TurtleItem;
 import dan200.computercraft.shared.turtle.recipes.TurtleOverlayRecipe;
 import dan200.computercraft.shared.turtle.recipes.TurtleRecipe;
 import dan200.computercraft.shared.turtle.recipes.TurtleUpgradeRecipe;
 import dan200.computercraft.shared.turtle.upgrades.*;
+import dan200.computercraft.shared.util.ComponentMap;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.synchronization.ArgumentTypeInfo;
 import net.minecraft.commands.synchronization.SingletonArgumentInfo;
@@ -102,6 +108,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.MapColor;
 import net.minecraft.world.level.storage.loot.predicates.LootItemConditionType;
 
+import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.Predicate;
 
@@ -445,6 +452,22 @@ public final class ModRegistry {
             if (item instanceof IMedia media) return media;
             if (item instanceof RecordItem) return RecordMedia.INSTANCE;
             return null;
+        });
+
+        ComputerCraftAPI.registerAPIFactory(computer -> {
+            var turtle = computer.getComponent(ComputerComponents.TURTLE);
+            var metrics = Objects.requireNonNull(computer.getComponent(ComponentMap.METRICS));
+            return turtle == null ? null : new TurtleAPI(metrics, (TurtleAccessInternal) turtle);
+        });
+
+        ComputerCraftAPI.registerAPIFactory(computer -> {
+            var pocket = computer.getComponent(ComputerComponents.POCKET);
+            return pocket == null ? null : new PocketAPI(pocket);
+        });
+
+        ComputerCraftAPI.registerAPIFactory(computer -> {
+            var admin = computer.getComponent(ComputerComponents.ADMIN_COMPUTER);
+            return admin == null ? null : new CommandAPI(computer, admin);
         });
 
         VanillaDetailRegistries.ITEM_STACK.addProvider(ItemDetails::fill);

--- a/projects/common/src/main/java/dan200/computercraft/shared/computer/apis/CommandAPI.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/computer/apis/CommandAPI.java
@@ -6,11 +6,11 @@ package dan200.computercraft.shared.computer.apis;
 
 import com.mojang.brigadier.tree.CommandNode;
 import com.mojang.brigadier.tree.LiteralCommandNode;
+import dan200.computercraft.api.component.AdminComputer;
 import dan200.computercraft.api.detail.BlockReference;
 import dan200.computercraft.api.detail.VanillaDetailRegistries;
 import dan200.computercraft.api.lua.*;
 import dan200.computercraft.core.Logging;
-import dan200.computercraft.shared.computer.core.ServerComputer;
 import dan200.computercraft.shared.util.NBTUtil;
 import net.minecraft.commands.CommandSource;
 import net.minecraft.commands.CommandSourceStack;
@@ -35,11 +35,13 @@ import java.util.*;
 public class CommandAPI implements ILuaAPI {
     private static final Logger LOG = LoggerFactory.getLogger(CommandAPI.class);
 
-    private final ServerComputer computer;
+    private final IComputerSystem computer;
+    private final AdminComputer admin;
     private final OutputReceiver receiver = new OutputReceiver();
 
-    public CommandAPI(ServerComputer computer) {
+    public CommandAPI(IComputerSystem computer, AdminComputer admin) {
         this.computer = computer;
+        this.admin = admin;
     }
 
     @Override
@@ -287,7 +289,7 @@ public class CommandAPI implements ILuaAPI {
 
         return new CommandSourceStack(receiver,
             Vec3.atCenterOf(computer.getPosition()), Vec2.ZERO,
-            computer.getLevel(), 2,
+            computer.getLevel(), admin.permissionLevel(),
             name, Component.literal(name),
             computer.getLevel().getServer(), null
         );

--- a/projects/common/src/main/java/dan200/computercraft/shared/computer/blocks/ComputerBlockEntity.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/computer/blocks/ComputerBlockEntity.java
@@ -12,6 +12,7 @@ import dan200.computercraft.shared.computer.core.ComputerState;
 import dan200.computercraft.shared.computer.core.ServerComputer;
 import dan200.computercraft.shared.computer.inventory.ComputerMenuWithoutInventory;
 import dan200.computercraft.shared.config.Config;
+import dan200.computercraft.shared.util.ComponentMap;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.server.level.ServerLevel;
@@ -34,7 +35,8 @@ public class ComputerBlockEntity extends AbstractComputerBlockEntity {
     protected ServerComputer createComputer(int id) {
         return new ServerComputer(
             (ServerLevel) getLevel(), getBlockPos(), id, label,
-            getFamily(), Config.computerTermWidth, Config.computerTermHeight
+            getFamily(), Config.computerTermWidth, Config.computerTermHeight,
+            ComponentMap.empty()
         );
     }
 

--- a/projects/common/src/main/java/dan200/computercraft/shared/computer/core/ComputerSystem.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/computer/core/ComputerSystem.java
@@ -4,28 +4,41 @@
 
 package dan200.computercraft.shared.computer.core;
 
+import dan200.computercraft.api.component.ComputerComponent;
 import dan200.computercraft.api.lua.IComputerSystem;
 import dan200.computercraft.api.lua.ILuaAPIFactory;
-import dan200.computercraft.api.peripheral.IComputerAccess;
 import dan200.computercraft.api.peripheral.IPeripheral;
 import dan200.computercraft.core.apis.ComputerAccess;
 import dan200.computercraft.core.apis.IAPIEnvironment;
 import dan200.computercraft.core.computer.ApiLifecycle;
+import dan200.computercraft.shared.util.ComponentMap;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
 
 import javax.annotation.Nullable;
 import java.util.Map;
 
 /**
- * Implementation of {@link IComputerAccess}/{@link IComputerSystem} for usage by externally registered APIs.
+ * Implementation of {@link IComputerSystem} for usage by externally registered APIs.
  *
  * @see ILuaAPIFactory
  */
-class ComputerSystem extends ComputerAccess implements IComputerSystem, ApiLifecycle {
+final class ComputerSystem extends ComputerAccess implements IComputerSystem, ApiLifecycle {
+    private final ServerComputer computer;
     private final IAPIEnvironment environment;
+    private final ComponentMap components;
 
-    ComputerSystem(IAPIEnvironment environment) {
+    private boolean active;
+
+    ComputerSystem(ServerComputer computer, IAPIEnvironment environment, ComponentMap components) {
         super(environment);
+        this.computer = computer;
         this.environment = environment;
+        this.components = components;
+    }
+
+    void activate() {
+        active = true;
     }
 
     @Override
@@ -36,6 +49,31 @@ class ComputerSystem extends ComputerAccess implements IComputerSystem, ApiLifec
     @Override
     public String getAttachmentName() {
         return "computer";
+    }
+
+    @Override
+    public ServerLevel getLevel() {
+        if (!active) {
+            throw new IllegalStateException("""
+                Cannot access level when constructing the API. Computers are not guaranteed to stay in one place and
+                APIs should not rely on the level remaining constant. Instead, call this method when needed.
+                """.replace('\n', ' ').strip()
+            );
+        }
+        return computer.getLevel();
+    }
+
+    @Override
+    public BlockPos getPosition() {
+        if (!active) {
+            throw new IllegalStateException("""
+                Cannot access computer position when constructing the API. Computers are not guaranteed to stay in one
+                place and APIs should not rely on the position remaining constant. Instead, call this method when
+                needed.
+                """.replace('\n', ' ').strip()
+            );
+        }
+        return computer.getPosition();
     }
 
     @Nullable
@@ -54,5 +92,10 @@ class ComputerSystem extends ComputerAccess implements IComputerSystem, ApiLifec
     @Override
     public IPeripheral getAvailablePeripheral(String name) {
         return null;
+    }
+
+    @Override
+    public <T> @Nullable T getComponent(ComputerComponent<T> component) {
+        return components.get(component);
     }
 }

--- a/projects/common/src/main/java/dan200/computercraft/shared/computer/core/ServerComputer.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/computer/core/ServerComputer.java
@@ -5,8 +5,9 @@
 package dan200.computercraft.shared.computer.core;
 
 import dan200.computercraft.api.ComputerCraftAPI;
+import dan200.computercraft.api.component.AdminComputer;
+import dan200.computercraft.api.component.ComputerComponents;
 import dan200.computercraft.api.filesystem.WritableMount;
-import dan200.computercraft.api.lua.ILuaAPI;
 import dan200.computercraft.api.peripheral.IPeripheral;
 import dan200.computercraft.api.peripheral.WorkMonitor;
 import dan200.computercraft.core.computer.Computer;
@@ -14,7 +15,6 @@ import dan200.computercraft.core.computer.ComputerEnvironment;
 import dan200.computercraft.core.computer.ComputerSide;
 import dan200.computercraft.core.metrics.MetricsObserver;
 import dan200.computercraft.impl.ApiFactories;
-import dan200.computercraft.shared.computer.apis.CommandAPI;
 import dan200.computercraft.shared.computer.menu.ComputerMenu;
 import dan200.computercraft.shared.computer.terminal.NetworkedTerminal;
 import dan200.computercraft.shared.computer.terminal.TerminalState;
@@ -23,6 +23,7 @@ import dan200.computercraft.shared.network.NetworkMessage;
 import dan200.computercraft.shared.network.client.ClientNetworkContext;
 import dan200.computercraft.shared.network.client.ComputerTerminalClientMessage;
 import dan200.computercraft.shared.network.server.ServerNetworking;
+import dan200.computercraft.shared.util.ComponentMap;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.player.Player;
@@ -50,7 +51,8 @@ public class ServerComputer implements InputHandler, ComputerEnvironment {
     private int ticksSincePing;
 
     public ServerComputer(
-        ServerLevel level, BlockPos position, int computerID, @Nullable String label, ComputerFamily family, int terminalWidth, int terminalHeight
+        ServerLevel level, BlockPos position, int computerID, @Nullable String label, ComputerFamily family, int terminalWidth, int terminalHeight,
+        ComponentMap baseComponents
     ) {
         this.level = level;
         this.position = position;
@@ -61,17 +63,27 @@ public class ServerComputer implements InputHandler, ComputerEnvironment {
         terminal = new NetworkedTerminal(terminalWidth, terminalHeight, family != ComputerFamily.NORMAL, this::markTerminalChanged);
         metrics = context.metrics().createMetricObserver(this);
 
+        var componentBuilder = ComponentMap.builder();
+        componentBuilder.add(ComponentMap.METRICS, metrics);
+        if (family == ComputerFamily.COMMAND) {
+            componentBuilder.add(ComputerComponents.ADMIN_COMPUTER, new AdminComputer() {
+            });
+        }
+        componentBuilder.add(baseComponents);
+        var components = componentBuilder.build();
+
         computer = new Computer(context.computerContext(), this, terminal, computerID);
         computer.setLabel(label);
 
         // Load in the externally registered APIs.
         for (var factory : ApiFactories.getAll()) {
-            var system = new ComputerSystem(computer.getAPIEnvironment());
+            var system = new ComputerSystem(this, computer.getAPIEnvironment(), components);
             var api = factory.create(system);
-            if (api != null) computer.addApi(api, system);
-        }
+            if (api == null) continue;
 
-        if (family == ComputerFamily.COMMAND) addAPI(new CommandAPI(this));
+            system.activate();
+            computer.addApi(api, system);
+        }
     }
 
     public ComputerFamily getFamily() {
@@ -223,10 +235,6 @@ public class ServerComputer implements InputHandler, ComputerEnvironment {
 
     public void setBundledRedstoneInput(ComputerSide side, int combination) {
         computer.getEnvironment().setBundledRedstoneInput(side, combination);
-    }
-
-    public void addAPI(ILuaAPI api) {
-        computer.addApi(api);
     }
 
     public void setPeripheral(ComputerSide side, @Nullable IPeripheral peripheral) {

--- a/projects/common/src/main/java/dan200/computercraft/shared/pocket/core/PocketServerComputer.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/pocket/core/PocketServerComputer.java
@@ -4,6 +4,7 @@
 
 package dan200.computercraft.shared.pocket.core;
 
+import dan200.computercraft.api.component.ComputerComponents;
 import dan200.computercraft.shared.computer.core.ComputerFamily;
 import dan200.computercraft.shared.computer.core.ComputerState;
 import dan200.computercraft.shared.computer.core.ServerComputer;
@@ -12,6 +13,7 @@ import dan200.computercraft.shared.network.client.PocketComputerDataMessage;
 import dan200.computercraft.shared.network.client.PocketComputerDeletedClientMessage;
 import dan200.computercraft.shared.network.server.ServerNetworking;
 import dan200.computercraft.shared.pocket.items.PocketComputerItem;
+import dan200.computercraft.shared.util.ComponentMap;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.ChunkPos;
 
@@ -40,7 +42,10 @@ public final class PocketServerComputer extends ServerComputer {
     private Set<ServerPlayer> tracking = Set.of();
 
     PocketServerComputer(PocketBrain brain, PocketHolder holder, int computerID, @Nullable String label, ComputerFamily family) {
-        super(holder.level(), holder.blockPos(), computerID, label, family, Config.pocketTermWidth, Config.pocketTermHeight);
+        super(
+            holder.level(), holder.blockPos(), computerID, label, family, Config.pocketTermWidth, Config.pocketTermHeight,
+            ComponentMap.builder().add(ComputerComponents.POCKET, brain).build()
+        );
         this.brain = brain;
     }
 

--- a/projects/common/src/main/java/dan200/computercraft/shared/pocket/items/PocketComputerItem.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/pocket/items/PocketComputerItem.java
@@ -20,7 +20,6 @@ import dan200.computercraft.shared.computer.core.ServerContext;
 import dan200.computercraft.shared.computer.items.IComputerItem;
 import dan200.computercraft.shared.config.Config;
 import dan200.computercraft.shared.network.container.ComputerContainerData;
-import dan200.computercraft.shared.pocket.apis.PocketAPI;
 import dan200.computercraft.shared.pocket.core.PocketBrain;
 import dan200.computercraft.shared.pocket.core.PocketHolder;
 import dan200.computercraft.shared.pocket.core.PocketServerComputer;
@@ -238,8 +237,6 @@ public class PocketComputerItem extends Item implements IComputerItem, IMedia, I
         var tag = stack.getOrCreateTag();
         tag.putInt(NBT_SESSION, registry.getSessionID());
         tag.putUUID(NBT_INSTANCE, computer.register());
-
-        computer.addAPI(new PocketAPI(brain));
 
         // Only turn on when initially creating the computer, rather than each tick.
         if (isMarkedOn(stack) && holder instanceof PocketHolder.PlayerHolder) computer.turnOn();

--- a/projects/common/src/main/java/dan200/computercraft/shared/turtle/apis/TurtleAPI.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/turtle/apis/TurtleAPI.java
@@ -11,7 +11,6 @@ import dan200.computercraft.api.turtle.TurtleCommandResult;
 import dan200.computercraft.api.turtle.TurtleSide;
 import dan200.computercraft.core.metrics.Metrics;
 import dan200.computercraft.core.metrics.MetricsObserver;
-import dan200.computercraft.shared.computer.core.ServerComputer;
 import dan200.computercraft.shared.peripheral.generic.methods.AbstractInventoryMethods;
 import dan200.computercraft.shared.turtle.core.*;
 
@@ -68,8 +67,8 @@ public class TurtleAPI implements ILuaAPI {
     private final MetricsObserver metrics;
     private final TurtleAccessInternal turtle;
 
-    public TurtleAPI(ServerComputer computer, TurtleAccessInternal turtle) {
-        this.metrics = computer.getMetrics();
+    public TurtleAPI(MetricsObserver metrics, TurtleAccessInternal turtle) {
+        this.metrics = metrics;
         this.turtle = turtle;
     }
 

--- a/projects/common/src/main/java/dan200/computercraft/shared/turtle/blocks/TurtleBlockEntity.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/turtle/blocks/TurtleBlockEntity.java
@@ -5,6 +5,7 @@
 package dan200.computercraft.shared.turtle.blocks;
 
 import com.mojang.authlib.GameProfile;
+import dan200.computercraft.api.component.ComputerComponents;
 import dan200.computercraft.api.peripheral.IPeripheral;
 import dan200.computercraft.api.turtle.ITurtleAccess;
 import dan200.computercraft.api.turtle.ITurtleUpgrade;
@@ -17,9 +18,9 @@ import dan200.computercraft.shared.computer.core.ComputerState;
 import dan200.computercraft.shared.computer.core.ServerComputer;
 import dan200.computercraft.shared.config.Config;
 import dan200.computercraft.shared.container.BasicContainer;
-import dan200.computercraft.shared.turtle.apis.TurtleAPI;
 import dan200.computercraft.shared.turtle.core.TurtleBrain;
 import dan200.computercraft.shared.turtle.inventory.TurtleMenu;
+import dan200.computercraft.shared.util.ComponentMap;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.NonNullList;
@@ -75,10 +76,9 @@ public class TurtleBlockEntity extends AbstractComputerBlockEntity implements Ba
     protected ServerComputer createComputer(int id) {
         var computer = new ServerComputer(
             (ServerLevel) getLevel(), getBlockPos(), id, label,
-            getFamily(), Config.turtleTermWidth,
-            Config.turtleTermHeight
+            getFamily(), Config.turtleTermWidth, Config.turtleTermHeight,
+            ComponentMap.builder().add(ComputerComponents.TURTLE, brain).build()
         );
-        computer.addAPI(new TurtleAPI(computer, brain));
         brain.setupComputer(computer);
         return computer;
     }

--- a/projects/common/src/main/java/dan200/computercraft/shared/util/ComponentMap.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/util/ComponentMap.java
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2024 The CC: Tweaked Developers
+//
+// SPDX-License-Identifier: MPL-2.0
+
+package dan200.computercraft.shared.util;
+
+import dan200.computercraft.api.component.ComputerComponent;
+import dan200.computercraft.core.metrics.MetricsObserver;
+
+import javax.annotation.Nullable;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * An immutable map of components.
+ */
+public final class ComponentMap {
+    public static final ComputerComponent<MetricsObserver> METRICS = ComputerComponent.create("computercraft", "metrics");
+
+    private static final ComponentMap EMPTY = new ComponentMap(Map.of());
+
+    private final Map<ComputerComponent<?>, Object> components;
+
+    private ComponentMap(Map<ComputerComponent<?>, Object> components) {
+        this.components = components;
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T> @Nullable T get(ComputerComponent<T> component) {
+        return (T) components.get(component);
+    }
+
+    public static ComponentMap empty() {
+        return EMPTY;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private final Map<ComputerComponent<?>, Object> components = new HashMap<>();
+
+        private Builder() {
+        }
+
+        public <T> Builder add(ComputerComponent<T> component, T value) {
+            addImpl(component, value);
+            return this;
+        }
+
+        public Builder add(ComponentMap components) {
+            for (var component : components.components.entrySet()) addImpl(component.getKey(), component.getValue());
+            return this;
+        }
+
+        private void addImpl(ComputerComponent<?> component, Object value) {
+            if (components.containsKey(component)) throw new IllegalArgumentException(component + " is already set");
+            components.put(component, value);
+        }
+
+        public ComponentMap build() {
+            return new ComponentMap(Map.copyOf(components));
+        }
+    }
+}


### PR DESCRIPTION
CC:Tweaked (/CCTweaks) has had support for external mods adding custom APIs for [9 years now](https://github.com/SquidDev-CC/CCTweaks/commit/b5e5f2cbd99ef350816850929e673459ba103679). This was originally designed for adding standalone APIs to all computers (such as [`socket`](https://github.com/SquidDev-CC/CCTweaks-Lua/wiki/socket-library) or [`data`](https://github.com/SquidDev-CC/CCTweaks-Lua/wiki/data-library)), however in recent years, we've seen people want to add APIs to only a subset of computers (e.g. only turtles), or APIs that require more information about the computer (e.g. its position). I will confess, I think most of these APIs probably should be peripherals. However, there are some legitimate use-cases, and we should aim to support those.

Unfortunately, this is not currently possible to do without mixins. This PR aims to rectify that, by providing a way to extract additional information from a `IComputerSystem` in the form of "computer components"[^1]. These components are attached to a computer when it is constructed, and then can be queried by other mods in their API providers.[^2]

[^1]: We can't just provide simple getters as a) this isn't especially extensible and b) `IComputerSystem` doesn't know anything about Minecraft.
[^2]: This is pretty similar to Forge's capability system, or vanilla's own item/data components. 

For an example, here's how CC:T registers the `pocket` API now:

```java
ComputerCraftAPI.registerAPIFactory(computer -> {
  // Try to extract the IPocketAccess from the computer.
  IPocketAccess pocket = computer.getComponent(ComputerComponents.POCKET);
  // If present, attach the pocket API.
  return pocket == null ? null : new PocketAPI(pocket);
});
```

I'm marking this as draft for now, as there's some further cleanup and documentation I'd like to do here. However, I'm pretty happy with the public API, so would appreciate thoughts on the design here!
