### PR TITLE
Add `turtle.getItemDetail` `detailed` flag introduction date

### DIFF
--- a/projects/common/src/main/java/dan200/computercraft/shared/turtle/apis/TurtleAPI.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/turtle/apis/TurtleAPI.java
@@ -747,6 +747,7 @@ public class TurtleAPI implements ILuaAPI {
      * @throws LuaException If the slot is out of range.
      * @cc.treturn nil|table Information about the given slot, or {@code nil} if it is empty.
      * @cc.since 1.64
+     * @cc.changed 1.90.0 Added detailed parameter.
      * @cc.usage Print the current slot, assuming it contains 13 dirt.
      *
      * <pre>{@code


### PR DESCRIPTION
This is a tiny doc fix to add the introduction of the `detailed` flag to the `turtle.getItemDetail` docs - a user on 1.89/1.12 pointed this out, and I figured I'd PR it real quick.