### PR TITLE
http stream option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,10 +30,11 @@
 .kotlin
 *.DS_Store
 
-/.classpath
-/.project
-/.settings
+.classpath
+.project
+.settings
 /.vscode
 *.launch
+bin/
 
 /projects/*/src/generated/resources/.cache

--- a/projects/core/src/main/java/dan200/computercraft/core/apis/HTTPAPI.java
+++ b/projects/core/src/main/java/dan200/computercraft/core/apis/HTTPAPI.java
@@ -73,7 +73,7 @@ public class HTTPAPI implements ILuaAPI {
         String address, requestMethod;
         ByteBuffer postBody;
         Map<?, ?> headerTable;
-        boolean binary, redirect;
+        boolean binary, redirect, stream;
         Optional<Double> timeoutArg;
 
         if (args.get(0) instanceof Map) {
@@ -85,6 +85,7 @@ public class HTTPAPI implements ILuaAPI {
             requestMethod = options.optString("method").orElse(null);
             redirect = options.optBoolean("redirect").orElse(true);
             timeoutArg = options.optFiniteDouble("timeout");
+            stream = options.optBoolean("stream").orElse(false);
         } else {
             // Get URL and post information
             address = args.getString(0);
@@ -94,6 +95,7 @@ public class HTTPAPI implements ILuaAPI {
             requestMethod = null;
             redirect = true;
             timeoutArg = Optional.empty();
+            stream = false;
         }
 
         var headers = getHeaders(headerTable);
@@ -111,7 +113,7 @@ public class HTTPAPI implements ILuaAPI {
 
         try {
             var uri = HttpRequest.checkUri(address);
-            var request = new HttpRequest(requests, apiEnvironment, address, postBody, headers, binary, redirect, timeout);
+            var request = new HttpRequest(requests, apiEnvironment, address, postBody, headers, binary, redirect, timeout, stream);
 
             // Make the request
             if (!request.queue(r -> r.request(uri, httpMethod))) {

--- a/projects/core/src/main/java/dan200/computercraft/core/apis/http/request/HttpRequest.java
+++ b/projects/core/src/main/java/dan200/computercraft/core/apis/http/request/HttpRequest.java
@@ -39,6 +39,7 @@ public class HttpRequest extends Resource<HttpRequest> {
     private static final Logger LOG = LoggerFactory.getLogger(HttpRequest.class);
     private static final String SUCCESS_EVENT = "http_success";
     private static final String FAILURE_EVENT = "http_failure";
+    static final String CONTENT_EVENT = "http_content";
 
     private static final int MAX_REDIRECTS = 16;
 
@@ -48,17 +49,18 @@ public class HttpRequest extends Resource<HttpRequest> {
 
     private final IAPIEnvironment environment;
 
-    private final String address;
+    final String address;
     private final ByteBuf postBuffer;
     private final HttpHeaders headers;
     private final boolean binary;
     private final int timeout;
+    private final boolean stream;
 
     final AtomicInteger redirects;
 
     public HttpRequest(
         ResourceGroup<HttpRequest> limiter, IAPIEnvironment environment, String address, @Nullable ByteBuffer postBody,
-        HttpHeaders headers, boolean binary, boolean followRedirects, int timeout
+        HttpHeaders headers, boolean binary, boolean followRedirects, int timeout, boolean stream
     ) {
         super(limiter);
         this.environment = environment;
@@ -70,6 +72,7 @@ public class HttpRequest extends Resource<HttpRequest> {
         this.binary = binary;
         redirects = new AtomicInteger(followRedirects ? MAX_REDIRECTS : 0);
         this.timeout = timeout;
+        this.stream = stream;
 
         if (postBody != null) {
             if (!headers.contains(HttpHeaderNames.CONTENT_TYPE)) {
@@ -139,7 +142,7 @@ public class HttpRequest extends Resource<HttpRequest> {
             environment.observe(Metrics.HTTP_REQUESTS);
             environment.observe(Metrics.HTTP_UPLOAD, requestBody);
 
-            var handler = currentRequest = new HttpRequestHandler(this, uri, method, options);
+            var handler = currentRequest = new HttpRequestHandler(this, uri, method, stream, options);
             connectFuture = new Bootstrap()
                 .group(NetworkUtils.LOOP_GROUP)
                 .channelFactory(NioSocketChannel::new)
@@ -184,6 +187,22 @@ public class HttpRequest extends Resource<HttpRequest> {
 
     void success(HttpResponseHandle object) {
         if (tryClose()) environment.queueEvent(SUCCESS_EVENT, address, object);
+    }
+
+    void partialFailure(String message, HttpResponseHandle object) {
+        if (!checkClosed()) environment.queueEvent(FAILURE_EVENT, address, message, object);
+    }
+
+    void partialSuccess(HttpResponseHandle object) {
+        if (!checkClosed()) environment.queueEvent(SUCCESS_EVENT, address, object);
+    }
+
+    void partialContent() {
+        if (!checkClosed()) environment.queueEvent(CONTENT_EVENT, address);
+    }
+
+    void partialClosed() {
+        if (tryClose()) environment.queueEvent(CONTENT_EVENT, address); // wakeup readers for them to return
     }
 
     @Override

--- a/projects/core/src/main/java/dan200/computercraft/core/apis/http/request/HttpRequestHandler.java
+++ b/projects/core/src/main/java/dan200/computercraft/core/apis/http/request/HttpRequestHandler.java
@@ -10,7 +10,9 @@ import dan200.computercraft.core.apis.http.HTTPRequestException;
 import dan200.computercraft.core.apis.http.NetworkUtils;
 import dan200.computercraft.core.apis.http.options.Options;
 import dan200.computercraft.core.metrics.Metrics;
+import io.netty.buffer.ByteBuf;
 import io.netty.buffer.CompositeByteBuf;
+import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.http.*;
@@ -19,6 +21,7 @@ import org.jspecify.annotations.Nullable;
 import java.io.Closeable;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
@@ -33,6 +36,10 @@ public final class HttpRequestHandler extends SimpleChannelInboundHandler<HttpOb
      */
     private static final int DEFAULT_MAX_COMPOSITE_BUFFER_COMPONENTS = 1024;
 
+    // TODO: make it be configurable
+    // Note: this is not the real maximum buffer size. Reading will only stop after buffer exceed the size defined.
+    private static final int MAX_STREAM_BUFFER_CACHE = 1024 * 1024;
+
     private static final byte[] EMPTY_BYTES = new byte[0];
 
     private final HttpRequest request;
@@ -40,18 +47,24 @@ public final class HttpRequestHandler extends SimpleChannelInboundHandler<HttpOb
 
     private final URI uri;
     private final HttpMethod method;
+    private final boolean stream;
     private final Options options;
 
     private @Nullable Charset responseCharset;
     private final HttpHeaders responseHeaders = new DefaultHttpHeaders();
     private @Nullable HttpResponseStatus responseStatus;
-    private @Nullable CompositeByteBuf responseBody;
 
-    HttpRequestHandler(HttpRequest request, URI uri, HttpMethod method, Options options) {
+    private final Object responseBodyLock = new Object();
+    private @Nullable CompositeByteBuf responseBody;
+    private @Nullable ByteBuf unpooledResponseBody;
+    private @Nullable Runnable responseBodyTrigger;
+
+    HttpRequestHandler(HttpRequest request, URI uri, HttpMethod method, boolean stream, Options options) {
         this.request = request;
 
         this.uri = uri;
         this.method = method;
+        this.stream = stream;
         this.options = options;
     }
 
@@ -119,38 +132,56 @@ public final class HttpRequestHandler extends SimpleChannelInboundHandler<HttpOb
             responseCharset = HttpUtil.getCharset(response, StandardCharsets.UTF_8);
             responseStatus = response.status();
             responseHeaders.add(response.headers());
+
+            if (stream) {
+                sendResponseStreamed();
+            }
         }
 
         if (message instanceof HttpContent content) {
 
-            if (responseBody == null) {
-                responseBody = ctx.alloc().compositeBuffer(DEFAULT_MAX_COMPOSITE_BUFFER_COMPONENTS);
-            }
-
             var partial = content.content();
             if (partial.isReadable()) {
-                // If we've read more than we're allowed to handle, abort as soon as possible.
-                if (options.maxDownload() != 0 && responseBody.readableBytes() + partial.readableBytes() > options.maxDownload()) {
-                    closed = true;
-                    ctx.close();
+                synchronized (responseBodyLock) {
+                    if (responseBody == null) {
+                        responseBody = ctx.alloc().compositeBuffer(DEFAULT_MAX_COMPOSITE_BUFFER_COMPONENTS);
+                    }
+                    if (!stream && options.maxDownload() != 0 && responseBody.readableBytes() + partial.readableBytes() > options.maxDownload()) {
+                        // If we've read more than we're allowed to handle, abort as soon as possible.
+                        closed = true;
+                        ctx.close();
 
-                    request.failure("Response is too large");
-                    return;
+                        request.failure("Response is too large");
+                        return;
+                    }
+                    var wasEmpty = !responseBody.isReadable();
+                    responseBody.addComponent(true, partial.retain());
+                    if (stream) {
+                        if (wasEmpty) {
+                            request.partialContent();
+                        }
+                        if (responseBody.readableBytes() >= MAX_STREAM_BUFFER_CACHE) {
+                            ctx.channel().config().setAutoRead(false);
+                        }
+                        responseBodyTrigger = () -> ctx.channel().config().setAutoRead(true);
+                    }
                 }
-
-                responseBody.addComponent(true, partial.retain());
             }
 
             if (message instanceof LastHttpContent last) {
-                responseHeaders.add(last.trailingHeaders());
-
-                // Set the content length, if not already given.
-                if (responseHeaders.contains(HttpHeaderNames.CONTENT_LENGTH)) {
-                    responseHeaders.set(HttpHeaderNames.CONTENT_LENGTH, responseBody.readableBytes());
-                }
-
                 ctx.close();
-                sendResponse();
+
+                // TODO: we should have some way to provide trailing headers for streamed connection
+                if (!stream) {
+                    responseHeaders.add(last.trailingHeaders());
+
+                    // Set the content length, if not already given.
+                    if (!responseHeaders.contains(HttpHeaderNames.CONTENT_LENGTH)) {
+                        responseHeaders.set(HttpHeaderNames.CONTENT_LENGTH, responseBody == null ? 0 : responseBody.readableBytes());
+                    }
+
+                    sendResponse();
+                }
             }
         }
     }
@@ -192,6 +223,113 @@ public final class HttpRequestHandler extends SimpleChannelInboundHandler<HttpOb
         }
     }
 
+    private void sendResponseStreamed() {
+        Objects.requireNonNull(responseStatus, "Status has not been set");
+        Objects.requireNonNull(responseCharset, "Charset has not been set");
+
+        // Decode the headers
+        var status = responseStatus;
+        Map<String, String> headers = new HashMap<>();
+        for (var header : responseHeaders) {
+            var existing = headers.get(header.getKey());
+            headers.put(header.getKey(), existing == null ? header.getValue() : existing + "," + header.getValue());
+        }
+
+        // Fire off a stats event
+        request.environment().observe(Metrics.HTTP_DOWNLOAD, getHeaderSize(responseHeaders));
+
+        // Prepare to queue an event
+        var stream = new HttpResponseHandle(new HttpStreamReader(request, this), status.code(), status.reasonPhrase(), headers);
+
+        if (status.code() >= 200 && status.code() < 400) {
+            request.partialSuccess(stream);
+        } else {
+            request.partialFailure(status.reasonPhrase(), stream);
+        }
+    }
+
+    /**
+     * Read response body into the designate buffer.
+     * This method does not block, and will only read currently cached data into the buffer and returns the amount of available bytes.
+     *
+     * @param buffer the designate buffer
+     * @return The amount of bytes read, or {@code -1} if stream is ended.
+     */
+    int readBody(ByteBuffer buffer) {
+        synchronized (responseBodyLock) {
+            ByteBuf source = responseBody != null ? responseBody : unpooledResponseBody;
+            if (source == null) return -1;
+            int maxRead = buffer.remaining();
+            int oldLimit = -1;
+            if (maxRead > source.readableBytes()) {
+                maxRead = source.readableBytes();
+                oldLimit = buffer.limit();
+                buffer.limit(buffer.position() + maxRead);
+            }
+            source.readBytes(buffer);
+            if (oldLimit != -1) {
+                buffer.limit(oldLimit);
+            }
+            if (source == responseBody) {
+                responseBody.discardReadComponents();
+                if (responseBodyTrigger != null && responseBody.readableBytes() < MAX_STREAM_BUFFER_CACHE) {
+                    responseBodyTrigger.run();
+                    responseBodyTrigger = null;
+                }
+            } else if (source == unpooledResponseBody) {
+                if (unpooledResponseBody.readableBytes() == 0) {
+                    unpooledResponseBody = null;
+                }
+            }
+            return maxRead;
+        }
+    }
+
+    /**
+     * Read response body into the designate buffer until the specific separator.
+     * This method does not block, and will only read currently cached data into the buffer and returns the amount of available bytes.
+     * Separator will be read into the buffer, and if exists, it will always and only appears at the buffer's last position.
+     *
+     * @param buffer the designate buffer
+     * @param separator the target separator
+     * @return The amount of bytes read, or {@code -1} if stream is ended.
+     */
+    int readBodyUntil(ByteBuffer buffer, byte separator) {
+        synchronized (responseBodyLock) {
+            ByteBuf source = responseBody != null ? responseBody : unpooledResponseBody;
+            if (source == null) return -1;
+            int maxRead = buffer.remaining();
+            if (maxRead > source.readableBytes()) maxRead = source.readableBytes();
+            int sepIndex = source.bytesBefore(maxRead, separator);
+            if (sepIndex != -1) {
+                maxRead = sepIndex + 1;
+            }
+            int oldLimit = -1;
+            if (maxRead != buffer.remaining()) {
+                oldLimit = buffer.limit();
+                buffer.limit(buffer.position() + maxRead);
+            }
+
+            source.readBytes(buffer);
+
+            if (oldLimit != -1) {
+                buffer.limit(oldLimit);
+            }
+            if (source == responseBody) {
+                responseBody.discardReadComponents();
+                if (responseBodyTrigger != null && responseBody.readableBytes() < MAX_STREAM_BUFFER_CACHE) {
+                    responseBodyTrigger.run();
+                    responseBodyTrigger = null;
+                }
+            } else if (source == unpooledResponseBody) {
+                if (unpooledResponseBody.readableBytes() == 0) {
+                    unpooledResponseBody = null;
+                }
+            }
+            return maxRead;
+        }
+    }
+
     /**
      * Determine the redirect from this response.
      *
@@ -216,10 +354,19 @@ public final class HttpRequestHandler extends SimpleChannelInboundHandler<HttpOb
 
     @Override
     public void close() {
+        if (closed) {
+            return;
+        }
         closed = true;
-        if (responseBody != null) {
-            responseBody.release();
-            responseBody = null;
+        synchronized (responseBodyLock) {
+            responseBodyTrigger = null;
+            if (responseBody != null) {
+                if (stream && responseBody.readableBytes() > 0) {
+                    unpooledResponseBody = Unpooled.copiedBuffer(responseBody);
+                }
+                responseBody.release();
+                responseBody = null;
+            }
         }
     }
 }

--- a/projects/core/src/main/java/dan200/computercraft/core/apis/http/request/HttpResponseHandle.java
+++ b/projects/core/src/main/java/dan200/computercraft/core/apis/http/request/HttpResponseHandle.java
@@ -7,7 +7,6 @@ package dan200.computercraft.core.apis.http.request;
 import dan200.computercraft.api.lua.IArguments;
 import dan200.computercraft.api.lua.LuaFunction;
 import dan200.computercraft.core.apis.HTTPAPI;
-import dan200.computercraft.core.apis.handles.AbstractHandle;
 import dan200.computercraft.core.apis.handles.ReadHandle;
 import dan200.computercraft.core.methods.ObjectSource;
 
@@ -27,7 +26,7 @@ public class HttpResponseHandle implements ObjectSource {
     private final String responseStatus;
     private final Map<String, String> responseHeaders;
 
-    public HttpResponseHandle(AbstractHandle reader, int responseCode, String responseStatus, Map<String, String> responseHeaders) {
+    public HttpResponseHandle(Object reader, int responseCode, String responseStatus, Map<String, String> responseHeaders) {
         this.reader = reader;
         this.responseCode = responseCode;
         this.responseStatus = responseStatus;

--- a/projects/core/src/main/java/dan200/computercraft/core/apis/http/request/HttpStreamReader.java
+++ b/projects/core/src/main/java/dan200/computercraft/core/apis/http/request/HttpStreamReader.java
@@ -1,0 +1,298 @@
+// SPDX-FileCopyrightText: 2026 The CC: Tweaked Developers
+//
+// SPDX-License-Identifier: MPL-2.0
+
+package dan200.computercraft.core.apis.http.request;
+
+import com.google.errorprone.annotations.DoNotCall;
+import dan200.computercraft.api.lua.ILuaCallback;
+import dan200.computercraft.api.lua.LuaException;
+import dan200.computercraft.api.lua.LuaFunction;
+import dan200.computercraft.api.lua.MethodResult;
+import org.jspecify.annotations.Nullable;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+public class HttpStreamReader {
+    private static final int BUFFER_SIZE = 8192;
+
+    private final HttpRequest request;
+    private final HttpRequestHandler handler;
+    private final boolean binary;
+
+    private boolean isClosed = false;
+    private ByteBuffer single = ByteBuffer.allocate(1);
+
+    public HttpStreamReader(HttpRequest request, HttpRequestHandler handler) {
+        this.request = request;
+        this.handler = handler;
+        this.binary = request.isBinary();
+    }
+
+    protected void checkOpen() throws LuaException {
+        if (isClosed) throw new LuaException("attempt to use a closed connection");
+    }
+
+    @LuaFunction
+    public final void close() throws LuaException {
+        checkOpen();
+        isClosed = true;
+        handler.close();
+    }
+
+    @LuaFunction
+    public final MethodResult read(Optional<Integer> countArg, Optional<Boolean> blockingArg) throws LuaException {
+        checkOpen();
+
+        if (binary && countArg.isEmpty()) {
+            return new HttpContentSingleBytePoller(request.address).pollBody();
+        }
+
+        int count = countArg.orElse(1);
+        boolean blocking = blockingArg.orElse(true);
+
+        if (count == 0) return MethodResult.of("");
+        if (count <= BUFFER_SIZE) {
+            return new HttpContentSimpleBufferPoller(request.address, blocking, ByteBuffer.allocate(count)).pollBody();
+        }
+
+        return new HttpContentLargePoller(request.address, blocking, count).pollBody();
+    }
+
+    @LuaFunction
+    public final MethodResult readAll() throws LuaException {
+        checkOpen();
+
+        return new HttpContentAllPoller(request.address, true).pollBody();
+    }
+
+    @LuaFunction
+    public final MethodResult readLine(Optional<Boolean> withTrailingArg) throws LuaException {
+        checkOpen();
+
+        boolean withTrailing = withTrailingArg.orElse(false);
+        return new HttpContentLinePoller(request.address, withTrailing).pollBody();
+    }
+
+    @DoNotCall
+    @LuaFunction
+    public final MethodResult seek(Optional<String> whence, Optional<Long> offset) throws LuaException {
+        throw new LuaException("cannot seek on a streamed connection");
+    }
+
+    private static abstract class HttpContentPoller implements ILuaCallback {
+        final MethodResult pull = MethodResult.pullEvent(HttpRequest.CONTENT_EVENT, this);
+        private final String url;
+        final boolean blocking;
+
+        private HttpContentPoller(String url, boolean blocking) {
+            this.url = url;
+            this.blocking = blocking;
+        }
+
+        @Override
+        public MethodResult resume(@Nullable Object[] args) throws LuaException {
+            if (args.length < 2 || !Objects.equals(args[0], HttpRequest.CONTENT_EVENT) || !Objects.equals(args[1], url)) {
+                return pull;
+            }
+            return this.pollBody();
+        }
+
+        abstract MethodResult pollBody() throws LuaException;
+    }
+
+    private final class HttpContentSingleBytePoller extends HttpContentPoller {
+        private HttpContentSingleBytePoller(String url) {
+            super(url, true);
+        }
+
+        @Override
+        MethodResult pollBody() throws LuaException {
+            checkOpen();
+
+            single.clear();
+            var read = handler.readBody(single);
+            if (read == 0) return pull;
+            if (read < 0) return MethodResult.of();
+            return MethodResult.of(single.get(0) & 0xff);
+        }
+    }
+
+    private final class HttpContentSimpleBufferPoller extends HttpContentPoller {
+        private final ByteBuffer buffer;
+
+        private HttpContentSimpleBufferPoller(String url, boolean blocking, ByteBuffer buffer) {
+            super(url, blocking);
+            this.buffer = buffer;
+        }
+
+        @Override
+        MethodResult pollBody() throws LuaException {
+            checkOpen();
+
+            if (!buffer.hasRemaining()) return MethodResult.of(buffer.flip());
+            var read = handler.readBody(buffer);
+            if (read < 0) {
+                buffer.flip();
+                return MethodResult.of(buffer.hasRemaining() ? buffer : null);
+            }
+            if (read == 0) return blocking ? pull : MethodResult.of(buffer.flip());
+            if (blocking && buffer.hasRemaining()) return pull;
+            return MethodResult.of(buffer.flip());
+        }
+    }
+
+    private static abstract class HttpContentPartsPoller extends HttpContentPoller {
+        final List<ByteBuffer> parts = new ArrayList<>(4);
+        int totalRead = 0;
+
+        private HttpContentPartsPoller(String url, boolean blocking) {
+            super(url, blocking);
+        }
+
+        byte[] joinParts() {
+            var bytes = new byte[totalRead];
+            var pos = 0;
+            for (var part : parts) {
+                var length = part.remaining();
+                part.get(bytes, pos, length);
+                pos += length;
+            }
+            assert pos == totalRead;
+            return bytes;
+        }
+    }
+
+    private final class HttpContentLargePoller extends HttpContentPartsPoller {
+        private final int count;
+        private @Nullable ByteBuffer buffer = null;
+
+        private HttpContentLargePoller(String url, boolean blocking, int count) {
+            super(url, blocking);
+            this.count = count;
+        }
+
+        @Override
+        MethodResult pollBody() throws LuaException {
+            checkOpen();
+
+            while (totalRead < count) {
+                if (buffer == null) buffer = ByteBuffer.allocate(Math.min(BUFFER_SIZE, count - totalRead));
+                var read = handler.readBody(buffer);
+                if (read < 0) {
+                    buffer.flip();
+                    if (buffer.hasRemaining()) parts.add(buffer);
+                    else if (parts.isEmpty()) return MethodResult.of();
+                    break;
+                }
+
+                totalRead += read;
+                if (read == 0) {
+                    if (blocking) return pull;
+                    parts.add(buffer.flip());
+                    break;
+                }
+
+                if (!buffer.hasRemaining()) {
+                    parts.add(buffer.flip());
+                    buffer = null;
+                }
+            }
+            return MethodResult.of(joinParts());
+        }
+    }
+
+    private final class HttpContentAllPoller extends HttpContentPartsPoller {
+        private ByteBuffer buffer = ByteBuffer.allocate(BUFFER_SIZE);
+
+        private HttpContentAllPoller(String url, boolean blocking) {
+            super(url, blocking);
+        }
+
+        @Override
+        MethodResult pollBody() throws LuaException {
+            checkOpen();
+
+            while (true) {
+                var read = handler.readBody(buffer);
+                if (read < 0) {
+                    buffer.flip();
+                    if (buffer.hasRemaining()) parts.add(buffer);
+                    break;
+                }
+
+                totalRead += read;
+                if (read == 0) {
+                    if (blocking) return pull;
+                    parts.add(buffer.flip());
+                    break;
+                }
+
+                if (!buffer.hasRemaining()) {
+                    parts.add(buffer.flip());
+                    buffer = ByteBuffer.allocate(BUFFER_SIZE);
+                }
+            }
+            return MethodResult.of(joinParts());
+        }
+    }
+
+    private final class HttpContentLinePoller extends HttpContentPartsPoller {
+        private static final byte SEP = '\n';
+        private static final byte CR = '\r';
+
+        private final boolean withTrailing;
+        private ByteBuffer buffer = ByteBuffer.allocate(BUFFER_SIZE);
+
+        private HttpContentLinePoller(String url, boolean withTrailing) {
+            super(url, true);
+            this.withTrailing = withTrailing;
+        }
+
+        @Override
+        MethodResult pollBody() throws LuaException {
+            checkOpen();
+
+            while (true) {
+                var read = handler.readBodyUntil(buffer, SEP);
+                if (read < 0) {
+                    buffer.flip();
+                    if (buffer.hasRemaining()) parts.add(buffer);
+                    break;
+                }
+
+                totalRead += read;
+                if (read == 0) {
+                    return pull;
+                }
+
+                if (!buffer.hasRemaining()) {
+                    parts.add(buffer.flip());
+                    if (buffer.get(buffer.limit()) == SEP) {
+                        if (!withTrailing) {
+                            // trim LF
+                            buffer.limit(buffer.limit() - 1);
+                            totalRead--;
+                            // trim CR
+                            var buf = buffer;
+                            if (buf.remaining() < 2) {
+                                buf = parts.size() >= 2 ? parts.get(parts.size() - 2) : null;
+                            }
+                            if (buf != null && buf.get(buf.limit()) == CR) {
+                                buf.limit(buf.limit() - 1);
+                                totalRead--;
+                            }
+                        }
+                        break;
+                    }
+                    buffer = ByteBuffer.allocate(BUFFER_SIZE);
+                }
+            }
+            return MethodResult.of(joinParts());
+        }
+    }
+}


### PR DESCRIPTION
close #1181

The APIs should be backward compatable after set `stream = true`.

An additional API is `response.read([count, [blocking, ]])`, where as when the `blocking` argument is explictly set to `false`, `read` method will not wait, it will just return immediately.

`seek` method is not available, and it is probably not a good idea to implement it on streamed connection consider it may require infinity amount of buffer.

After all, this PR is not well tested, we may need some test script for `http` API.
