### PR TITLE
changelog: retroactively document changes to os.version()

### DIFF
--- a/doc/stub/global.lua
+++ b/doc/stub/global.lua
@@ -117,10 +117,14 @@ function read(replaceChar, history, completeFn, default) end
 -- Outside of Minecraft (for instance, in an emulator) [`_HOST`] will contain the
 -- emulator's version instead.
 --
+-- If you need to check for the presence of a feature, it is usually better to
+-- rely on feature detection, rather than comparing mod or Minecraft versions.
+--
 -- For example, `ComputerCraft 1.93.0 (Minecraft 1.15.2)`.
 -- @usage Print the current computer's environment.
 --
 --     print(_HOST)
+-- @see os.version
 -- @since 1.76
 _HOST = _HOST
 

--- a/doc/stub/os.lua
+++ b/doc/stub/os.lua
@@ -100,13 +100,12 @@ function sleep(time) end
 -- This is defined by `bios.lua`. For the current version of CC:Tweaked, this
 -- should return `CraftOS 1.9`.
 --
--- The version returned by this function is purely decorative.
--- It is usually better to rely on direct feature detection instead of
--- programmatically using the value of this string.
+-- If you need to check for the presence of a feature, it is usually better to
+-- rely on feature detection, rather than comparing CraftOS versions.
 --
 -- @treturn string The current CraftOS version.
 -- @usage os.version()
--- @see _HOST
+-- @see _G._HOST
 function version() end
 
 --[[- Run the program at the given path with the specified environment and

--- a/doc/stub/os.lua
+++ b/doc/stub/os.lua
@@ -106,6 +106,7 @@ function sleep(time) end
 --
 -- @treturn string The current CraftOS version.
 -- @usage os.version()
+-- @see _HOST
 function version() end
 
 --[[- Run the program at the given path with the specified environment and

--- a/doc/stub/os.lua
+++ b/doc/stub/os.lua
@@ -100,6 +100,10 @@ function sleep(time) end
 -- This is defined by `bios.lua`. For the current version of CC:Tweaked, this
 -- should return `CraftOS 1.9`.
 --
+-- The version returned by this function is purely decorative.
+-- It is usually better to rely on direct feature detection instead of
+-- programmatically using the value of this string.
+--
 -- @treturn string The current CraftOS version.
 -- @usage os.version()
 function version() end

--- a/projects/core/src/main/resources/data/computercraft/lua/rom/help/changelog.md
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/help/changelog.md
@@ -252,6 +252,7 @@ Several bug fixes:
 * File handles, HTTP requests and websocket messages now use raw bytes rather than converting to UTF-8.
 * Add `allow_repetitions` option to `textutils.serialiseJSON`.
 * Track memory allocated by computers.
+* Update the version returned by `os.version()` to `CraftOS 1.9`.
 
 Several bug fixes:
 * Fix error when using position captures and backreferences in string patterns (e.g. `()(%1)`).
@@ -1283,6 +1284,7 @@ And several bug fixes:
 * Monitors glow in the dark.
 * http_failure event includes the HTTP handle if available.
 * HTTP responses include the response headers.
+* Update the version returned by `os.version()` to `CraftOS 1.8`.
 
 # New Features in ComputerCraft 1.79:
 
@@ -1353,6 +1355,7 @@ And several bug fixes:
 * Fixed various bugs, crashes and exploits
 * Fixed problems with HD texture packs
 * Documented the new features in the in-game help
+* Update the version returned by `os.version()` to `CraftOS 1.7`.
 
 # New Features in ComputerCraft 1.65:
 
@@ -1411,6 +1414,7 @@ And several bug fixes:
 * `turtle.suck( [limit] )` can now be used to limit the number of items picked up
 * Users of `turtle.dig()` and `turtle.attack()` can now specify which side of the turtle to look for a tool to use (by default, both will be considered)
 * `textutils.serialise( text )` now produces human-readable output
+* Update the version returned by `os.version()` to `CraftOS 1.6`.
 * Refactored most of the codebase and fixed many old bugs and instabilities, turtles should never ever lose their content now
 * Fixed the `turtle_inventory` event firing when it shouldn't have
 * Added error messages to many more turtle functions after they return false
@@ -1472,6 +1476,7 @@ And several bug fixes:
 * `turtle.place()` now tries all possible block orientations before failing
 * `turtle.refuel(0)` returns true if a fuel item is selected
 * `turtle.craft(0)` returns true if the inventory is a valid recipe
+* Update the version returned by `os.version()` to `CraftOS 1.5`.
 * The in-game help system now has documentation for all the peripherals and their methods, including the new modem functionality
 * A romantic surprise
 
@@ -1544,6 +1549,7 @@ And several bug fixes:
 * `http.request()` now supports https:// URLs
 * Right clicking a Disk Drive with a Floppy Disk or a Record when sneaking will insert the item into the Disk Drive automatically
 * The default size of the computer screen has been increased
+* Update the version returned by `os.version()` to `CraftOS 1.4`.
 * Several stability and security fixes. LuaJ can now no longer leave dangling threads when a computer is unloaded, turtles can no longer be destroyed by tree leaves or walking off the edge of the loaded map. Computers no longer crash when used with RedPower frames.
 
 # New Features in ComputerCraft 1.31:
@@ -1584,6 +1590,7 @@ And several bug fixes:
 * New io file function: `file:lines()`
 * New fs function: `fs.getSize()`
 * Disk Drives can now play records from other mods
+* Update the version returned by `os.version()` to `CraftOS 1.3`.
 * Bug fixes, program tweaks, and help updates
 
 # New Features in ComputerCraft 1.2:
@@ -1599,6 +1606,7 @@ And several bug fixes:
 * New os functions: `os.loadAPI()`, `os.unloadAPI()`, `os.clock()`, `os.time()`, `os.setAlarm()`, `os.reboot()`, `os.queueEvent()`
 * New redstone function: `redstone.getSides()`
 * New shell functions: `shell.setPath()`, `shell.programs()`, `shell.resolveProgram()`, `shell.setAlias()`
+* Update the version returned by `os.version()` to `CraftOS 1.2`.
 * Lots of updates to the help pages
 * Bug fixes
 
@@ -1609,6 +1617,7 @@ And several bug fixes:
 * Added HTTP api, enabled via the mod config, to allow computers to access the real world internet
 * Added command history to the shell.
 * Programs which spin in an infinite loop without yielding will no longer freeze minecraft
+* Update the version returned by `os.version()` to `CraftOS 1.1`.
 * Help updates and bug fixes
 
 # New Features in ComputerCraft 1.0:


### PR DESCRIPTION
This is useful information for people who want to know what changed along with the changes for these version numbers, if someone wants to write a backwards-compatible program that relies on behavior that changed between the two versions.

I had to do some archaeology to find this information. Here are the commits:
* 2c7ee1d7e75dc89f720e40feee430fbfb8cb525c
* d272a327c7d48e7001361697764687031872aa8d

An aside: it would be nice if this version number changed whenever a breaking change occured in CraftOS, but I digress.
