### PR TITLE
Update TurtleAPI documentation for block breaking

### DIFF
--- a/projects/common/src/main/java/dan200/computercraft/shared/turtle/apis/TurtleAPI.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/turtle/apis/TurtleAPI.java
@@ -165,8 +165,8 @@ public class TurtleAPI implements ILuaAPI {
      * Attempt to break the block in front of the turtle.
      * <p>
      * This requires a turtle tool capable of breaking the block. Diamond pickaxes
-     * (mining turtles) can break any vanilla block, but other tools (such as axes)
-     * are more limited.
+     * (mining turtles) can break any vanilla block breakable in survival mode,
+     * but other tools (such as axes) are more limited.
      *
      * @param side The specific tool to use. Should be "left" or "right".
      * @return The turtle command result.


### PR DESCRIPTION
Clarified the description of block breaking capabilities for mining turtles. I opted for "breakable in survival mode" to include similarly unbreakable blocks, like End portal frames, barriers, reinforced deepslate, etc.

Fix to issue #2379.