### PR TITLE
Recipe sync fix

### DIFF
--- a/projects/common/src/main/java/dan200/computercraft/shared/ModRegistry.java
+++ b/projects/common/src/main/java/dan200/computercraft/shared/ModRegistry.java
@@ -558,7 +558,12 @@ public final class ModRegistry {
         static final RegistrationHelper<RecipeSerializer<?>> REGISTRY = PlatformHelper.get().createRegistrationHelper(Registries.RECIPE_SERIALIZER);
 
         private static <T extends CustomRecipe> RegistryEntry<RecipeSerializer<T>> simple(String name, Supplier<T> factory) {
-            return REGISTRY.register(name, () -> new RecipeSerializer<>(MapCodec.unit(factory), StreamCodec.unit(factory.get())));
+            var streamCodec = StreamCodec.<RegistryFriendlyByteBuf, T>of(
+                (_, _) -> {
+                },
+                _ -> factory.get()
+            );
+            return REGISTRY.register(name, () -> new RecipeSerializer<>(MapCodec.unit(factory), streamCodec));
         }
 
         private static <U, T extends CustomRecipe> RegistryEntry<RecipeSerializer<T>> withRegistry(


### PR DESCRIPTION
Fixes stream encoding for stateless custom recipes I was running into when loading with other mods.
The old codec used `StreamCodec.unit(factory.get())`, which stores a single recipe instance and expects that exact object when encoding. In my dev environment, recipe sync could pass a different instance of the same stateless recipe, causing encoding to fail even though there was no recipe data to serialize.
This changes the stream codec to write no data and create a fresh instance on decode, matching the behavior of stateless recipes.

- ./gradlew :forge:build
- Tested the cc-tweaked jar in my neoforge dev setup with LaserIO, Patchouli, and JEI installed
- Confirmed recipe sync no longer throws error

 `Caused by: java.lang.IllegalStateException: Can't encode 'dan200.computercraft.shared.common.ClearColourRecipe@6a973a5b', expected 'dan200.computercraft.shared.common.ClearColourRecipe@2ce715cc'
	at TRANSFORMER/minecraft@26.1.2/net.minecraft.network.codec.StreamCodec$3.encode(StreamCodec.java:60) ~[minecraft-patched-26.1.2.29-beta.jar:?] {}
	at TRANSFORMER/minecraft@26.1.2/net.minecraft.network.codec.StreamCodec$6.encode(StreamCodec.java:124) ~[minecraft-patched-26.1.2.29-beta.jar:?] {}
	at TRANSFORMER/minecraft@26.1.2/net.minecraft.network.codec.StreamCodec$8.encode(StreamCodec.java:162) ~[minecraft-patched-26.1.2.29-beta.jar:?] {}
	at TRANSFORMER/minecraft@26.1.2/net.minecraft.network.codec.ByteBufCodecs$26.encode(ByteBufCodecs.java:430) ~[minecraft-patched-26.1.2.29-beta.jar:?] {}
	at TRANSFORMER/minecraft@26.1.2/net.minecraft.network.codec.ByteBufCodecs$26.encode(ByteBufCodecs.java:414) ~[minecraft-patched-26.1.2.29-beta.jar:?] {}`
