### PR TITLE
Allow GPS to use modems connected through a hub

### DIFF
--- a/projects/core/src/main/resources/data/computercraft/lua/rom/apis/gps.lua
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/apis/gps.lua
@@ -106,7 +106,7 @@ function locate(_nTimeout, _bDebug)
         return commands.getBlockPosition()
     end
 
-    -- Open GPS channel to listen for ping responses
+    -- Find a modem
     local modem = peripheral.find("modem", function(_, m) return m.isWireless() end)
     
     if modem == nil then
@@ -120,6 +120,7 @@ function locate(_nTimeout, _bDebug)
         print("Finding position...")
     end
 
+    -- Open GPS channel to listen for ping responses
     local sModemSide = peripheral.getName(modem)
     local bCloseChannel = false
     if not modem.isOpen(CHANNEL_GPS) then

--- a/projects/core/src/main/resources/data/computercraft/lua/rom/apis/gps.lua
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/apis/gps.lua
@@ -106,16 +106,10 @@ function locate(_nTimeout, _bDebug)
         return commands.getBlockPosition()
     end
 
-    -- Find a modem
-    local sModemSide = nil
-    for _, sSide in ipairs(rs.getSides()) do
-        if peripheral.getType(sSide) == "modem" and peripheral.call(sSide, "isWireless") then
-            sModemSide = sSide
-            break
-        end
-    end
-
-    if sModemSide == nil then
+    -- Open GPS channel to listen for ping responses
+    local modem = peripheral.find("modem", function(_, m) return m.isWireless() end)
+    
+    if modem == nil then
         if _bDebug then
             print("No wireless modem attached")
         end
@@ -126,8 +120,7 @@ function locate(_nTimeout, _bDebug)
         print("Finding position...")
     end
 
-    -- Open GPS channel to listen for ping responses
-    local modem = peripheral.wrap(sModemSide)
+    local sModemSide = peripheral.getName(modem)
     local bCloseChannel = false
     if not modem.isOpen(CHANNEL_GPS) then
         modem.open(CHANNEL_GPS)

--- a/projects/core/src/test/resources/test-rom/spec/apis/gps_spec.lua
+++ b/projects/core/src/test/resources/test-rom/spec/apis/gps_spec.lua
@@ -24,6 +24,7 @@ describe("The gps library", function()
             local computer = fake_computer.make_computer(1, fn)
             computer.position = vector.new(x, y, z)
             fake_computer.add_api(computer, "rom/apis/gps.lua")
+            fake_computer.add_api(computer, "rom/apis/peripheral.lua")
             fake_computer.add_api(computer, "rom/apis/vector.lua")
 
             local modem = fake_computer.add_modem(computer, "back")
@@ -39,6 +40,7 @@ describe("The gps library", function()
                 end)
                 host.position = position
                 fake_computer.add_api(host, "rom/apis/gps.lua")
+                fake_computer.add_api(computer, "rom/apis/peripheral.lua")
                 fake_computer.add_api(host, "rom/apis/vector.lua")
 
                 local host_modem = fake_computer.add_modem(host, "back")

--- a/projects/core/src/test/resources/test-rom/spec/support/fake_computer.lua
+++ b/projects/core/src/test/resources/test-rom/spec/support/fake_computer.lua
@@ -28,6 +28,7 @@ local function make_computer(id, fn)
         getNames = function() return keys(peripherals) end,
         isPresent = function(name) return peripherals[name] ~= nil end,
         getType = function(name) return peripherals[name] and getmetatable(peripherals[name]).type end,
+        hasType = function(name, typ) return peripherals[name] and getmetatable(peripherals[name]).type == typ end,
         getMethods = function(name) return peripherals[name] and keys(peripherals[name]) end,
         call = function(name, method, ...)
             local p = peripherals[name]


### PR DESCRIPTION
This PR changes the `gps.locate` code to use `peripheral.find` to look for a modem, instead of manually enumerating through `rs.getSides()`, which is both more verbose than necessary and skips over networked modems.