### PR TITLE
docs: specify valid types for settings.define

### DIFF
--- a/projects/core/src/main/resources/data/computercraft/lua/rom/apis/settings.lua
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/apis/settings.lua
@@ -61,7 +61,7 @@ for _, v in ipairs(valid_types) do valid_types[v] = true end
 --  - `default`: A default value, which is returned by [`settings.get`] if the
 --    setting has not been changed.
 --  - `type`: Require values to be of this type. [Setting][`set`] the value to another type
---    will error.
+--    will error. Must be one of: `"number"`, `"string"`, `"boolean"`, or `"table"`.
 -- @since 1.87.0
 function define(name, options)
     expect(1, name, "string")


### PR DESCRIPTION
As per `valid_types` defined here:
https://github.com/cc-tweaked/CC-Tweaked/blob/676fb5fb53d14222bd90e60fef1f25f16495600b/projects/core/src/main/resources/data/computercraft/lua/rom/apis/settings.lua#L48