### PR TITLE
Add capacity to fluid tank data (1.21.x)

### DIFF
--- a/projects/fabric/src/main/java/dan200/computercraft/shared/details/FluidDetails.java
+++ b/projects/fabric/src/main/java/dan200/computercraft/shared/details/FluidDetails.java
@@ -21,6 +21,7 @@ public class FluidDetails {
     public static void fillBasic(Map<? super String, Object> data, StorageView<FluidVariant> fluid) {
         data.put("name", DetailHelpers.getId(BuiltInRegistries.FLUID, fluid.getResource().getFluid()));
         data.put("amount", fluid.getAmount());
+        data.put("capacity", fluid.getCapacity());
     }
 
     public static void fill(Map<? super String, Object> data, StorageView<FluidVariant> fluid) {

--- a/projects/forge/src/main/java/dan200/computercraft/shared/details/FluidData.java
+++ b/projects/forge/src/main/java/dan200/computercraft/shared/details/FluidData.java
@@ -13,6 +13,8 @@ public class FluidData {
     public static void fillBasic(Map<? super String, Object> data, FluidStack stack) {
         data.put("name", DetailHelpers.getId(BuiltInRegistries.FLUID, stack.getFluid()));
         data.put("amount", stack.getAmount());
+        // "capacity" is added manually elsewhere since FluidStack does not contain a capacity.
+        // See: dan200.computercraft.shared.peripheral.generic.methods.FluidMethods#tanks
     }
 
     public static void fill(Map<? super String, Object> data, FluidStack stack) {

--- a/projects/forge/src/main/java/dan200/computercraft/shared/peripheral/generic/methods/FluidMethods.java
+++ b/projects/forge/src/main/java/dan200/computercraft/shared/peripheral/generic/methods/FluidMethods.java
@@ -35,7 +35,13 @@ public final class FluidMethods extends AbstractFluidMethods<IFluidHandler> {
         var size = fluids.getTanks();
         for (var i = 0; i < size; i++) {
             var stack = fluids.getFluidInTank(i);
-            if (!stack.isEmpty()) result.put(i + 1, ForgeDetailRegistries.FLUID_STACK.getBasicDetails(stack));
+            if (!stack.isEmpty()) {
+                var data = ForgeDetailRegistries.FLUID_STACK.getBasicDetails(stack);
+                // FluidStacks do not keep capacity, meaning the DetailRegistry cannot add it by itself. We'll
+                // add it manually here instead.
+                data.put("capacity", fluids.getTankCapacity(i));
+                result.put(i + 1, data);
+            }
         }
 
         return result;


### PR DESCRIPTION
Closes #1629

The Forge implementation feels pretty hacky. I considered trying to change `ComputerCraftAPIImpl#fluidStackDetails` to a `DetailRegistry<IFluidTank>` or similar, however it seemed like it would have been less compatible or would entail a more breaking change for addon developers.

The Fabric implementation was clean-cut.

I also made this change for 1.20.x in another PR. Porting this to 1.21.y should be the exact same.
