### PR TITLE
Update motd path in startup.lua

### DIFF
--- a/projects/core/src/main/resources/data/computercraft/lua/rom/startup.lua
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/startup.lua
@@ -191,7 +191,7 @@ end
 
 -- Show MOTD
 if settings.get("motd.enable") then
-    shell.run("motd")
+    shell.run("/rom/programs/motd")
 end
 
 -- Run the user created startup, either from disk drives or the root


### PR DESCRIPTION
## Issue:
Currently startup.lua is using just name of program "motd" to run /rom motd program. This means that if user accidentally or maliciously creates a program named `motd` at root, due to way shell resolution works it will be executed instead of /rom motd program, basically getting executed from hard drive before normal startup files logic can happen. This can cause both confusion, and/or be used by crafty user to run code from computer hard drive even when CC would use disk drive startup file afterwards.

## Solution:
Changing path to absolute one removes this bit of ambiguity. 