### PR TITLE
Add Ctrl+key text navigation and editing shortcuts

### DIFF
--- a/projects/core/src/main/resources/data/computercraft/lua/bios.lua
+++ b/projects/core/src/main/resources/data/computercraft/lua/bios.lua
@@ -166,6 +166,7 @@ function read(_sReplaceChar, _tHistory, _fnComplete, _sDefault)
 
     local tCompletions
     local nCompletion
+    local bCtrlHeld = false  -- Track if Ctrl is currently held
     local function recomplete()
         if _fnComplete and nPos == #sLine then
             tCompletions = _fnComplete(sLine)
@@ -281,20 +282,52 @@ function read(_sReplaceChar, _tHistory, _fnComplete, _sDefault)
                 break
 
             elseif param == keys.left then
-                -- Left
+                -- Left or Ctrl+Left
                 if nPos > 0 then
                     clear()
-                    nPos = nPos - 1
+                    if bCtrlHeld then
+                        -- Move word left
+                        local nWordStart = nPos
+                        -- Skip backwards over non-word characters
+                        while nWordStart > 1 and not string.sub(sLine, nWordStart - 1, nWordStart - 1):match("%w") do
+                            nWordStart = nWordStart - 1
+                        end
+                        -- Skip backwards over word characters
+                        while nWordStart > 1 and string.sub(sLine, nWordStart - 1, nWordStart - 1):match("%w") do
+                            nWordStart = nWordStart - 1
+                        end
+                        nPos = nWordStart - 1
+                        if nPos < 0 then nPos = 0 end
+                    else
+                        -- Move single character left
+                        nPos = nPos - 1
+                    end
                     recomplete()
                     redraw()
                 end
 
             elseif param == keys.right then
-                -- Right
+                -- Right or Ctrl+Right
                 if nPos < #sLine then
                     -- Move right
                     clear()
-                    nPos = nPos + 1
+                    if bCtrlHeld then
+                        -- Move word right
+                        local nWordEnd = nPos + 1
+                        -- Skip forward over non-word characters
+                        while nWordEnd <= #sLine and not string.sub(sLine, nWordEnd, nWordEnd):match("%w") do
+                            nWordEnd = nWordEnd + 1
+                        end
+                        -- Skip forward over word characters
+                        while nWordEnd <= #sLine and string.sub(sLine, nWordEnd, nWordEnd):match("%w") do
+                            nWordEnd = nWordEnd + 1
+                        end
+                        nPos = nWordEnd - 1
+                        if nPos > #sLine then nPos = #sLine end
+                    else
+                        -- Move single character right
+                        nPos = nPos + 1
+                    end
                     recomplete()
                     redraw()
                 else
@@ -353,12 +386,34 @@ function read(_sReplaceChar, _tHistory, _fnComplete, _sDefault)
                 end
 
             elseif param == keys.backspace then
-                -- Backspace
+                -- Backspace or Ctrl+Backspace
                 if nPos > 0 then
                     clear()
-                    sLine = string.sub(sLine, 1, nPos - 1) .. string.sub(sLine, nPos + 1)
-                    nPos = nPos - 1
-                    if nScroll > 0 then nScroll = nScroll - 1 end
+                    if bCtrlHeld then
+                        -- Delete word
+                        local nWordStart = nPos
+                        -- Skip backwards over non-word characters
+                        while nWordStart > 1 and not string.sub(sLine, nWordStart - 1, nWordStart - 1):match("%w") do
+                            nWordStart = nWordStart - 1
+                        end
+                        -- Skip backwards over word characters
+                        while nWordStart > 1 and string.sub(sLine, nWordStart - 1, nWordStart - 1):match("%w") do
+                            nWordStart = nWordStart - 1
+                        end
+                        sLine = string.sub(sLine, 1, nWordStart - 1) .. string.sub(sLine, nPos + 1)
+                        local nDeleted = nPos - nWordStart + 1
+                        nPos = nWordStart - 1
+                        if nScroll >= nDeleted then
+                            nScroll = nScroll - nDeleted
+                        else
+                            nScroll = 0
+                        end
+                    else
+                        -- Delete single character
+                        sLine = string.sub(sLine, 1, nPos - 1) .. string.sub(sLine, nPos + 1)
+                        nPos = nPos - 1
+                        if nScroll > 0 then nScroll = nScroll - 1 end
+                    end
                     recomplete()
                     redraw()
                 end
@@ -373,10 +428,25 @@ function read(_sReplaceChar, _tHistory, _fnComplete, _sDefault)
                 end
 
             elseif param == keys.delete then
-                -- Delete
+                -- Delete or Ctrl+Delete
                 if nPos < #sLine then
                     clear()
-                    sLine = string.sub(sLine, 1, nPos) .. string.sub(sLine, nPos + 2)
+                    if bCtrlHeld then
+                        -- Delete word to the right
+                        local nWordEnd = nPos + 1
+                        -- Skip forward over non-word characters
+                        while nWordEnd <= #sLine and not string.sub(sLine, nWordEnd, nWordEnd):match("%w") do
+                            nWordEnd = nWordEnd + 1
+                        end
+                        -- Skip forward over word characters
+                        while nWordEnd <= #sLine and string.sub(sLine, nWordEnd, nWordEnd):match("%w") do
+                            nWordEnd = nWordEnd + 1
+                        end
+                        sLine = string.sub(sLine, 1, nPos) .. string.sub(sLine, nWordEnd)
+                    else
+                        -- Delete single character
+                        sLine = string.sub(sLine, 1, nPos) .. string.sub(sLine, nPos + 2)
+                    end
                     recomplete()
                     redraw()
                 end
@@ -394,6 +464,16 @@ function read(_sReplaceChar, _tHistory, _fnComplete, _sDefault)
                 -- Tab (accept autocomplete)
                 acceptCompletion()
 
+            elseif param == keys.leftCtrl or param == keys.rightCtrl then
+                -- Track Ctrl key press
+                bCtrlHeld = true
+
+            end
+
+        elseif sEvent == "key_up" then
+            if param == keys.leftCtrl or param == keys.rightCtrl then
+                -- Track Ctrl key release
+                bCtrlHeld = false
             end
 
         elseif sEvent == "mouse_click" or sEvent == "mouse_drag" and param == 1 then

--- a/projects/core/src/main/resources/data/computercraft/lua/bios.lua
+++ b/projects/core/src/main/resources/data/computercraft/lua/bios.lua
@@ -166,7 +166,15 @@ function read(_sReplaceChar, _tHistory, _fnComplete, _sDefault)
 
     local tCompletions
     local nCompletion
-    local bCtrlHeld = false  -- Track if Ctrl is currently held
+    local bLeftCtrlHeld = false   -- Track left Ctrl key state
+    local bRightCtrlHeld = false  -- Track right Ctrl key state
+    local bAltHeld = false        -- Track Alt key to detect AltGr
+    
+    -- Helper function to check if Ctrl is held for text navigation (not AltGr)
+    local function isCtrlHeldForNavigation()
+        return (bLeftCtrlHeld or bRightCtrlHeld) and not bAltHeld
+    end
+    
     local function recomplete()
         if _fnComplete and nPos == #sLine then
             tCompletions = _fnComplete(sLine)
@@ -285,7 +293,7 @@ function read(_sReplaceChar, _tHistory, _fnComplete, _sDefault)
                 -- Left or Ctrl+Left
                 if nPos > 0 then
                     clear()
-                    if bCtrlHeld then
+                    if isCtrlHeldForNavigation() then
                         -- Move word left
                         local nWordStart = nPos
                         -- Skip backwards over non-word characters
@@ -311,7 +319,7 @@ function read(_sReplaceChar, _tHistory, _fnComplete, _sDefault)
                 if nPos < #sLine then
                     -- Move right
                     clear()
-                    if bCtrlHeld then
+                    if isCtrlHeldForNavigation() then
                         -- Move word right
                         local nWordEnd = nPos + 1
                         -- Skip forward over non-word characters
@@ -389,7 +397,7 @@ function read(_sReplaceChar, _tHistory, _fnComplete, _sDefault)
                 -- Backspace or Ctrl+Backspace
                 if nPos > 0 then
                     clear()
-                    if bCtrlHeld then
+                    if isCtrlHeldForNavigation() then
                         -- Delete word
                         local nWordStart = nPos
                         -- Skip backwards over non-word characters
@@ -431,7 +439,7 @@ function read(_sReplaceChar, _tHistory, _fnComplete, _sDefault)
                 -- Delete or Ctrl+Delete
                 if nPos < #sLine then
                     clear()
-                    if bCtrlHeld then
+                    if isCtrlHeldForNavigation() then
                         -- Delete word to the right
                         local nWordEnd = nPos + 1
                         -- Skip forward over non-word characters
@@ -464,16 +472,30 @@ function read(_sReplaceChar, _tHistory, _fnComplete, _sDefault)
                 -- Tab (accept autocomplete)
                 acceptCompletion()
 
-            elseif param == keys.leftCtrl or param == keys.rightCtrl then
-                -- Track Ctrl key press
-                bCtrlHeld = true
+            elseif param == keys.leftCtrl then
+                -- Track left Ctrl key press
+                bLeftCtrlHeld = true
+                
+            elseif param == keys.rightCtrl then
+                -- Track right Ctrl key press  
+                bRightCtrlHeld = true
+                
+            elseif param == keys.leftAlt or param == keys.rightAlt then
+                -- Track Alt key press (for AltGr detection)
+                bAltHeld = true
 
             end
 
         elseif sEvent == "key_up" then
-            if param == keys.leftCtrl or param == keys.rightCtrl then
-                -- Track Ctrl key release
-                bCtrlHeld = false
+            if param == keys.leftCtrl then
+                -- Track left Ctrl key release
+                bLeftCtrlHeld = false
+            elseif param == keys.rightCtrl then
+                -- Track right Ctrl key release
+                bRightCtrlHeld = false
+            elseif param == keys.leftAlt or param == keys.rightAlt then
+                -- Track Alt key release
+                bAltHeld = false
             end
 
         elseif sEvent == "mouse_click" or sEvent == "mouse_drag" and param == 1 then

--- a/projects/core/src/main/resources/data/computercraft/lua/rom/programs/edit.lua
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/programs/edit.lua
@@ -32,10 +32,17 @@ local scrollX, scrollY = 0, 0
 
 local tLines, tLineLexStates = {}, {}
 local bRunning = true
-local bCtrlHeld = false  -- Track if Ctrl is currently held
-local nCtrlPressTime = 0  -- Track when Ctrl was pressed
+local bLeftCtrlHeld = false   -- Track left Ctrl key state
+local bRightCtrlHeld = false  -- Track right Ctrl key state
+local bAltHeld = false        -- Track Alt key to detect AltGr
+local nCtrlPressTime = 0      -- Track when Ctrl was pressed
 local bCtrlUsedForCombo = false  -- Track if Ctrl was used with other keys
-local bJustClosedMenu = false  -- Track if we just closed menu with Ctrl
+local bJustClosedMenu = false    -- Track if we just closed menu with Ctrl
+
+-- Helper function to check if Ctrl is held for text navigation (not AltGr)
+local function isCtrlHeldForNavigation()
+    return (bLeftCtrlHeld or bRightCtrlHeld) and not bAltHeld
+end
 
 -- Colours
 local isColour = term.isColour()
@@ -560,15 +567,26 @@ while bRunning do
                 -- Close menu immediately, block reopening
                 current_menu = nil
                 redrawMenu()
-                bCtrlHeld = true
+                if key == keys.leftCtrl then
+                    bLeftCtrlHeld = true
+                else
+                    bRightCtrlHeld = true
+                end
                 bCtrlUsedForCombo = true
                 bJustClosedMenu = true
             else
-                bCtrlHeld = true
+                if key == keys.leftCtrl then
+                    bLeftCtrlHeld = true
+                else
+                    bRightCtrlHeld = true
+                end
                 nCtrlPressTime = os.epoch("utc")
                 bCtrlUsedForCombo = false
                 bJustClosedMenu = false
             end
+        elseif (key == keys.leftAlt or key == keys.rightAlt) and not event[3] then
+            -- Track Alt key for AltGr detection
+            bAltHeld = true
         elseif current_menu then
             handleMenuEvent(event)
         else
@@ -643,11 +661,11 @@ while bRunning do
 
             elseif key == keys.home then
                 -- Mark Ctrl as used for combo if held
-                if bCtrlHeld then
+                if isCtrlHeldForNavigation() then
                     bCtrlUsedForCombo = true
                 end
                 
-                if bCtrlHeld then
+                if isCtrlHeldForNavigation() then
                     -- Move to beginning of file
                     setCursor(1, 1)
                 else
@@ -659,11 +677,11 @@ while bRunning do
 
             elseif key == keys["end"] then
                 -- Mark Ctrl as used for combo if held
-                if bCtrlHeld then
+                if isCtrlHeldForNavigation() then
                     bCtrlUsedForCombo = true
                 end
                 
-                if bCtrlHeld then
+                if isCtrlHeldForNavigation() then
                     -- Move to end of file
                     local lastLine = #tLines
                     setCursor(#tLines[lastLine] + 1, lastLine)
@@ -677,11 +695,11 @@ while bRunning do
 
             elseif key == keys.left then
                 -- Mark Ctrl as used for combo if held
-                if bCtrlHeld then
+                if isCtrlHeldForNavigation() then
                     bCtrlUsedForCombo = true
                 end
                 
-                if bCtrlHeld then
+                if isCtrlHeldForNavigation() then
                     -- Move word left
                     if x > 1 then
                         local sLine = tLines[y]
@@ -710,11 +728,11 @@ while bRunning do
 
             elseif key == keys.right then
                 -- Mark Ctrl as used for combo if held
-                if bCtrlHeld then
+                if isCtrlHeldForNavigation() then
                     bCtrlUsedForCombo = true
                 end
                 
-                if bCtrlHeld then
+                if isCtrlHeldForNavigation() then
                     -- Move word right
                     if x <= #tLines[y] then
                         local sLine = tLines[y]
@@ -748,14 +766,14 @@ while bRunning do
 
             elseif key == keys.delete and not bReadOnly then
                 -- Mark Ctrl as used for combo if held
-                if bCtrlHeld then
+                if isCtrlHeldForNavigation() then
                     bCtrlUsedForCombo = true
                 end
                 
                 local nLimit = #tLines[y] + 1
                 if x < nLimit then
                     local sLine = tLines[y]
-                    if bCtrlHeld then
+                    if isCtrlHeldForNavigation() then
                         -- Delete word to the right
                         local nWordEnd = x
                         -- Skip forward over non-word characters
@@ -783,13 +801,13 @@ while bRunning do
 
             elseif key == keys.backspace and not bReadOnly then
                 -- Mark Ctrl as used for combo if held
-                if bCtrlHeld then
+                if isCtrlHeldForNavigation() then
                     bCtrlUsedForCombo = true
                 end
                 
                 if x > 1 then
                     local sLine = tLines[y]
-                    if bCtrlHeld then
+                    if isCtrlHeldForNavigation() then
                         -- Delete word
                         local nWordStart = x - 1
                         -- Skip backwards over non-word characters
@@ -839,7 +857,7 @@ while bRunning do
 
             else
                 -- Any other key pressed while Ctrl is held counts as a combination
-                if bCtrlHeld then
+                if isCtrlHeldForNavigation() then
                     bCtrlUsedForCombo = true
                 end
             end
@@ -847,17 +865,31 @@ while bRunning do
 
     elseif event[1] == "key_up" then
         local key = event[2]
-        if key == keys.leftCtrl or key == keys.rightCtrl then
-            -- Track Ctrl key release
-            bCtrlHeld = false
+        if key == keys.leftCtrl then
+            -- Track left Ctrl key release
+            bLeftCtrlHeld = false
             -- Only open menu if: quick tap AND no combo used AND no menu open AND didn't just close menu
             local holdTime = os.epoch("utc") - nCtrlPressTime
-            if holdTime < 1000 and not bCtrlUsedForCombo and not current_menu and not bJustClosedMenu then
+            if holdTime < 1000 and not bCtrlUsedForCombo and not current_menu and not bJustClosedMenu and not bRightCtrlHeld then
                 current_menu = menu.create(menu_items)
                 redrawMenu()
             end
             -- Reset the flag after processing
             bJustClosedMenu = false
+        elseif key == keys.rightCtrl then
+            -- Track right Ctrl key release
+            bRightCtrlHeld = false
+            -- Only open menu if: quick tap AND no combo used AND no menu open AND didn't just close menu
+            local holdTime = os.epoch("utc") - nCtrlPressTime
+            if holdTime < 1000 and not bCtrlUsedForCombo and not current_menu and not bJustClosedMenu and not bLeftCtrlHeld then
+                current_menu = menu.create(menu_items)
+                redrawMenu()
+            end
+            -- Reset the flag after processing
+            bJustClosedMenu = false
+        elseif key == keys.leftAlt or key == keys.rightAlt then
+            -- Track Alt key release
+            bAltHeld = false
         end
 
     elseif event[1] == "char" then
@@ -937,3 +969,4 @@ end
 term.clear()
 term.setCursorBlink(false)
 term.setCursorPos(1, 1)
+

--- a/projects/core/src/main/resources/data/computercraft/lua/rom/programs/edit.lua
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/programs/edit.lua
@@ -32,6 +32,10 @@ local scrollX, scrollY = 0, 0
 
 local tLines, tLineLexStates = {}, {}
 local bRunning = true
+local bCtrlHeld = false  -- Track if Ctrl is currently held
+local nCtrlPressTime = 0  -- Track when Ctrl was pressed
+local bCtrlUsedForCombo = false  -- Track if Ctrl was used with other keys
+local bJustClosedMenu = false  -- Track if we just closed menu with Ctrl
 
 -- Colours
 local isColour = term.isColour()
@@ -549,7 +553,23 @@ end
 while bRunning do
     local event = table.pack(os.pullEvent())
     if event[1] == "key" then
-        if current_menu then
+        local key = event[2]
+        if (key == keys.leftCtrl or key == keys.rightCtrl) and not event[3] then
+            -- Handle Ctrl press before anything else (even when menu is open)
+            if current_menu then
+                -- Close menu immediately, block reopening
+                current_menu = nil
+                redrawMenu()
+                bCtrlHeld = true
+                bCtrlUsedForCombo = true
+                bJustClosedMenu = true
+            else
+                bCtrlHeld = true
+                nCtrlPressTime = os.epoch("utc")
+                bCtrlUsedForCombo = false
+                bJustClosedMenu = false
+            end
+        elseif current_menu then
             handleMenuEvent(event)
         else
             local key = event[2]
@@ -622,44 +642,135 @@ while bRunning do
                 setCursor(newX, newY)
 
             elseif key == keys.home then
-                -- Move cursor to the beginning
-                if x > 1 then
-                    setCursor(1, y)
+                -- Mark Ctrl as used for combo if held
+                if bCtrlHeld then
+                    bCtrlUsedForCombo = true
+                end
+                
+                if bCtrlHeld then
+                    -- Move to beginning of file
+                    setCursor(1, 1)
+                else
+                    -- Move cursor to the beginning of line
+                    if x > 1 then
+                        setCursor(1, y)
+                    end
                 end
 
             elseif key == keys["end"] then
-                -- Move cursor to the end
-                local nLimit = #tLines[y] + 1
-                if x < nLimit then
-                    setCursor(nLimit, y)
+                -- Mark Ctrl as used for combo if held
+                if bCtrlHeld then
+                    bCtrlUsedForCombo = true
+                end
+                
+                if bCtrlHeld then
+                    -- Move to end of file
+                    local lastLine = #tLines
+                    setCursor(#tLines[lastLine] + 1, lastLine)
+                else
+                    -- Move cursor to the end of line
+                    local nLimit = #tLines[y] + 1
+                    if x < nLimit then
+                        setCursor(nLimit, y)
+                    end
                 end
 
             elseif key == keys.left then
-                if x > 1 then
+                -- Mark Ctrl as used for combo if held
+                if bCtrlHeld then
+                    bCtrlUsedForCombo = true
+                end
+                
+                if bCtrlHeld then
+                    -- Move word left
+                    if x > 1 then
+                        local sLine = tLines[y]
+                        local nWordStart = x - 1
+                        -- Skip backwards over non-word characters
+                        while nWordStart > 1 and not string.sub(sLine, nWordStart - 1, nWordStart - 1):match("%w") do
+                            nWordStart = nWordStart - 1
+                        end
+                        -- Skip backwards over word characters
+                        while nWordStart > 1 and string.sub(sLine, nWordStart - 1, nWordStart - 1):match("%w") do
+                            nWordStart = nWordStart - 1
+                        end
+                        setCursor(nWordStart, y)
+                    elseif y > 1 then
+                        -- Jump to end of previous line
+                        setCursor(#tLines[y - 1] + 1, y - 1)
+                    end
+                else
                     -- Move cursor left
-                    setCursor(x - 1, y)
-                elseif x == 1 and y > 1 then
-                    setCursor(#tLines[y - 1] + 1, y - 1)
+                    if x > 1 then
+                        setCursor(x - 1, y)
+                    elseif x == 1 and y > 1 then
+                        setCursor(#tLines[y - 1] + 1, y - 1)
+                    end
                 end
 
             elseif key == keys.right then
-                local nLimit = #tLines[y] + 1
-                if x < nLimit then
-                    -- Move cursor right
-                    setCursor(x + 1, y)
-                elseif nCompletion and x == #tLines[y] + 1 then
-                    -- Accept autocomplete
-                    acceptCompletion()
-                elseif x == nLimit and y < #tLines then
-                    -- Go to next line
-                    setCursor(1, y + 1)
+                -- Mark Ctrl as used for combo if held
+                if bCtrlHeld then
+                    bCtrlUsedForCombo = true
+                end
+                
+                if bCtrlHeld then
+                    -- Move word right
+                    if x <= #tLines[y] then
+                        local sLine = tLines[y]
+                        local nWordEnd = x
+                        -- Skip forward over non-word characters
+                        while nWordEnd <= #sLine and not string.sub(sLine, nWordEnd, nWordEnd):match("%w") do
+                            nWordEnd = nWordEnd + 1
+                        end
+                        -- Skip forward over word characters
+                        while nWordEnd <= #sLine and string.sub(sLine, nWordEnd, nWordEnd):match("%w") do
+                            nWordEnd = nWordEnd + 1
+                        end
+                        setCursor(nWordEnd, y)
+                    elseif y < #tLines then
+                        -- Jump to start of next line
+                        setCursor(1, y + 1)
+                    end
+                else
+                    local nLimit = #tLines[y] + 1
+                    if x < nLimit then
+                        -- Move cursor right
+                        setCursor(x + 1, y)
+                    elseif nCompletion and x == #tLines[y] + 1 then
+                        -- Accept autocomplete
+                        acceptCompletion()
+                    elseif x == nLimit and y < #tLines then
+                        -- Go to next line
+                        setCursor(1, y + 1)
+                    end
                 end
 
             elseif key == keys.delete and not bReadOnly then
+                -- Mark Ctrl as used for combo if held
+                if bCtrlHeld then
+                    bCtrlUsedForCombo = true
+                end
+                
                 local nLimit = #tLines[y] + 1
                 if x < nLimit then
                     local sLine = tLines[y]
-                    tLines[y] = string.sub(sLine, 1, x - 1) .. string.sub(sLine, x + 1)
+                    if bCtrlHeld then
+                        -- Delete word to the right
+                        local nWordEnd = x
+                        -- Skip forward over non-word characters
+                        while nWordEnd <= #sLine and not string.sub(sLine, nWordEnd, nWordEnd):match("%w") do
+                            nWordEnd = nWordEnd + 1
+                        end
+                        -- Skip forward over word characters
+                        while nWordEnd <= #sLine and string.sub(sLine, nWordEnd, nWordEnd):match("%w") do
+                            nWordEnd = nWordEnd + 1
+                        end
+                        tLines[y] = string.sub(sLine, 1, x - 1) .. string.sub(sLine, nWordEnd)
+                    else
+                        -- Delete single character
+                        tLines[y] = string.sub(sLine, 1, x - 1) .. string.sub(sLine, x + 1)
+                    end
                     recomplete()
                     redrawLines(y)
                 elseif y < #tLines then
@@ -671,13 +782,32 @@ while bRunning do
                 end
 
             elseif key == keys.backspace and not bReadOnly then
+                -- Mark Ctrl as used for combo if held
+                if bCtrlHeld then
+                    bCtrlUsedForCombo = true
+                end
+                
                 if x > 1 then
-                    -- Remove character
                     local sLine = tLines[y]
-                    if x > 4 and string.sub(sLine, x - 4, x - 1) == "    " and not string.sub(sLine, 1, x - 1):find("%S") then
+                    if bCtrlHeld then
+                        -- Delete word
+                        local nWordStart = x - 1
+                        -- Skip backwards over non-word characters
+                        while nWordStart > 0 and not string.sub(sLine, nWordStart, nWordStart):match("%w") do
+                            nWordStart = nWordStart - 1
+                        end
+                        -- Skip backwards over word characters
+                        while nWordStart > 0 and string.sub(sLine, nWordStart, nWordStart):match("%w") do
+                            nWordStart = nWordStart - 1
+                        end
+                        tLines[y] = string.sub(sLine, 1, nWordStart) .. string.sub(sLine, x)
+                        setCursor(nWordStart + 1, y)
+                    elseif x > 4 and string.sub(sLine, x - 4, x - 1) == "    " and not string.sub(sLine, 1, x - 1):find("%S") then
+                        -- Remove indentation (existing behavior)
                         tLines[y] = string.sub(sLine, 1, x - 5) .. string.sub(sLine, x)
                         setCursor(x - 4, y)
                     else
+                        -- Remove single character  
                         tLines[y] = string.sub(sLine, 1, x - 2) .. string.sub(sLine, x)
                         setCursor(x - 1, y)
                     end
@@ -705,10 +835,31 @@ while bRunning do
                 redrawText()
 
             elseif key == keys.leftCtrl or key == keys.rightCtrl then
+                -- Already handled above before current_menu check - do nothing here
+
+            else
+                -- Any other key pressed while Ctrl is held counts as a combination
+                if bCtrlHeld then
+                    bCtrlUsedForCombo = true
+                end
+            end
+        end
+
+    elseif event[1] == "key_up" then
+        local key = event[2]
+        if key == keys.leftCtrl or key == keys.rightCtrl then
+            -- Track Ctrl key release
+            bCtrlHeld = false
+            -- Only open menu if: quick tap AND no combo used AND no menu open AND didn't just close menu
+            local holdTime = os.epoch("utc") - nCtrlPressTime
+            if holdTime < 1000 and not bCtrlUsedForCombo and not current_menu and not bJustClosedMenu then
                 current_menu = menu.create(menu_items)
                 redrawMenu()
             end
+            -- Reset the flag after processing
+            bJustClosedMenu = false
         end
+
     elseif event[1] == "char" then
         if current_menu then
             handleMenuEvent(event)


### PR DESCRIPTION
Added Ctrl+key combinations for text navigation and editing in both the shell and the edit program.

**Shell (bios.lua):**
- Ctrl+Left/Right: Navigate by words
- Ctrl+Backspace: Delete word to the left
- Ctrl+Delete: Delete word to the right

**Text Editor (edit.lua):**
- Ctrl+Left/Right: Navigate by words
- Ctrl+Backspace: Delete word to the left
- Ctrl+Delete: Delete word to the right
- Ctrl+Home: Jump to beginning of file
- Ctrl+End: Jump to end of file
- Smart menu behavior: Ctrl combos don't interfere with menu system
