### PR TITLE
Made Pastebin uploads unlisted instead of public

### DIFF
--- a/projects/core/src/main/resources/data/computercraft/lua/rom/programs/http/pastebin.lua
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/programs/http/pastebin.lua
@@ -100,7 +100,7 @@ if sCommand == "put" then
         "api_option=paste&" ..
         "api_dev_key=" .. key .. "&" ..
         "api_paste_format=lua&" ..
-        "api_paste_private=1&"
+        "api_paste_private=1&" ..
         "api_paste_name=" .. textutils.urlEncode(sName) .. "&" ..
         "api_paste_code=" .. textutils.urlEncode(sText)
     )

--- a/projects/core/src/main/resources/data/computercraft/lua/rom/programs/http/pastebin.lua
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/programs/http/pastebin.lua
@@ -100,6 +100,7 @@ if sCommand == "put" then
         "api_option=paste&" ..
         "api_dev_key=" .. key .. "&" ..
         "api_paste_format=lua&" ..
+        "api_paste_private=1&"
         "api_paste_name=" .. textutils.urlEncode(sName) .. "&" ..
         "api_paste_code=" .. textutils.urlEncode(sText)
     )


### PR DESCRIPTION
I made Pastebin uploads unlisted instead of public.
The majority of the time this isn't an issue but a player might upload something they shouldn't without realizing the pastes are public by default.