### PR TITLE
Add normal modem to all pockets

### DIFF
--- a/projects/common/src/main/java/dan200/computercraft/shared/pocket/core/PocketBrain.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/pocket/core/PocketBrain.java
@@ -14,6 +14,7 @@ import dan200.computercraft.shared.computer.core.ComputerFamily;
 import dan200.computercraft.shared.network.client.PocketComputerDataMessage;
 import dan200.computercraft.shared.network.server.ServerNetworking;
 import dan200.computercraft.shared.pocket.items.PocketComputerItem;
+import dan200.computercraft.shared.pocket.peripherals.PocketModem;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
@@ -154,6 +155,8 @@ public final class PocketBrain implements IPocketAccess {
     public void invalidatePeripheral() {
         var peripheral = upgrade == null ? null : upgrade.upgrade().createPeripheral(this);
         computer.setPeripheral(ComputerSide.BACK, peripheral);
+        // Attach a modem to the top of the pocket. This is a massive hack, but the easiest way to do it without duplicating code.
+        computer.setPeripheral(ComputerSide.TOP, new PocketModem(new ResourceLocation("computercraft", "fake_modem"), ItemStack.EMPTY, false).createPeripheral(this));
     }
 
     @Override


### PR DESCRIPTION
Allow me to preface that this is a draft because this is most likely not a proper way to implement this. This is just created as showcase/experimentation space to allow interested parties to see how this would feel.

![image](https://github.com/user-attachments/assets/8e52b800-9223-4d7f-b755-66a78d3c955c)

### What this is:
This basic bodge permanently attaches basic modem to top slot of all pockets. For base mod it means that one can attach second basic modem to double amount of channels they can open, ender modem to allow better range/interdimensionality or a speaker to add sound while still having basic functionality of basic modem installed. With other peripheral mods it means one can use peripherals from those mods on pocket without loosing network access. This does keep pockets as one swappable peripheral, it just add a unswapable internal top modem that increased functionality of pockets.

This is example of Suggestion A from https://github.com/cc-tweaked/CC-Tweaked/issues/1406 in same vein that https://github.com/cc-tweaked/CC-Tweaked/pull/1689 is a example of Suggestion B.

Despite fact that this is not proper way to do it it seems to be working correctly from tests i have preformed. 
![image](https://github.com/user-attachments/assets/ffb17d65-7d1d-4792-9793-e5d6bf31a3b0)
![image](https://github.com/user-attachments/assets/7e6d54c7-3485-443b-ad6c-7eb45d64ef9e)

As a side note that highly amuses me:
Turns out [colony4cc](https://github.com/uecasm/colony4cc/blob/trunk/src/main/java/nz/co/mirality/colony4cc/mixin/MixinPocketServerComputer.java) have been doing something similiar for last 4 years so this is not exactly unexplored solution.

Additionally i would like to thank SquidDev in https://github.com/cc-tweaked/CC-Tweaked/discussions/1916 for pointing out to me this is possible to bodge in this simple way. 😄 

EDIT: And if any of you wanna to test how this PR works you can use jar from this PR checks to try it out. https://github.com/cc-tweaked/CC-Tweaked/actions/runs/10193099406/artifacts/1763405706

