### PR TITLE
Show error in wget on http.get error

### DIFF
--- a/projects/core/src/main/resources/data/computercraft/lua/rom/programs/http/wget.lua
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/programs/http/wget.lua
@@ -45,9 +45,10 @@ local function get(sUrl)
 
     write("Connecting to " .. sUrl .. "... ")
 
-    local response = http.get(sUrl)
+    local response, err = http.get(sUrl)
     if not response then
-        print("Failed.")
+        print() -- write() above does not wrap, and error might be longer than available space
+        print(string.format("Failed: %s", err))
         return nil
     end
 

--- a/projects/core/src/main/resources/data/computercraft/lua/rom/programs/http/wget.lua
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/programs/http/wget.lua
@@ -47,7 +47,6 @@ local function get(sUrl)
 
     local response, err = http.get(sUrl)
     if not response then
-        print() -- write() above does not wrap, and error might be longer than available space
         print(string.format("Failed: %s", err))
         return nil
     end

--- a/projects/core/src/main/resources/data/computercraft/lua/rom/programs/http/wget.lua
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/programs/http/wget.lua
@@ -35,7 +35,7 @@ local function getFilename(sUrl)
     return sUrl:match("/([^/]+)$")
 end
 
-local function get(sUrl)
+local function get(url)
     -- Check if the URL is valid
     local ok, err = http.checkURL(url)
     if not ok then
@@ -43,12 +43,12 @@ local function get(sUrl)
         return
     end
 
-    write("Connecting to " .. sUrl .. "... ")
+    write("Connecting to " .. url .. "... ")
 
-    local response, err = http.get(sUrl)
+    local response, err = http.get(url)
     if not response then
-        print(string.format("Failed: %s", err))
-        return nil
+        printError(err)
+        return
     end
 
     print("Success.")


### PR DESCRIPTION
This is the most minor change one could ask for, but removes the need to open a lua shell to check why a file download failed.