### PR TITLE
fix typo in shell.pathWithExtension

### DIFF
--- a/projects/core/src/main/resources/data/computercraft/lua/rom/programs/shell.lua
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/programs/shell.lua
@@ -351,7 +351,7 @@ function shell.resolve(path)
 end
 
 local function pathWithExtension(_sPath, _sExt)
-    local nLen = #sPath
+    local nLen = #_sPath
     local sEndChar = string.sub(_sPath, nLen, nLen)
     -- Remove any trailing slashes so we can add an extension to the path safely
     if sEndChar == "/" or sEndChar == "\\" then


### PR DESCRIPTION
`#sPath` is the length of global sPath. Its length have nothing to do with the method parameter `_sPath`. So mostly likely it is a typo.

This problem exists in other branches as well.
