### PR TITLE
Add network name parameter to redstone event.

### DIFF
--- a/projects/common/src/main/java/dan200/computercraft/shared/peripheral/redstone/RedstoneRelayPeripheral.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/peripheral/redstone/RedstoneRelayPeripheral.java
@@ -65,6 +65,8 @@ public final class RedstoneRelayPeripheral extends RedstoneMethods implements IP
     }
 
     void queueRedstoneEvent() {
-        computers.queueEvent("redstone");
+        computers.forEach(computer -> {
+            computer.queueEvent("redstone", computer.getAttachmentName());
+        });
     }
 }


### PR DESCRIPTION
This PR adds the network name of the Redstone relay to the `redstone` event when queued by it.

As many people expressed in https://github.com/cc-tweaked/CC-Tweaked/pull/2002, including this parameter would simplify the code and avoid querying all the Redstone relays attached to the computer.