### PR TITLE
Add cat, echo, and touch shell programs

### DIFF
--- a/projects/core/src/main/resources/data/computercraft/lua/rom/programs/cat.lua
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/programs/cat.lua
@@ -1,0 +1,26 @@
+-- SPDX-FileCopyrightText: 2025 The CC: Tweaked Developers
+--
+-- SPDX-License-Identifier: MPL-2.0
+
+local tArgs = { ... }
+
+if #tArgs < 1 then
+    local programName = arg[0] or fs.getName(shell.getRunningProgram())
+    print("Usage: " .. programName .. " <paths>")
+    return
+end
+
+for _, v in ipairs(tArgs) do
+    local sPath = shell.resolve(v)
+    if fs.exists(sPath) then
+        if fs.isDir(sPath) then
+            printError(v .. ": Is a directory")
+        else
+            local file = fs.open(sPath, "r")
+            print(file.readAll())
+            file.close()
+        end
+    else
+        printError(v .. ": No such file")
+    end
+end

--- a/projects/core/src/main/resources/data/computercraft/lua/rom/programs/echo.lua
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/programs/echo.lua
@@ -1,0 +1,5 @@
+-- SPDX-FileCopyrightText: 2025 The CC: Tweaked Developers
+--
+-- SPDX-License-Identifier: MPL-2.0
+
+print(...)

--- a/projects/core/src/main/resources/data/computercraft/lua/rom/programs/touch.lua
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/programs/touch.lua
@@ -1,0 +1,23 @@
+-- SPDX-FileCopyrightText: 2025 The CC: Tweaked Developers
+--
+-- SPDX-License-Identifier: MPL-2.0
+
+local tArgs = { ... }
+
+if #tArgs < 1 then
+    local programName = arg[0] or fs.getName(shell.getRunningProgram())
+    print("Usage: " .. programName .. " <paths>")
+    return
+end
+
+for _, v in ipairs(tArgs) do
+    local sPath = shell.resolve(v)
+    if fs.isDir(sPath) then
+        printError(v .. ": Is a directory")
+    elseif fs.isReadOnly(sPath) then
+        printError(v .. ": Access denied")
+    else
+        local file = fs.open(sPath, "a")
+        file.close()
+    end
+end


### PR DESCRIPTION
I've been using startup scripts to make a more unix-like environment for a while now, thought I'd add a few common things. I'll be honest where AI (Claude Code) was used:

- `echo` can be used in combination with `monitor` to print on a monitor without having to first write a program. Claude tried wrapping tArgs and joining them with " " but I just `print(...)` directly, plus `{...}.x` or `{...}[x]` tends to be unreliable in Lua unless cast to a variable first.
- `cat` prints file contents, again, without having to go through `edit`, can be used in combination with a txt file for what echo can do. I have a `less` command on my own computer which uses `textutils.pagedPrint`, that's more helpful for larger files Claude basically rewrote this, my implementation was basically just `print(fs.open(..., "r").readAll())`, which gets the job done I guess.
- `touch` creates an empty file, or does nothing if the file already exists. Again, my implementation was very basic, `fs.open(..., "a").close()`, Claude did everything else in this file.