### PR TITLE
Fix getNextVersion

### DIFF
--- a/buildSrc/src/main/kotlin/cc/tweaked/gradle/Extensions.kt
+++ b/buildSrc/src/main/kotlin/cc/tweaked/gradle/Extensions.kt
@@ -143,7 +143,7 @@ fun getNextVersion(version: String): String {
     val lastIndex = mainVersion.lastIndexOf('.')
     if (lastIndex < 0) throw IllegalArgumentException("Cannot parse version format \"$version\"")
     val lastVersion = try {
-        version.substring(lastIndex + 1).toInt()
+        mainVersion.substring(lastIndex + 1).toInt()
     } catch (e: NumberFormatException) {
         throw IllegalArgumentException("Cannot parse version format \"$version\"", e)
     }


### PR DESCRIPTION
Fix `getNextVersion` to work properly with stuff like `1.2.3-SNAPSHOT`. It would previously crash, trying to parse `3-SNAPSHOT` as an integer.