### PR TITLE
Fix `min` & `sec` field defaults in os.time

### DIFF
--- a/projects/core/src/main/java/dan200/computercraft/core/apis/LuaDateTime.java
+++ b/projects/core/src/main/java/dan200/computercraft/core/apis/LuaDateTime.java
@@ -77,8 +77,8 @@ final class LuaDateTime {
         var month = getField(table, "month", -1);
         var day = getField(table, "day", -1);
         var hour = getField(table, "hour", 12);
-        var minute = getField(table, "min", 12);
-        var second = getField(table, "sec", 12);
+        var minute = getField(table, "min", 0);
+        var second = getField(table, "sec", 0);
         var time = LocalDateTime.of(year, month, day, hour, minute, second);
 
         var isDst = getBoolField(table, "isdst");

--- a/projects/core/src/test/resources/test-rom/spec/apis/os_spec.lua
+++ b/projects/core/src/test/resources/test-rom/spec/apis/os_spec.lua
@@ -143,6 +143,24 @@ describe("The os library", function()
             local t2 = os.time { year = 2000, month = 10, day = 1, hour = 23, min = 10, sec = 19 }
             expect(t1 - t2):eq(60 * 2 - 2)
         end)
+
+        it("uses correct date table default for hour", function()
+            local t1 = os.time { year = 1970, month = 1, day = 1, hour = nil, min = 0, sec = 0 }
+            local t2 = os.time { year = 1970, month = 1, day = 1, hour = 12, min = 0, sec = 0 }
+            expect(t1):eq(t2)
+        end)
+
+        it("uses correct date table default for min", function()
+            local t1 = os.time { year = 1970, month = 1, day = 1, hour = 0, min = nil, sec = 0 }
+            local t2 = os.time { year = 1970, month = 1, day = 1, hour = 0, min = 0, sec = 0 }
+            expect(t1):eq(t2)
+        end)
+
+        it("uses correct date table default for sec", function()
+            local t1 = os.time { year = 1970, month = 1, day = 1, hour = 0, min = 0, sec = nil }
+            local t2 = os.time { year = 1970, month = 1, day = 1, hour = 0, min = 0, sec = 0 }
+            expect(t1):eq(t2)
+        end)
     end)
 
     describe("os.day", function()


### PR DESCRIPTION
When os.time is called with a date table, the `min` and `sec` fields are wrongly set to 12 if their values are missing. This looks like it was copied from the `hour` field default. They should both be 0 for parity with stock Lua.
