### PR TITLE
Remove ability for turtles to be GPS hosts

### DIFF
--- a/projects/core/src/main/resources/data/computercraft/lua/rom/programs/gps.lua
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/programs/gps.lua
@@ -25,7 +25,7 @@ if sCommand == "locate" then
 elseif sCommand == "host" then
     -- "gps host"
     -- Act as a GPS host
-    if pocket then
+    if pocket or turtle then
         print("GPS Hosts must be stationary")
         return
     end


### PR DESCRIPTION
If a GPS host ever moves, it would no longer send back accurate data. This was accounted for pocket computers, but not turtles.