### PR TITLE
Miniscule typo fix in the shell.path() doc comment

### DIFF
--- a/projects/core/src/main/resources/data/computercraft/lua/rom/programs/shell.lua
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/programs/shell.lua
@@ -300,7 +300,7 @@ function shell.setDir(dir)
     sDir = fs.combine(dir, "")
 end
 
---- Set the path where programs are located.
+--- Get the path where programs are located.
 --
 -- The path is composed of a list of directory names in a string, each separated
 -- by a colon (`:`). On normal turtles will look in the current directory (`.`),


### PR DESCRIPTION
Noticed this when reading the [shell API page](https://tweaked.cc/module/shell.html#v:path) in the wiki.

