### PR TITLE
Fix shebang absolute path handling

### DIFF
--- a/projects/core/src/main/resources/data/computercraft/lua/rom/programs/shell.lua
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/programs/shell.lua
@@ -141,8 +141,11 @@ local function executeProgram(remainingRecursion, path, args)
             return false
         end
 
-        -- Add the path and any arguments to the interpreter's arguments
-        table.insert(hashbangArgs, path)
+        -- Add the program path to the interpreter's arguments
+        -- Always add a leading slash to prevent any shell.resolve calls within the interpreter
+        --   from prepending the current directory since program path is already absolute
+        table.insert(hashbangArgs, "/" .. path)
+        -- Add any arguments passed to program to end of the interpreter's arguments
         for _, v in ipairs(args) do
             table.insert(hashbangArgs, v)
         end

--- a/projects/core/src/test/resources/test-rom/data/resolve-args.lua
+++ b/projects/core/src/test/resources/test-rom/data/resolve-args.lua
@@ -1,0 +1,12 @@
+-- SPDX-FileCopyrightText: 2026 The CC: Tweaked Developers
+--
+-- SPDX-License-Identifier: MPL-2.0
+
+local paths = {}
+
+local args = { ... }
+for i = 1, #args do
+  paths[i] = shell.resolve(args[i])
+end
+
+_G.__resolved = paths

--- a/projects/core/src/test/resources/test-rom/spec/programs/shell_spec.lua
+++ b/projects/core/src/test/resources/test-rom/spec/programs/shell_spec.lua
@@ -39,7 +39,7 @@ describe("The shell", function()
 
             expect(args):same {
                 [0] = "/test-rom/data/dump-args",
-                "test-files/out.lua",
+                "/test-files/out.lua",
                 "arg1",
                 "arg2",
             }
@@ -56,9 +56,25 @@ describe("The shell", function()
                 [0] = "/test-rom/data/dump-args",
                 "iArg1 iArg1-2",
                 "iArg2",
-                "test-files/out.lua",
+                "/test-files/out.lua",
                 "arg1",
                 "arg2",
+            }
+        end)
+
+        it("handles path resolving of arguments correctly", function()
+            make_hashbang_file("/test-rom/data/dump-resolved-args")
+            shell.setDir("test-files")
+            shell.execute("out.lua", "/a/b/path1", "c/d/path2")
+
+            local args = _G.__arg
+            _G.__arg = nil
+
+            expect(args):same {
+                [0] = "/test-rom/data/dump-resolved-args",
+                "test-files/out.lua",
+                "a/b/path1",
+                "test-files/c/d/path2",
             }
         end)
 
@@ -73,8 +89,8 @@ describe("The shell", function()
 
             expect(args):same {
                 [0] = "/test-rom/data/dump-args",
-                "test-files/out.lua",
-                "test-files/out2.lua",
+                "/test-files/out.lua",
+                "/test-files/out2.lua",
                 "arg1",
                 "arg2",
             }

--- a/projects/core/src/test/resources/test-rom/spec/programs/shell_spec.lua
+++ b/projects/core/src/test/resources/test-rom/spec/programs/shell_spec.lua
@@ -62,16 +62,15 @@ describe("The shell", function()
             }
         end)
 
-        it("handles path resolving of arguments correctly", function()
-            make_hashbang_file("/test-rom/data/dump-resolved-args")
+        it("handles shell resolving of path arguments correctly", function()
+            make_hashbang_file("/test-rom/data/resolve-args")
             shell.setDir("test-files")
             shell.execute("out.lua", "/a/b/path1", "c/d/path2")
 
-            local args = _G.__arg
-            _G.__arg = nil
+            local resolved = _G.__resolved
+            _G.__resolved = nil
 
-            expect(args):same {
-                [0] = "/test-rom/data/dump-resolved-args",
+            expect(resolved):same {
                 "test-files/out.lua",
                 "a/b/path1",
                 "test-files/c/d/path2",


### PR DESCRIPTION

**The Problem:**
You cannot write a program that correctly handles user-supplied relative paths and shebangs inside script files without using some kind of workaround.
A user-facing program typically calls `shell.resolve` on any path arguments passed before using the result with functions like `fs.exists` and `fs.open`.
When a shebang passes the absolute path of the script file to the program, it does so without a leading slash, thus it can be easily mangled by `shell.resolve` if the current directory is not `/`.
Some workarounds include using an option flag (e.g. `--absolute` or `--shebang`) to indicate to the program when not to call `shell.resolve`.

**Reproduction Steps:**
1. `mkdir test/`
2. `cd test/`
4. `edit test.txt`:
```
#!type
```
5. `type test.txt` should correctly print `file`
6. `test.txt` should incorrectly print `No such path` despite calling the same program on the same file.

Another example:
`#!edit` on a file `a/b/c.lua` executed with current directory `a/b/` saves to `a/b/a/b/c.lua`

**Rationale:**
The shell program makes the distinction between relative paths and absolute paths, it should also consistently produce explicitly absolute paths (with leading slashes) when passing known absolute paths to programs that may use the shell API.
I understand that the leading slash isn't neccessary when the program uses the underlying filesystem API, but since programs can receive user-passed explicitly absolute and relative paths and convert them to absolute paths with `shell.resolve`, they should be able to handle shebang absolute paths seamlessly.

**Provided Solution:**
Always prepend a leading slash to the program path when adding it to the hashbangArgs table.
It shouldn't break backwards compatibility since the filesystem API ignores leading slashes.