### PR TITLE
Fix missing reference to data packs in .ignoreme files

### DIFF
--- a/projects/core/src/main/resources/data/computercraft/lua/rom/autorun/.ignoreme
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/autorun/.ignoreme
@@ -1,4 +1,4 @@
 --[[
 Alright then, don't ignore me. This file is to ensure the existence of the "autorun" folder, files placed in this folder
-using resource packs/data packs will always run when computers startup.
+using data packs will always run when computers startup.
 ]]

--- a/projects/core/src/main/resources/data/computercraft/lua/rom/autorun/.ignoreme
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/autorun/.ignoreme
@@ -1,4 +1,4 @@
 --[[
 Alright then, don't ignore me. This file is to ensure the existence of the "autorun" folder, files placed in this folder
-using resource packs will always run when computers startup.
+using resource packs/data packs will always run when computers startup.
 ]]

--- a/projects/core/src/main/resources/data/computercraft/lua/rom/modules/command/.ignoreme
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/modules/command/.ignoreme
@@ -1,4 +1,4 @@
 --[[
 Alright then, don't ignore me. This file is to ensure the existence of the "modules/command" folder.
-You can use this folder to add modules who can be loaded with require() to your Resourcepack.
+You can use this folder to add modules who can be loaded with require() to your Resourcepack/Datapack.
 ]]

--- a/projects/core/src/main/resources/data/computercraft/lua/rom/modules/command/.ignoreme
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/modules/command/.ignoreme
@@ -1,4 +1,4 @@
 --[[
 Alright then, don't ignore me. This file is to ensure the existence of the "modules/command" folder.
-You can use this folder to add modules who can be loaded with require() to your Resourcepack/Datapack.
+You can use this folder to add modules who can be loaded with require() to your data pack.
 ]]

--- a/projects/core/src/main/resources/data/computercraft/lua/rom/modules/main/.ignoreme
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/modules/main/.ignoreme
@@ -1,4 +1,4 @@
 --[[
 Alright then, don't ignore me. This file is to ensure the existence of the "modules/main" folder.
-You can use this folder to add modules who can be loaded with require() to your Resourcepack.
+You can use this folder to add modules who can be loaded with require() to your Resourcepack/Datapack.
 ]]

--- a/projects/core/src/main/resources/data/computercraft/lua/rom/modules/main/.ignoreme
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/modules/main/.ignoreme
@@ -1,4 +1,4 @@
 --[[
 Alright then, don't ignore me. This file is to ensure the existence of the "modules/main" folder.
-You can use this folder to add modules who can be loaded with require() to your Resourcepack/Datapack.
+You can use this folder to add modules who can be loaded with require() to your data pack.
 ]]

--- a/projects/core/src/main/resources/data/computercraft/lua/rom/modules/turtle/.ignoreme
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/modules/turtle/.ignoreme
@@ -1,4 +1,4 @@
 --[[
 Alright then, don't ignore me. This file is to ensure the existence of the "modules/turtle" folder.
-You can use this folder to add modules who can be loaded with require() to your Resourcepack.
+You can use this folder to add modules who can be loaded with require() to your Resourcepack/Datapack.
 ]]

--- a/projects/core/src/main/resources/data/computercraft/lua/rom/modules/turtle/.ignoreme
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/modules/turtle/.ignoreme
@@ -1,4 +1,4 @@
 --[[
 Alright then, don't ignore me. This file is to ensure the existence of the "modules/turtle" folder.
-You can use this folder to add modules who can be loaded with require() to your Resourcepack/Datapack.
+You can use this folder to add modules who can be loaded with require() to your data pack.
 ]]


### PR DESCRIPTION
The autorun and module folders can be given files using resource packs, but as of Minecraft 1.13, they are modified using data packs. This PR adds a mention of datapacks to the .ignoreme files in these folders.