### PR TITLE
Fix discrepancy in `type` help

### DIFF
--- a/projects/core/src/main/resources/data/computercraft/lua/rom/help/type.txt
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/help/type.txt
@@ -1,1 +1,1 @@
-type determines the type of a file or directory. Prints "file", "directory" or "does not exist".
+type determines the type of a file or directory. Prints "file", "directory" or "No such path".


### PR DESCRIPTION
to see for yourself, run `help type`, then `type potato`

Image of it:
<img width="619" height="146" alt="Screenshot 2026-01-26 at 11 18 34 AM" src="https://github.com/user-attachments/assets/02474e0f-8af9-4f0a-a47c-62fc7ccb0a8d" />

While "No such path" is capitalized while real types are not, this is hardcoded to be the case, so I assume it is intended and updated the presumably outdated help info instead.


(this was originally going to be an issue, but it's so simple I thought I'd just go do it myself)