### PR TITLE
Add notes about minor changed file handle behavior in 1.109.0

### DIFF
--- a/projects/core/src/main/java/dan200/computercraft/core/apis/handles/AbstractHandle.java
+++ b/projects/core/src/main/java/dan200/computercraft/core/apis/handles/AbstractHandle.java
@@ -76,6 +76,7 @@ public abstract class AbstractHandle {
      * @cc.treturn [2] nil If seeking failed.
      * @cc.treturn string The reason seeking failed.
      * @cc.since 1.80pr1.9
+     * @cc.changed 1.109.0 Now available on all file handles, instead of only binary handles.
      */
     public Object @Nullable [] seek(Optional<String> whence, Optional<Long> offset) throws LuaException {
         checkOpen();
@@ -179,6 +180,7 @@ public abstract class AbstractHandle {
      * @throws LuaException If the file has been closed.
      * @cc.treturn string|nil The remaining contents of the file, or {@code nil} in the event of an error.
      * @cc.since 1.80pr1
+     * @cc.changed 1.109.0 No longer returns {@code nil} at the end of the file.
      */
     public Object @Nullable [] readAll() throws LuaException {
         checkOpen();

--- a/projects/core/src/main/java/dan200/computercraft/core/apis/handles/AbstractHandle.java
+++ b/projects/core/src/main/java/dan200/computercraft/core/apis/handles/AbstractHandle.java
@@ -76,7 +76,7 @@ public abstract class AbstractHandle {
      * @cc.treturn [2] nil If seeking failed.
      * @cc.treturn string The reason seeking failed.
      * @cc.since 1.80pr1.9
-     * @cc.changed 1.109.0 Now available on all file handles, instead of only binary handles.
+     * @cc.changed 1.109.0 Now available on all file handles, not just binary-mode handles.
      */
     public Object @Nullable [] seek(Optional<String> whence, Optional<Long> offset) throws LuaException {
         checkOpen();
@@ -180,7 +180,8 @@ public abstract class AbstractHandle {
      * @throws LuaException If the file has been closed.
      * @cc.treturn string|nil The remaining contents of the file, or {@code nil} in the event of an error.
      * @cc.since 1.80pr1
-     * @cc.changed 1.109.0 No longer returns {@code nil} at the end of the file.
+     * @cc.changed 1.109.0 Binary-mode handles are now consistent with non-binary files, and return an empty string at
+     * the end of the file, rather than {@code nil}.
      */
     public Object @Nullable [] readAll() throws LuaException {
         checkOpen();


### PR DESCRIPTION
This PR adds some notes about minor behavior changes to file handles in 1.109.0 that may be important to users dealing with compatibility, and that I missed in that update and am definitely not adding notes for out of spite.
