### PR TITLE
Fix parse_color

### DIFF
--- a/projects/core/src/main/resources/data/computercraft/lua/rom/apis/colors.lua
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/apis/colors.lua
@@ -371,7 +371,7 @@ function toBlit(color)
     local hex = color_hex_lookup[color]
     if hex then return hex end
 
-    if color < 0 or color > 0xffff then error("Colour out of range", 2) end
+    if color < 1 or color > 0xffff then error("Colour out of range", 2) end
     return string.format("%x", math.floor(math.log(color, 2)))
 end
 

--- a/projects/core/src/main/resources/data/computercraft/lua/rom/apis/window.lua
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/apis/window.lua
@@ -61,12 +61,11 @@ local string_sub = string.sub
 --- A custom version of [`colors.toBlit`], specialised for the window API.
 local function parse_color(color)
     if type(color) ~= "number" then
+        -- By tail-calling expect, we ensure expect has the right error level.
         return expect(1, color, "number")
     end
 
-    if color < 1 or color > 0xffff then
-        error("Colour out of range", 3)
-    end
+    if color < 1 or color > 0xffff then error("Colour out of range", 3) end
 
     return 2 ^ math.floor(math.log(color, 2))
 end

--- a/projects/core/src/main/resources/data/computercraft/lua/rom/apis/window.lua
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/apis/window.lua
@@ -66,7 +66,6 @@ local function parse_color(color)
     end
 
     if color < 1 or color > 0xffff then error("Colour out of range", 3) end
-
     return 2 ^ math.floor(math.log(color, 2))
 end
 

--- a/projects/core/src/main/resources/data/computercraft/lua/rom/apis/window.lua
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/apis/window.lua
@@ -61,11 +61,13 @@ local string_sub = string.sub
 --- A custom version of [`colors.toBlit`], specialised for the window API.
 local function parse_color(color)
     if type(color) ~= "number" then
-        -- By tail-calling expect, we ensure expect has the right error level.
         return expect(1, color, "number")
     end
 
-    if color < 0 or color > 0xffff then error("Colour out of range", 3) end
+    if color <= 0 or color > 0xffff then
+        error("Colour out of range", 3)
+    end
+
     return 2 ^ math.floor(math.log(color, 2))
 end
 

--- a/projects/core/src/main/resources/data/computercraft/lua/rom/apis/window.lua
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/apis/window.lua
@@ -64,7 +64,7 @@ local function parse_color(color)
         return expect(1, color, "number")
     end
 
-    if color <= 0 or color > 0xffff then
+    if color < 1 or color > 0xffff then
         error("Colour out of range", 3)
     end
 

--- a/projects/core/src/test/resources/test-rom/spec/apis/colors_spec.lua
+++ b/projects/core/src/test/resources/test-rom/spec/apis/colors_spec.lua
@@ -94,6 +94,7 @@ describe("The colors library", function()
         end)
 
         it("errors on out-of-range colours", function()
+            expect.error(colors.toBlit, 0):eq("Colour out of range")
             expect.error(colors.toBlit, -120):eq("Colour out of range")
             expect.error(colors.toBlit, 0x10000):eq("Colour out of range")
         end)

--- a/projects/core/src/test/resources/test-rom/spec/apis/window_spec.lua
+++ b/projects/core/src/test/resources/test-rom/spec/apis/window_spec.lua
@@ -59,6 +59,16 @@ describe("The window library", function()
 
             expect.error(w.setTextColour, nil):eq("bad argument #1 (number expected, got nil)")
             expect.error(w.setTextColour, -5):eq("Colour out of range")
+            expect.error(w.setTextColour, 0):eq("Colour out of range")
+            expect.error(w.setTextColour, 0x10000):eq("Colour out of range")
+        end)
+
+        it("accepts valid colours", function()
+            local w = mk()
+            for i = 0, 15 do
+                w.setBackgroundColour(2 ^ i)
+                expect(w.getBackgroundColour()):eq(2 ^ i)
+            end
         end)
 
         it("supports invalid combined colours", function()


### PR DESCRIPTION
## Minecraft version
Universal
## Version
All since this code has existed
## Details
First discovered when attempting to run `term.setBackgroundColor(0)`, attempting to input 0 to a function that uses `parse_color` will crash the current program with an error that does not explain what went wrong. This only occurs on advanced computers.