### PR TITLE
Clear terminal in edit program on resize event

### DIFF
--- a/projects/core/src/main/resources/data/computercraft/lua/rom/programs/edit.lua
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/programs/edit.lua
@@ -776,6 +776,7 @@ while bRunning do
     elseif event[1] == "term_resize" then
         w, h = term.getSize()
         setCursor(x, y)
+        term.clear()
         redrawMenu()
         redrawText()
 


### PR DESCRIPTION
## Issue:
In edit.lua program, when redrawing contents after `term_resize` events, `redrawMenu` and `redrawText` functions in some cases (if terminal has gotten bigger, and there is less text lines in edited file then height of terminal - 2) do not completely cover all areas of screen, letting it contain old data (usually old menu) from older resolution. 
This is most visible if user has single line file, and attempts to run it on advanced computer. Resulting by opening and closing new multishell window, 2 resizes, to smaller and then to bigger resolution are most common way players can encounter this bug. Each run call causes new extra copies of old menu to stack in dead space in middle:
<img width="798" height="745" alt="obraz" src="https://github.com/user-attachments/assets/c38b6621-6536-4368-bdb5-d9f47ad4a2d7" />

### Proposed solution:
Simplest solution to this issue is what is proposed in this PR, just adding term.clear() call in `term_resize` handling code before redraws happens ensures all artifacts from before resize would be cleared. While it would be possible to create more complicated handling code, that would only clear deal lines between Text and Menu areas, it would not provide any benefits over this solution, as `term_resize` events already cause contents to move around.