### PR TITLE
Persistence of shell aliases/completions, settings definitions.

### DIFF
--- a/projects/core/src/main/resources/data/computercraft/lua/bios.lua
+++ b/projects/core/src/main/resources/data/computercraft/lua/bios.lua
@@ -723,8 +723,11 @@ if _CC_DEFAULT_SETTINGS then
 end
 
 -- Load user settings
-if fs.exists(".settings") then
-    settings.load(".settings")
+if fs.exists(".cc/settings") then
+    settings.load(".cc/settings")
+end
+if fs.exists(".cc/settings.def") then
+    settings.loadDefinitions(".cc/settings.def")
 end
 
 -- Run the shell

--- a/projects/core/src/main/resources/data/computercraft/lua/rom/apis/settings.lua
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/apis/settings.lua
@@ -48,7 +48,7 @@ end
 local valid_types = { "number", "string", "boolean", "table" }
 for _, v in ipairs(valid_types) do valid_types[v] = true end
 
---- Define a new setting, optional specifying various properties about it.
+--- Define a new setting, optionally specifying various properties about it.
 --
 -- While settings do not have to be added before being used, doing so allows
 -- you to provide defaults and additional metadata.
@@ -208,21 +208,64 @@ function getNames()
     return result
 end
 
+--- Load settings definitions from the given file.
+-- 
+-- Existing definitions will be merged with any pre-existing ones. Conflicting
+-- entries will be overwritten, but any others will be preserved.
+--
+-- @tparam[opt=".cc/settings.def"] string path The file to load from.
+-- @treturn boolean Whether definitions were successfully read from this
+-- file. Reasons for failure may include the file not existing or being
+-- corrupted.
+--
+-- @see settings.saveDefinitions
+-- @since x.xx.x
+function loadDefinitions(path)
+    expect(1, path, "string", "nil")
+    path = path or ".cc/settings.def"
+
+    local file = fs.open(path, "r")
+    if not file then
+        return false
+    end
+
+    local sText = file.readAll()
+    file.close()
+
+    local tFile = textutils.unserialize(sText)
+    if type(tFile) ~= "table" then
+        return false
+    end
+
+    for k, v in pairs(tFile) do
+        if type(k) == "string" and type(v) == "table" then
+            local ok, v = pcall(reserialize, v)
+            if ok then details[k] = v end
+        end
+    end
+
+    return true
+end
+
 --- Load settings from the given file.
 --
 -- Existing settings will be merged with any pre-existing ones. Conflicting
 -- entries will be overwritten, but any others will be preserved.
 --
--- @tparam[opt=".settings"] string path The file to load from.
+-- @tparam[opt=".cc/settings"] string path The file to load from.
 -- @treturn boolean Whether settings were successfully read from this
 -- file. Reasons for failure may include the file not existing or being
 -- corrupted.
 --
 -- @see settings.save
 -- @changed 1.87.0 `path` is now optional.
+-- @changed x.xx.x Default path is now `.cc/settings`.
 function load(path)
     expect(1, path, "string", "nil")
-    local file = fs.open(path or ".settings", "r")
+    path = path or ".cc/settings"
+
+    -- Load the current values from the main file.
+    local file = fs.open(path, "r")
     if not file then
         return false
     end
@@ -250,25 +293,48 @@ function load(path)
     return true
 end
 
---- Save settings to the given file.
---
--- This will entirely overwrite the pre-existing file. Settings defined in the
--- file, but not currently loaded will be removed.
---
--- @tparam[opt=".settings"] string path The path to save settings to.
--- @treturn boolean If the settings were successfully saved.
---
--- @see settings.load
--- @changed 1.87.0 `path` is now optional.
-function save(path)
-    expect(1, path, "string", "nil")
-    local file = fs.open(path or ".settings", "w")
+local function writeFile(path, data)
+    local file = fs.open(path, "w")
     if not file then
         return false
     end
 
-    file.write(textutils.serialize(values))
+    file.write(data)
     file.close()
 
     return true
+end
+
+--- Save current settings to the given file.
+--
+-- This will entirely overwrite the pre-existing file. This only saves
+-- the current values, without the definitions.
+--
+-- @tparam[opt=".cc/settings"] string path The path to save settings to.
+-- @treturn boolean If the settings were successfully saved.
+--
+-- @see settings.load
+-- @changed 1.87.0 `path` is now optional.
+-- @changed x.xx.x Default path is now `.cc/settings`.
+function save(path)
+    expect(1, path, "string", "nil")
+    path = path or ".cc/settings"
+
+    return writeFile(path, textutils.serialize(values))
+end
+
+--- Save settings definitions to the given file.
+--
+-- This will entirely overwrite the pre-existing file.
+--
+-- @tparam[opt=".cc/settings.def"] string path The path to save settings to.
+-- @treturn boolean If the definitions were successfully saved.
+--
+-- @see settings.loadDefinitions
+-- @since x.xx.x
+function saveDefinitions(path)
+    expect(1, path, "string", "nil")
+    path = path or ".cc/settings.def"
+
+    return writeFile(path, textutils.serialize(details))
 end

--- a/projects/core/src/main/resources/data/computercraft/lua/rom/programs/shell.lua
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/programs/shell.lua
@@ -574,6 +574,48 @@ function shell.completeProgram(program)
     return completeProgram(program)
 end
 
+local function loadCompletion(file, data)
+    --[[
+        local env = setmetatable(createShellEnv(dir), { __index = _G })
+        env.arg = args
+    ]]
+
+    local env = setmetatable(
+        createShellEnv("/rom/programs"),
+        { __index = _G }
+    )
+
+    env.completion = require("cc.shell.completion")
+
+    local fn, err = load(
+        "return " .. data,
+        "@/" .. file,
+        "t",
+        env
+    )
+    if not fn then
+        -- Attempt 2: load without the return statement
+        fn, err = load(
+            data,
+            "@/" .. file,
+            "t",
+            env
+        )
+
+        -- If we still failed to load, return the error
+        if not fn then
+            error(err, 3)
+        end
+    end
+
+    local ok, result = pcall(fn)
+    if not ok then
+        error(result, 0)
+    end
+
+    return result
+end
+
 --- Set the completion function for a program. When the program is entered on
 -- the command line, this program will be called to provide auto-complete
 -- information.
@@ -595,20 +637,111 @@ end
 -- You completion entries may also be followed by a space, if you wish to
 -- indicate another argument is expected.
 --
+-- Optionally, you may pass a string containing the function you wish to use as
+-- the completion function. This string will be stored on disk, and loaded when
+-- the computer starts up. This allows you to write completion functions that
+-- persist between reboots. The shell `cc.shell.completion` module is injected
+-- into the environment of this function, allowing you to use its utilities.
+--
+-- @usage
+-- ```lua
+-- local completion = require("cc.shell.completion")
+-- shell.setCompletionFunction(
+--   "yourprogram.lua",
+--   completion.build(completion.program)
+-- )
+-- ```
+--
+-- @usage
+-- ```lua
+-- shell.setCompletionFunction("yourprogram.lua", [[
+--     completion.build(completion.program) -- The shell completion library is injected into the environment
+-- ]])
+-- ```
+--
 -- @tparam string program The path to the program. This should be an absolute path
 -- _without_ the leading `/`.
--- @tparam function(shell: table, index: number, argument: string, previous: { string }):({ string }|nil) complete
--- The completion function.
+-- @tparam string|function(shell: table, index: number, argument: string, previous: { string }):({ string }|nil) complete
+-- The completion function, or a `loadstring`able version of it.
 -- @see cc.shell.completion Various utilities to help with writing completion functions.
 -- @see shell.complete
 -- @see _G.read For more information about completion.
 -- @since 1.74
+-- @changed x.xx.x Accepts a loadable string as a completion function, and saves it to disk.
 function shell.setCompletionFunction(program, complete)
     expect(1, program, "string")
-    expect(2, complete, "function")
+    expect(2, complete, "function", "string")
+
+    if type(complete) == "string" then
+        -- Load the completion function
+        local result = loadCompletion(".cc/completion/" .. program, complete)
+
+        if not result then
+            error("Bad completion function: nil value returned", 2)
+        end
+
+        -- Save the loadable version of the function
+        local file = fs.open(".cc/completion/" .. program, "w")
+        if not file then
+            error("Failed to save completion function.", 2)
+        end
+        file.write(complete)
+        file.close()
+
+        complete = result
+    end
+
     tCompletionInfo[program] = {
         fnComplete = complete,
     }
+end
+
+--- Clear a completion function for a program.
+--
+-- @tparam string program The path to the program.
+-- @since x.xx.x
+function shell.clearCompletionFunction(program)
+    expect(1, program, "string")
+    tCompletionInfo[program] = nil
+
+    -- Delete the completion function file
+    fs.delete(".cc/completion/" .. program)
+end
+
+--- Load all completion functions from disk.
+--
+-- This is called automatically when the shell is loaded, and should not be
+-- needed in normal usage.
+--
+-- @since x.xx.x
+function shell.loadCompletionFunctions()
+    if not fs.exists(".cc/completion") or not fs.isDir(".cc/completion") then
+        return
+    end
+
+    local files = fs.list(".cc/completion")
+
+    for _, file in ipairs(files) do
+        local path = fs.combine(".cc/completion", file)
+        local handle = fs.open(path, "r")
+        if handle then
+            local data = handle.readAll()
+            handle.close()
+
+            -- Problem: This runs at startup, so if someone enters an invalid
+            -- completion function to be loaded, we'll brick the computer.
+            -- We will fix this by only printing the error, and not throwing it.
+            local ok, result = pcall(loadCompletion, path, data)
+
+            if ok and result then
+                tCompletionInfo[file] = {
+                    fnComplete = result,
+                }
+            else
+                printError(result and result or ("%s:Bad completion function: nil value returned"):format(path))
+            end
+        end
+    end
 end
 
 --- Get a table containing all completion functions.
@@ -637,22 +770,71 @@ end
 --
 -- @tparam string command The name of the alias to add.
 -- @tparam string program The name or path to the program.
+-- @tparam boolean|nil dont_save If true, will not save the alias to disk.
+-- This is mainly used internally for aliases that are registered in the shell's
+-- startup script.
+-- Used mostly internally for aliases that are registered in the shell's
+-- startup script.
 -- @since 1.2
 -- @usage Alias `vim` to the `edit` program
 --
 --     shell.setAlias("vim", "edit")
-function shell.setAlias(command, program)
+-- @changed x.xx.x Aliases are now saved to disk.
+function shell.setAlias(command, program, dont_save)
     expect(1, command, "string")
     expect(2, program, "string")
+    expect(3, dont_save, "boolean", "nil")
     tAliases[command] = program
+
+    if dont_save then
+        return
+    end
+    -- Save the new alias
+    local file = fs.open(".cc/aliases/" .. command, "w")
+    if not file then
+        printError(("Failed to save alias '%s'"):format(command))
+        return
+    end
+
+    file.write(program)
+    file.close()
 end
 
 --- Remove an alias.
 --
 -- @tparam string command The alias name to remove.
+-- @since x.xx.x
 function shell.clearAlias(command)
     expect(1, command, "string")
     tAliases[command] = nil
+
+    -- Delete the alias file
+    fs.delete(".cc/aliases/" .. command)
+end
+
+--- Load aliases from disk.
+--
+-- This is called automatically when the shell is loaded, and should not be
+-- needed in normal usage.
+--
+-- @since x.xx.x
+function shell.loadAliases()
+    if not fs.exists(".cc/aliases") or not fs.isDir(".cc/aliases") then
+        return
+    end
+
+    local files = fs.list(".cc/aliases")
+
+    for _, file in ipairs(files) do
+        local path = fs.combine(".cc/aliases", file)
+        local handle = fs.open(path, "r")
+        if handle then
+            local program = handle.readAll()
+            handle.close()
+
+            tAliases[file] = program
+        end
+    end
 end
 
 --- Get the current aliases for this shell.

--- a/projects/core/src/main/resources/data/computercraft/lua/rom/startup.lua
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/startup.lua
@@ -27,18 +27,21 @@ shell.setPath(sPath)
 help.setPath("/rom/help")
 
 -- Setup aliases
-shell.setAlias("ls", "list")
-shell.setAlias("dir", "list")
-shell.setAlias("cp", "copy")
-shell.setAlias("mv", "move")
-shell.setAlias("rm", "delete")
-shell.setAlias("clr", "clear")
-shell.setAlias("rs", "redstone")
-shell.setAlias("sh", "shell")
+shell.setAlias("ls", "list", true)
+shell.setAlias("dir", "list", true)
+shell.setAlias("cp", "copy", true)
+shell.setAlias("mv", "move", true)
+shell.setAlias("rm", "delete", true)
+shell.setAlias("clr", "clear", true)
+shell.setAlias("rs", "redstone", true)
+shell.setAlias("sh", "shell", true)
 if term.isColor() then
-    shell.setAlias("background", "bg")
-    shell.setAlias("foreground", "fg")
+    shell.setAlias("background", "bg", true)
+    shell.setAlias("foreground", "fg", true)
 end
+
+-- Load aliases from disk
+shell.loadAliases()
 
 -- Setup completion functions
 
@@ -152,6 +155,9 @@ if turtle then
         { completion.choice, { "left", "right" } }
     ))
 end
+
+-- Load completion functions from disk
+shell.loadCompletionFunctions()
 
 -- Run autorun files
 if fs.exists("/rom/autorun") and fs.isDir("/rom/autorun") then


### PR DESCRIPTION
A common problem with using settings definitions, shell aliases, and completions, is that they do not persist across a computer restart, unless you custom-build your program to write a file to something like `/startup/99_definitions.lua`. This works, but is (in my opinion) not very ideal, nor intuitive -- most people don't even realize you can make a startup *folder*! Thus, I decided to draft up this PR.

With this, users can now add all of this information in their installer program and have it registered only once, but persist forever. It will also still work if the definitions are placed in the main program itself (as most people currently do things). However, the user won't have to run the program without arguments (or register a startup file) in order to get completions or settings definitions. Or at the very least, they only have to do it once, instead of once per startup.

## Contents
This PR adds/modifies the following methods:

### Settings
#### Additions
- `settings.saveDefinitions`: Saves the current settings definitions to disk. Saves to `/.cc/settings.def` by default.
- `settings.loadDefinitions`: Loads the current settings definitions from disk.

#### Alterations
- `settings.save`/`settings.load`: The new default storage location is `/.cc/settings`

### Shell
#### Additions
- `shell.clearCompletionFunction`: Deletes a record of a completion function.
- `shell.loadCompletionFunctions`: Loads all completion functions from disk.
- `shell.saveAliases`: (NYI) -- Saves all current aliases to disk. Contemplating adding this since we won't be able to filter what actually saves to the disk easily (see the alterations section `shell.setAlias` for more).
- `shell.loadAliases`: Loads all aliases from disk.

#### Alterations
- `shell.setCompletionFunction`: Now alternatively accepts a `load`able string as its second argument.
  - This string is stored on disk, to enable persistence.
  - The `cc.shell.completion` library is injected into the `load` environment.
  - Calling `setCompletionFunction` with a function instead of a string will *not* save the function, it only saves if called with a string.
- `shell.setAlias`: Added a third optional argument, `dont_save`
  - Mainly used internally for aliases defined in ROM startup. Since these technically already persist, it didn't make sense to also store them to disk.
- `shell.setAlias`: Now saves aliases as they are created.
  - Aliases are stored in `/.cc/aliases/<program name>`. Each alias file contains only a string for what the alias should refer to.
 
### BIOS
#### Additions
- Now loads settings definitions as well.

#### Alterations
- Changes the default settings location from `/.settings` to `/.cc/settings` and `/.cc/settings.def`
  - This can be undone easily if we think this will ruin backwards compatibility too much. My reasoning on this change is that we are now storing much more data for persistence, so we may as well store it *all* together. My belief is that this shouldn't break compatibility, as programs *shouldn't* be manually modifying `/.settings`.

### Startup
#### Additions
- Now loads aliases
- Now loads completion functions

#### Alterations
- `shell.setAlias` calls now pass the new third `true` parameter so they do not get saved to disk.

## `.cc` Folder Structure
```
.cc/
| - settings : The settings file
| - settings.def : The settings definitions file
| - aliases/ : Each file contained within is a single alias
    | - sh : Example, would contain "shell"
| - completions/
    | - example.lua : Contains the code for shell completion of `example.lua`
```

## Considerations
As outlined above, the settings are now stored by default in `/.cc/settings` (and `/.cc/settings.def`). This *could* cause some backwards compatibility issues if a program manually alters `/.settings` assuming that `settings.save()` will store the data there.

Edit: There are a few more edge cases that were discussed in Discord. 

1. User program saves a CraftOS-specific setting and passes `.settings` to `settings.save` instead of relying on the default: Upon restart, the setting will no longer be set, as `.settings` is no longer the default.
2. In a similar vein, if the user `.save()`s without an argument, then `.load(".settings")`s, this will also fail.
3. A program may rely on loading from `.settings`, but the `set` program would now default to storing in `.cc/settings`

Honestly, I will probably revert this change, but would like more feedback before I do so!

___

This is very much a draft PR, I need to write tests still as well as some general cleanup (i.e: variable names, need to use `fs.combine` in some locations, etc.). I wanted to get feedback on this before I went ahead on that step however. Thoughts on this? Concerns?