### PR TITLE
Fix ConcurrentModificationException caused by timers

### DIFF
--- a/src/main/java/dan200/computercraft/core/apis/OSAPI.java
+++ b/src/main/java/dan200/computercraft/core/apis/OSAPI.java
@@ -203,8 +203,10 @@ public class OSAPI implements ILuaAPI {
      */
     @LuaFunction
     public final int startTimer(double timer) throws LuaException {
-        timers.put(nextTimerToken, new Timer((int) Math.round(checkFinite(0, timer) / 0.05)));
-        return nextTimerToken++;
+        synchronized (timers) {
+            timers.put(nextTimerToken, new Timer((int) Math.round(checkFinite(0, timer) / 0.05)));
+            return nextTimerToken++;
+        }
     }
 
     /**
@@ -217,7 +219,9 @@ public class OSAPI implements ILuaAPI {
      */
     @LuaFunction
     public final void cancelTimer(int token) {
-        timers.remove(token);
+        synchronized (timers) {
+            timers.remove(token);
+        }
     }
 
     /**


### PR DESCRIPTION

When running computer programs relying heavily on timers on CC-Tweaked for MC 1.4.7 the server crashes with the following:
```
java.util.ConcurrentModificationException
    at java.util.HashMap$HashIterator.remove(HashMap.java:1459)
    at dan200.computercraft.core.apis.OSAPI.advance(OSAPI.java:104)
    at dan200.computer.core.Computer.advance(Computer.java:560)
    at dan200.computer.shared.NetworkedComputerHelper.update(NetworkedComputerHelper.java:111)
    at dan200.computer.shared.TileEntityComputer.g(TileEntityComputer.java:95)
    at yc.h(World.java:2153)
    at in.h(WorldServer.java:516)
    at net.minecraft.server.MinecraftServer.r(MinecraftServer.java:680)
    at ho.r(DedicatedServer.java:269)
    at net.minecraft.server.MinecraftServer.q(MinecraftServer.java:599)
    at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:497)
    at fy.run(SourceFile:849)
```

It seems locks on timers where simply forgotten, I checked alarms and they do seems to lock properly.