### PR TITLE
Fix missing return value docs in shell.openTab

### DIFF
--- a/projects/core/src/main/resources/data/computercraft/lua/rom/programs/shell.lua
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/programs/shell.lua
@@ -684,6 +684,7 @@ if multishell then
     -- This function is only available if the [`multishell`] API is.
     --
     -- @tparam string ... The command line to run.
+    -- @treturn number The ID of the new tab that was opened.
     -- @see shell.run
     -- @see multishell.launch
     -- @since 1.6


### PR DESCRIPTION
This PR fixes missing documentation for `shell.openTab`'s return value, which returns the same as `multishell.launch` via tail call.